### PR TITLE
Extract placement geometry into a pure module; fix searchable overlay height

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,17 @@ lib/
 - Breaking changes require major version bump
 - Update version in both `pubspec.yaml` and documentation when releasing
 - CHANGELOG.md follows the format: `* **TYPE**: Description` (e.g., `* **FEAT**: New feature`)
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues on `kihyun1998/flutter_dropdown_button`, via the `gh` CLI. External pull requests are **not** a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles use their default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root, created lazily. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,43 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **single-context** repo.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the domain glossary.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+Neither `CONTEXT.md` nor `docs/adr/` exists yet in this repo. That is expected.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   ├── adr/
+│   │   ├── 0001-overlay-based-rendering.md
+│   │   └── 0002-shared-dropdown-mixin.md
+│   └── agents/
+└── lib/
+```
+
+If this repo ever splits into multiple bounded contexts, add a `CONTEXT-MAP.md` at the root pointing at one `CONTEXT.md` per context, and let each context keep its own `docs/adr/` alongside system-wide decisions at the root.
+
+Note: long-form user-facing docs already live in `documentation/` (API reference, theming, migration). That directory is **not** the domain-doc surface — it's product documentation. Don't conflate the two.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,47 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on
+[`kihyun1998/flutter_dropdown_button`](https://github.com/kihyun1998/flutter_dropdown_button).
+Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,18 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+These labels may not exist in the GitHub repo yet. Create one on first use with
+`gh label create <name> --description "..."`; `gh issue edit --add-label` fails on an unknown label.

--- a/lib/src/buttons/dropdown_mixin.dart
+++ b/lib/src/buttons/dropdown_mixin.dart
@@ -1,7 +1,6 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 
+import '../placement/dropdown_placement.dart';
 import 'menu_alignment.dart';
 
 /// Position calculation result for dropdown overlay positioning.
@@ -130,6 +129,14 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
   /// This padding creates internal spacing between the overlay edges
   /// and the item list. If null, no padding is applied.
   EdgeInsets? get overlayPadding => null;
+
+  /// Vertical space inside the overlay taken by furniture that is not an
+  /// item — a search field, for example.
+  ///
+  /// The overlay grows to hold it rather than shrinking the item list, so a
+  /// short list does not acquire a scrollbar just because search is enabled.
+  /// The border and [overlayPadding] are accounted for separately.
+  double get chromeHeight => 0.0;
 
   /// The minimum width of the dropdown menu overlay.
   ///
@@ -361,164 +368,105 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
     Offset buttonOffset,
     Size buttonSize,
   ) {
-    // Calculate available space for smart positioning
-    // Account for safe areas (status bar, navigation bar, home indicator)
-    // On desktop platforms, these padding values are 0.0
-    final mediaQuery = MediaQuery.of(context);
-    final screenHeight = mediaQuery.size.height;
-    final topPadding = mediaQuery.padding.top; // status bar
-    final bottomPadding =
-        mediaQuery.padding.bottom; // navigation bar / home indicator
-
-    final spaceBelow = screenHeight -
-        bottomPadding -
-        (buttonOffset.dy + buttonSize.height + screenMargin);
-    final spaceAbove = buttonOffset.dy - topPadding - screenMargin;
-
-    // Calculate dynamic preferred height based on items with actual item heights
-    final totalItemsHeight = itemCount * actualItemHeight;
-    // Calculate total overlay padding
-    final overlayPaddingVertical = overlayPadding != null
-        ? (overlayPadding!.top + overlayPadding!.bottom)
-        : 0.0;
-    // Add border thickness and overlay padding to ensure enough space for content + border + padding
-    final preferredHeight = math.min(totalItemsHeight, maxDropdownHeight) +
-        overlayBorderThickness +
-        overlayPaddingVertical;
-
-    // Determine positioning and height
-    double menuHeight;
-    bool openDown;
-    Alignment transformAlignment;
-
-    if (spaceBelow >= preferredHeight) {
-      // Sufficient space below - open downward
-      menuHeight = preferredHeight;
-      openDown = true;
-      transformAlignment = Alignment.topCenter;
-    } else if (spaceAbove >= preferredHeight) {
-      // Sufficient space above - open upward
-      menuHeight = preferredHeight;
-      openDown = false;
-      transformAlignment = Alignment.bottomCenter;
-    } else {
-      // Insufficient space in both directions - choose the larger space
-      if (spaceBelow >= spaceAbove) {
-        menuHeight = spaceBelow - screenMargin; // Extra margin for safety
-        openDown = true;
-        transformAlignment = Alignment.topCenter;
-      } else {
-        menuHeight = spaceAbove - screenMargin;
-        openDown = false;
-        transformAlignment = Alignment.bottomCenter;
-      }
-
-      // Ensure minimum height for usability with actual item heights + border + padding
-      final minHeight = minVisibleItems * actualItemHeight +
-          overlayBorderThickness +
-          overlayPaddingVertical;
-      menuHeight = math.max(menuHeight, minHeight);
-    }
-
-    final topPosition = openDown
-        ? buttonOffset.dy + buttonSize.height + buttonGap
-        : buttonOffset.dy - menuHeight - buttonGap;
+    final placement = resolvePlacement(buttonOffset, buttonSize);
 
     return DropdownPositionResult(
-      height: menuHeight,
-      openDown: openDown,
-      transformAlignment: transformAlignment,
-      topPosition: topPosition,
+      height: placement.height,
+      openDown: placement.openDown,
+      transformAlignment: placement.transformAlignment,
+      topPosition: placement.top,
+    );
+  }
+
+  /// Reads the screen from [MediaQuery] and resolves the menu's full geometry.
+  ///
+  /// This is the adapter: it gathers plain values and hands them to
+  /// [DropdownPlacement], which does the arithmetic without a [BuildContext].
+  DropdownPlacementResult resolvePlacement(
+    Offset buttonOffset,
+    Size buttonSize,
+  ) {
+    // Safe areas (status bar, navigation bar, home indicator). Zero on desktop.
+    final mediaQuery = MediaQuery.of(context);
+
+    final padding = overlayPadding;
+    final overlayPaddingVertical =
+        padding != null ? padding.top + padding.bottom : 0.0;
+
+    return DropdownPlacement.resolve(
+      DropdownPlacementInput(
+        screenSize: mediaQuery.size,
+        safeInsetTop: mediaQuery.padding.top,
+        safeInsetBottom: mediaQuery.padding.bottom,
+        buttonOffset: buttonOffset,
+        buttonSize: buttonSize,
+        itemCount: itemCount,
+        actualItemHeight: actualItemHeight,
+        maxDropdownHeight: maxDropdownHeight,
+        // The border and the overlay's padding occupy the overlay the same
+        // way a search field does; the module need not tell them apart.
+        chromeHeight:
+            chromeHeight + overlayBorderThickness + overlayPaddingVertical,
+        screenMargin: screenMargin,
+        buttonGap: buttonGap,
+        minVisibleItems: minVisibleItems,
+        minMenuWidth: minMenuWidth,
+        maxMenuWidth: maxMenuWidth,
+        menuAlignment: menuAlignment,
+      ),
     );
   }
 
   /// Calculates the effective width for the dropdown menu.
   ///
   /// Applies [minMenuWidth] and [maxMenuWidth] constraints to the button width.
-  /// Returns a width between minMenuWidth and maxMenuWidth, preferring buttonWidth.
+  @Deprecated(
+    'Use resolvePlacement() and read .width. '
+    'This method will be removed in 3.0.0.',
+  )
   double calculateMenuWidth(double buttonWidth) {
-    double menuWidth = buttonWidth;
-
-    // Apply minMenuWidth if provided
-    if (minMenuWidth != null && menuWidth < minMenuWidth!) {
-      menuWidth = minMenuWidth!;
-    }
-
-    // Apply maxMenuWidth if provided
-    if (maxMenuWidth != null && menuWidth > maxMenuWidth!) {
-      menuWidth = maxMenuWidth!;
-    }
-
-    return menuWidth;
+    return resolvePlacement(Offset.zero, Size(buttonWidth, 0)).width;
   }
 
-  /// Calculates the left position for the dropdown menu based on alignment.
-  ///
-  /// When the menu is wider than the button, aligns according to [menuAlignment]:
-  /// - [MenuAlignment.left]: Left edges align
-  /// - [MenuAlignment.center]: Centers menu over button
-  /// - [MenuAlignment.right]: Right edges align
-  ///
-  /// Also ensures the menu stays within screen bounds.
+  /// Calculates the left position for the dropdown menu based on alignment,
+  /// keeping the menu inside the screen.
+  @Deprecated(
+    'Use resolvePlacement() and read .left. '
+    'This method will be removed in 3.0.0.',
+  )
   double calculateMenuLeftPosition(
     double buttonLeft,
     double buttonWidth,
     double menuWidth,
   ) {
-    double leftPosition;
+    // Pinning both bounds to menuWidth makes the resolved width exactly the
+    // width the caller asked about, so .left is computed against it.
+    final mediaQuery = MediaQuery.of(context);
 
-    // Calculate initial position based on alignment
-    if (menuWidth <= buttonWidth) {
-      // Menu is not wider than button, use button position
-      leftPosition = buttonLeft;
-    } else {
-      // Menu is wider than button, apply alignment
-      final widthDiff = menuWidth - buttonWidth;
-
-      switch (menuAlignment) {
-        case MenuAlignment.left:
-          // Left edges align: menu extends to the right
-          leftPosition = buttonLeft;
-          break;
-
-        case MenuAlignment.center:
-          // Center menu over button
-          leftPosition = buttonLeft - (widthDiff / 2);
-          break;
-
-        case MenuAlignment.right:
-          // Right edges align: menu extends to the left
-          leftPosition = buttonLeft - widthDiff;
-          break;
-      }
-    }
-
-    // Ensure menu stays within screen bounds
-    final screenWidth = MediaQuery.of(context).size.width;
-    final rightEdge = leftPosition + menuWidth;
-
-    // Check right edge overflow
-    if (rightEdge > screenWidth - screenMargin) {
-      leftPosition = screenWidth - screenMargin - menuWidth;
-    }
-
-    // Check left edge overflow
-    if (leftPosition < screenMargin) {
-      leftPosition = screenMargin;
-    }
-
-    return leftPosition;
+    return DropdownPlacement.resolve(
+      DropdownPlacementInput(
+        screenSize: mediaQuery.size,
+        safeInsetTop: mediaQuery.padding.top,
+        safeInsetBottom: mediaQuery.padding.bottom,
+        buttonOffset: Offset(buttonLeft, 0),
+        buttonSize: Size(buttonWidth, 0),
+        itemCount: itemCount,
+        actualItemHeight: actualItemHeight,
+        maxDropdownHeight: maxDropdownHeight,
+        screenMargin: screenMargin,
+        buttonGap: buttonGap,
+        minMenuWidth: menuWidth,
+        maxMenuWidth: menuWidth,
+        menuAlignment: menuAlignment,
+      ),
+    ).left;
   }
 
   /// Creates the overlay entry that contains the dropdown options.
   OverlayEntry _createOverlayEntry(Offset buttonOffset, Size buttonSize) {
-    final position = calculateDropdownPosition(buttonOffset, buttonSize);
-    final menuWidth = calculateMenuWidth(buttonSize.width);
-    final leftPosition = calculateMenuLeftPosition(
-      buttonOffset.dx,
-      buttonSize.width,
-      menuWidth,
-    );
+    final position = resolvePlacement(buttonOffset, buttonSize);
+    final menuWidth = position.width;
+    final leftPosition = position.left;
 
     return OverlayEntry(
       builder: (context) => GestureDetector(
@@ -530,7 +478,7 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
             children: [
               Positioned(
                 left: leftPosition,
-                top: position.topPosition,
+                top: position.top,
                 width: menuWidth,
                 child: AnimatedBuilder(
                   animation: dropdownAnimationController,

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -391,6 +391,9 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   EdgeInsets? get overlayPadding => effectiveTheme.overlayPadding;
 
   @override
+  double get chromeHeight => _searchFieldHeight;
+
+  @override
   double? get minMenuWidth => widget.minMenuWidth;
 
   @override

--- a/lib/src/placement/dropdown_placement.dart
+++ b/lib/src/placement/dropdown_placement.dart
@@ -1,0 +1,217 @@
+import 'dart:math' as math;
+
+import 'package:flutter/painting.dart';
+
+import '../buttons/menu_alignment.dart';
+
+/// Everything the placement calculation needs, as plain values.
+///
+/// No [BuildContext], no `MediaQuery`, no `State` — the caller reads those
+/// and passes the results in.
+class DropdownPlacementInput {
+  /// Creates the inputs for a placement calculation.
+  const DropdownPlacementInput({
+    required this.screenSize,
+    required this.safeInsetTop,
+    required this.safeInsetBottom,
+    required this.buttonOffset,
+    required this.buttonSize,
+    required this.itemCount,
+    required this.actualItemHeight,
+    required this.maxDropdownHeight,
+    this.chromeHeight = 0.0,
+    this.screenMargin = 8.0,
+    this.buttonGap = 4.0,
+    this.minVisibleItems = 2,
+    this.minMenuWidth,
+    this.maxMenuWidth,
+    this.menuAlignment = MenuAlignment.left,
+  });
+
+  /// The full screen size.
+  final Size screenSize;
+
+  /// Space reserved at the top of the screen (status bar).
+  final double safeInsetTop;
+
+  /// Space reserved at the bottom (navigation bar, home indicator).
+  final double safeInsetBottom;
+
+  /// The button's top-left corner in global coordinates.
+  final Offset buttonOffset;
+
+  /// The button's size.
+  final Size buttonSize;
+
+  /// How many items the menu holds.
+  final int itemCount;
+
+  /// The vertical space one item occupies, including its margin.
+  final double actualItemHeight;
+
+  /// The tallest the item list may grow, ignoring available space.
+  ///
+  /// This caps the items, not the overlay: [chromeHeight] and any border or
+  /// padding sit on top of it.
+  final double maxDropdownHeight;
+
+  /// Vertical space taken by everything in the overlay that is not an item:
+  /// the search field, the border, the overlay's own padding.
+  ///
+  /// The overlay grows by this much rather than surrendering item space, so
+  /// enabling search does not force a short list to scroll. Callers sum the
+  /// pieces themselves — this module does not care what they are made of.
+  final double chromeHeight;
+
+  /// The gap kept between the menu and the edge of the safe area.
+  final double screenMargin;
+
+  /// The gap kept between the button and the menu.
+  final double buttonGap;
+
+  /// How many items must stay visible when space runs out.
+  ///
+  /// Honouring this can push the menu past [screenMargin]: a menu too short
+  /// to show anything is worse than one that crowds the screen edge.
+  final int minVisibleItems;
+
+  /// The narrowest the menu may be, even if the button is narrower.
+  final double? minMenuWidth;
+
+  /// The widest the menu may be, even if the button is wider.
+  final double? maxMenuWidth;
+
+  /// How the menu lines up with the button when it is the wider of the two.
+  final MenuAlignment menuAlignment;
+
+  /// The y coordinate of the button's bottom edge.
+  double get buttonBottom => buttonOffset.dy + buttonSize.height;
+}
+
+/// Where the menu should be drawn, and how large.
+class DropdownPlacementResult {
+  /// Creates a placement result.
+  const DropdownPlacementResult({
+    required this.height,
+    required this.openDown,
+    required this.transformAlignment,
+    required this.top,
+    required this.width,
+    required this.left,
+  });
+
+  /// The width the menu should occupy.
+  final double width;
+
+  /// The x coordinate of the menu's left edge.
+  final double left;
+
+  /// The height the menu should occupy.
+  final double height;
+
+  /// Whether the menu opens below the button rather than above it.
+  final bool openDown;
+
+  /// The anchor the open/close animation scales from.
+  final Alignment transformAlignment;
+
+  /// The y coordinate of the menu's top edge.
+  final double top;
+}
+
+/// Resolves where a dropdown menu should be drawn, given plain values.
+///
+/// The invariant: the menu always keeps [DropdownPlacementInput.screenMargin]
+/// between itself and the edge of the safe area, and
+/// [DropdownPlacementInput.buttonGap] between itself and the button.
+abstract final class DropdownPlacement {
+  /// Calculates the menu's placement.
+  static DropdownPlacementResult resolve(DropdownPlacementInput input) {
+    final width = _resolveWidth(input);
+    final preferredHeight = math.min(
+          input.itemCount * input.actualItemHeight,
+          input.maxDropdownHeight,
+        ) +
+        input.chromeHeight;
+
+    // Both spans already exclude the screen margin and the button gap, so a
+    // menu that fits within one of them satisfies the invariant by itself.
+    final spaceBelow = input.screenSize.height -
+        input.safeInsetBottom -
+        input.screenMargin -
+        input.buttonBottom -
+        input.buttonGap;
+    final spaceAbove = input.buttonOffset.dy -
+        input.safeInsetTop -
+        input.screenMargin -
+        input.buttonGap;
+
+    final double height;
+    final bool openDown;
+    if (spaceBelow >= preferredHeight) {
+      height = preferredHeight;
+      openDown = true;
+    } else if (spaceAbove >= preferredHeight) {
+      height = preferredHeight;
+      openDown = false;
+    } else {
+      // Neither side fits. Take the larger span whole; because the spans
+      // already exclude the margin and the gap, no further trimming is needed.
+      openDown = spaceBelow >= spaceAbove;
+      final available = openDown ? spaceBelow : spaceAbove;
+
+      // Deliberately allowed to exceed the span: see [minVisibleItems].
+      final minHeight =
+          input.minVisibleItems * input.actualItemHeight + input.chromeHeight;
+      height = math.max(available, minHeight);
+    }
+
+    return DropdownPlacementResult(
+      height: height,
+      openDown: openDown,
+      transformAlignment:
+          openDown ? Alignment.topCenter : Alignment.bottomCenter,
+      top: openDown
+          ? input.buttonBottom + input.buttonGap
+          : input.buttonOffset.dy - input.buttonGap - height,
+      width: width,
+      left: _resolveLeft(input, width),
+    );
+  }
+
+  static double _resolveWidth(DropdownPlacementInput input) {
+    var width = input.buttonSize.width;
+
+    final min = input.minMenuWidth;
+    if (min != null && width < min) width = min;
+
+    final max = input.maxMenuWidth;
+    if (max != null && width > max) width = max;
+
+    return width;
+  }
+
+  static double _resolveLeft(DropdownPlacementInput input, double width) {
+    final buttonLeft = input.buttonOffset.dx;
+    final overhang = width - input.buttonSize.width;
+
+    double left;
+    if (overhang <= 0) {
+      left = buttonLeft;
+    } else {
+      left = switch (input.menuAlignment) {
+        MenuAlignment.left => buttonLeft,
+        MenuAlignment.center => buttonLeft - overhang / 2,
+        MenuAlignment.right => buttonLeft - overhang,
+      };
+    }
+
+    // Slide back inside the screen. The right edge is corrected first so a
+    // menu wider than the screen ends up flush with the left margin.
+    final rightLimit = input.screenSize.width - input.screenMargin - width;
+    if (left > rightLimit) left = rightLimit;
+    if (left < input.screenMargin) left = input.screenMargin;
+
+    return left;
+  }
+}

--- a/test/flutter_dropdown_button_test.dart
+++ b/test/flutter_dropdown_button_test.dart
@@ -1,1 +1,61 @@
-void main() {}
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Wraps the dropdown in just enough app to give it an [Overlay].
+Widget host(Widget child) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Center(child: child),
+    ),
+  );
+}
+
+Future<void> openDropdown(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterDropdownButton<String>));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('searchable overlay sizing', () {
+    // The overlay lays its items out in a Column when they all fit, and in a
+    // ListView when they do not. The presence of a ListView is therefore an
+    // observable stand-in for "this dropdown scrolls".
+
+    testWidgets('a short list does not scroll just because search is on',
+        (tester) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana', 'Cherry'],
+            hint: 'Pick a fruit',
+            searchable: true,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      await openDropdown(tester);
+
+      expect(find.byType(TextField), findsOneWidget, reason: 'search is on');
+      expect(find.byType(ListView), findsNothing);
+    });
+
+    testWidgets('a long list still scrolls', (tester) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: List<String>.generate(10, (i) => 'Item $i'),
+            hint: 'Pick an item',
+            searchable: true,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      await openDropdown(tester);
+
+      expect(find.byType(ListView), findsOneWidget);
+    });
+  });
+}

--- a/test/placement/dropdown_placement_test.dart
+++ b/test/placement/dropdown_placement_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dropdown_button/src/buttons/menu_alignment.dart';
+import 'package:flutter_dropdown_button/src/placement/dropdown_placement.dart';
+
+/// A button 40px tall, sitting 100px down a roomy 400x800 screen.
+///
+/// Leaves 648px of usable space below once the screen margin and the
+/// button gap are accounted for, so nothing is ever constrained unless
+/// a test deliberately shrinks the screen.
+DropdownPlacementInput roomyInput({
+  double screenHeight = 800,
+  double buttonTop = 100,
+  int itemCount = 3,
+  double actualItemHeight = 48,
+  double maxDropdownHeight = 200,
+  double chromeHeight = 0,
+  double buttonLeft = 20,
+  double? minMenuWidth,
+  double? maxMenuWidth,
+  MenuAlignment menuAlignment = MenuAlignment.left,
+}) {
+  return DropdownPlacementInput(
+    screenSize: Size(400, screenHeight),
+    safeInsetTop: 0,
+    safeInsetBottom: 0,
+    buttonOffset: Offset(buttonLeft, buttonTop),
+    buttonSize: const Size(200, 40),
+    itemCount: itemCount,
+    actualItemHeight: actualItemHeight,
+    maxDropdownHeight: maxDropdownHeight,
+    chromeHeight: chromeHeight,
+    minMenuWidth: minMenuWidth,
+    maxMenuWidth: maxMenuWidth,
+    menuAlignment: menuAlignment,
+  );
+}
+
+void main() {
+  group('vertical placement', () {
+    test('opens downward when there is room below', () {
+      final result = DropdownPlacement.resolve(roomyInput());
+
+      expect(result.openDown, isTrue);
+      expect(result.height, 144.0);
+      expect(result.top, 144.0);
+      expect(result.transformAlignment, Alignment.topCenter);
+    });
+
+    test('opens upward when below is too short but above is roomy', () {
+      // Button bottom sits at 740, leaving 48px below once margin and gap
+      // are taken — not enough for the 144px the three items want. Above
+      // the button there are 688 usable pixels.
+      final result = DropdownPlacement.resolve(roomyInput(buttonTop: 700));
+
+      expect(result.openDown, isFalse);
+      expect(result.height, 144.0);
+      expect(result.top, 552.0);
+      expect(result.transformAlignment, Alignment.bottomCenter);
+    });
+
+    test('shrinks to the larger span when neither side fits', () {
+      // 300px screen. Below the button: 128 usable. Above it: 108.
+      // The three items want 144, so the menu takes the larger span whole.
+      final result = DropdownPlacement.resolve(
+        roomyInput(screenHeight: 300, buttonTop: 120),
+      );
+
+      expect(result.openDown, isTrue);
+      expect(result.height, 128.0);
+      expect(result.top, 164.0);
+    });
+
+    test('keeps exactly one screen margin below when it shrinks', () {
+      final input = roomyInput(screenHeight: 300, buttonTop: 120);
+      final result = DropdownPlacement.resolve(input);
+
+      final menuBottom = result.top + result.height;
+      final safeBottom =
+          input.screenSize.height - input.safeInsetBottom - input.screenMargin;
+
+      expect(menuBottom, safeBottom);
+    });
+  });
+
+  group('chrome height', () {
+    // A search field is 48px of furniture that is not an item. The overlay
+    // must grow to hold it, not steal the space from the item list.
+    const searchField = 48.0;
+
+    test('grows the overlay to hold the search field', () {
+      final result = DropdownPlacement.resolve(
+        roomyInput(chromeHeight: searchField),
+      );
+
+      expect(result.height, 192.0);
+    });
+
+    test('three items with a search field still do not scroll', () {
+      final input = roomyInput(itemCount: 3, chromeHeight: searchField);
+      final result = DropdownPlacement.resolve(input);
+
+      final contentHeight = result.height - input.chromeHeight;
+      final itemsHeight = input.itemCount * input.actualItemHeight;
+
+      expect(contentHeight, greaterThanOrEqualTo(itemsHeight));
+    });
+  });
+
+  group('minimum visibility', () {
+    test('keeps two items visible even when that overruns the margin', () {
+      // 200px screen, button bottom at 120. Only 68 usable pixels either
+      // side — less than the 96 two items need. Usability wins: the menu
+      // takes 96 and knowingly eats into the screen margin.
+      final result = DropdownPlacement.resolve(
+        roomyInput(screenHeight: 200, buttonTop: 80),
+      );
+
+      expect(result.height, 96.0);
+    });
+
+    test('reserves room for chrome on top of the minimum items', () {
+      final result = DropdownPlacement.resolve(
+        roomyInput(screenHeight: 200, buttonTop: 80, chromeHeight: 48),
+      );
+
+      expect(result.height, 144.0);
+    });
+  });
+
+  group('menu width', () {
+    test('matches the button when unconstrained', () {
+      expect(DropdownPlacement.resolve(roomyInput()).width, 200.0);
+    });
+
+    test('grows to minMenuWidth when the button is narrower', () {
+      final result = DropdownPlacement.resolve(roomyInput(minMenuWidth: 300));
+
+      expect(result.width, 300.0);
+    });
+
+    test('shrinks to maxMenuWidth when the button is wider', () {
+      final result = DropdownPlacement.resolve(roomyInput(maxMenuWidth: 150));
+
+      expect(result.width, 150.0);
+    });
+  });
+
+  group('menu alignment', () {
+    test('lines up with the button when the widths match', () {
+      expect(DropdownPlacement.resolve(roomyInput(buttonLeft: 20)).left, 20.0);
+    });
+
+    test('left alignment keeps the left edges together', () {
+      final result = DropdownPlacement.resolve(
+        roomyInput(buttonLeft: 50, minMenuWidth: 300),
+      );
+
+      expect(result.left, 50.0);
+    });
+
+    test('center alignment splits the overhang evenly', () {
+      // Menu is 300 wide over a 200 wide button: 100px of overhang, half
+      // of it to the left of the button.
+      final result = DropdownPlacement.resolve(
+        roomyInput(
+          buttonLeft: 100,
+          minMenuWidth: 300,
+          menuAlignment: MenuAlignment.center,
+        ),
+      );
+
+      expect(result.left, 50.0);
+    });
+
+    test('right alignment keeps the right edges together', () {
+      final result = DropdownPlacement.resolve(
+        roomyInput(
+          buttonLeft: 150,
+          minMenuWidth: 300,
+          menuAlignment: MenuAlignment.right,
+        ),
+      );
+
+      expect(result.left, 50.0);
+    });
+  });
+
+  group('screen bounds', () {
+    test('pulls the menu back inside the right edge', () {
+      // The scenario from issue #1: a 200px button flush against the right
+      // of a 400px screen. The menu must slide left to keep its margin.
+      final result = DropdownPlacement.resolve(roomyInput(buttonLeft: 250));
+
+      expect(result.left, 192.0);
+      expect(result.left + result.width, 392.0);
+    });
+
+    test('pushes the menu back inside the left edge', () {
+      final result = DropdownPlacement.resolve(roomyInput(buttonLeft: 2));
+
+      expect(result.left, 8.0);
+    });
+  });
+}


### PR DESCRIPTION
Closes #3.

## What changed

Overlay geometry — open direction, height, width, and the screen-edge correction — moved out of `DropdownMixin` and into a pure module under `lib/src/placement/`. It takes plain values and returns plain values: no `BuildContext`, no `MediaQuery`, no `State`. `DropdownMixin` stays as the adapter that reads the screen and delegates.

This is the package's **first test coverage**. 19 tests, 17 of which run without pumping a widget.

## Defect fixed

`preferredHeight` accounted for items, border and padding, but not the search field — while `buildOverlayContent` subtracted the search field from that same value. The overlay never grew to hold the field; it shrank the item area instead.

With defaults, three 48px items in a 200px budget:

```
before:  144 - 48 = 96  available  →  144 > 96   →  scrollbar
after:   192 - 48 = 144 available  →  144 == 144 →  no scrollbar
```

The module now takes a `chromeHeight` — everything in the overlay that is not an item — so omitting it is a compile error rather than a layout bug. The adapter sums the search field, the border and the overlay padding into it; the module never learns what they are.

## Invariants pinned down

Two boundary conditions in the old arithmetic were ambiguous. Both are now stated once and asserted:

- `screenMargin` was subtracted twice in the constrained branch (`spaceBelow` already excluded it).
- `buttonGap` was added to the top position but never subtracted from `spaceBelow`, so a downward menu could overrun the margin by 4px.

Folding `buttonGap` into the definition of `spaceBelow` and `spaceAbove` removes both: `menuHeight <= spaceBelow` now *means* "keeps one screen margin". The one deliberate exception — crowding the edge to keep `minVisibleItems` visible — has its own test saying so.

## Public API

Unchanged. `DropdownPositionResult` keeps its name and shape. `calculateMenuWidth` and `calculateMenuLeftPosition` are undocumented but public, so they remain as `@Deprecated` wrappers delegating to the new `resolvePlacement()`; they go away with the mixin in #7.

## Verification

- `flutter test` — 19 passing
- `flutter analyze` — clean, package and example
- `dart format` — no changes
- The widget test was checked against a deliberately reverted `chromeHeight`: it fails when the bug returns, so it is not vacuous.

Not touched: `CHANGELOG.md` and the version in `pubspec.yaml`. Release sequencing depends on whether #4 and #5 ship alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)