### PR TITLE
Preserve the search query across parent rebuilds

### DIFF
--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -431,18 +431,20 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     return (item as String).toLowerCase().contains(query.toLowerCase());
   }
 
+  /// The items [query] leaves visible. A pure function of its arguments.
+  List<T> _applyFilter(List<T> items, String query) {
+    if (query.isEmpty) return List<T>.from(items);
+
+    final filter =
+        widget.searchFilter ?? (widget.isTextMode ? _defaultTextFilter : null);
+    if (filter == null) return List<T>.from(items);
+
+    return items.where((item) => filter(item, query)).toList();
+  }
+
   void _onSearchChanged(String query) {
     _searchQuery = query;
-    if (query.isEmpty) {
-      _filteredItems = List<T>.from(widget.items);
-    } else {
-      final filter = widget.searchFilter ??
-          (widget.isTextMode ? _defaultTextFilter : null);
-      if (filter != null) {
-        _filteredItems =
-            widget.items.where((item) => filter(item, query)).toList();
-      }
-    }
+    _filteredItems = _applyFilter(widget.items, query);
 
     // Reset scroll position
     if (_scrollController != null && _scrollController!.hasClients) {
@@ -475,11 +477,15 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   void didUpdateWidget(FlutterDropdownButton<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     _autoSelectSingleItem();
-    if (oldWidget.items != widget.items) {
-      _filteredItems = List<T>.from(widget.items);
-      _searchQuery = '';
-      _searchController?.clear();
-    }
+
+    // Recompute unconditionally rather than guessing whether `items` changed.
+    // Comparing by identity is wrong for a list rebuilt each frame, and
+    // comparing by value is wrong for a `T` that does not override `==`;
+    // re-applying the current query is correct either way, and costs the
+    // same as one keystroke. The query is the user's — clearing it belongs
+    // to open, close and select, which `_resetSearch()` already handles.
+    _filteredItems = _applyFilter(widget.items, _searchQuery);
+
     // Handle searchable toggled on at runtime
     if (widget.searchable && _searchController == null) {
       _searchController = TextEditingController();

--- a/test/search_invalidation_test.dart
+++ b/test/search_invalidation_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Reads the text currently sitting in the dropdown's search field.
+String searchFieldText(WidgetTester tester) {
+  return tester.widget<TextField>(find.byType(TextField)).controller!.text;
+}
+
+Future<void> openDropdown(WidgetTester tester, [Finder? button]) async {
+  await tester.tap(button ?? find.byType(FlutterDropdownButton<String>));
+  await tester.pumpAndSettle();
+}
+
+/// A domain type that deliberately does not override `==`, so two instances
+/// carrying the same name are never equal.
+class Fruit {
+  const Fruit(this.name);
+  final String name;
+}
+
+void main() {
+  group('search survives a parent rebuild', () {
+    testWidgets('typed query is kept when items arrive as a fresh list',
+        (tester) async {
+      late StateSetter rebuildParent;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: StatefulBuilder(
+                builder: (context, setState) {
+                  rebuildParent = setState;
+                  // A new List instance on every build — what any caller
+                  // writing `source.map(...).toList()` produces.
+                  return FlutterDropdownButton<String>.text(
+                    items: ['Apple', 'Banana', 'Cherry'],
+                    hint: 'Pick a fruit',
+                    searchable: true,
+                    onChanged: (_) {},
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await openDropdown(tester);
+      await tester.enterText(find.byType(TextField), 'App');
+      await tester.pumpAndSettle();
+
+      expect(searchFieldText(tester), 'App');
+
+      // Anything at all rebuilds the ancestor while the user is mid-search.
+      rebuildParent(() {});
+      await tester.pumpAndSettle();
+
+      expect(searchFieldText(tester), 'App');
+    });
+
+    testWidgets('an item added in place shows up on the next open',
+        (tester) async {
+      final items = <String>['Apple', 'Banana'];
+      late StateSetter rebuildParent;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: StatefulBuilder(
+                builder: (context, setState) {
+                  rebuildParent = setState;
+                  // Same List instance every build; only its contents change.
+                  return FlutterDropdownButton<String>.text(
+                    items: items,
+                    hint: 'Pick a fruit',
+                    searchable: true,
+                    onChanged: (_) {},
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      rebuildParent(() => items.add('Cherry'));
+      await tester.pumpAndSettle();
+
+      await openDropdown(tester);
+
+      expect(find.text('Cherry'), findsOneWidget);
+    });
+
+    testWidgets('the filtered results survive the rebuild too', (tester) async {
+      late StateSetter rebuildParent;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: StatefulBuilder(
+                builder: (context, setState) {
+                  rebuildParent = setState;
+                  return FlutterDropdownButton<String>.text(
+                    items: ['Apple', 'Banana', 'Cherry'],
+                    hint: 'Pick a fruit',
+                    searchable: true,
+                    onChanged: (_) {},
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await openDropdown(tester);
+      await tester.enterText(find.byType(TextField), 'App');
+      await tester.pumpAndSettle();
+
+      rebuildParent(() {});
+      await tester.pumpAndSettle();
+
+      expect(find.text('Apple'), findsOneWidget);
+      expect(find.text('Banana'), findsNothing);
+    });
+
+    testWidgets('holds for a T that does not override ==', (tester) async {
+      late StateSetter rebuildParent;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: StatefulBuilder(
+                builder: (context, setState) {
+                  rebuildParent = setState;
+                  // Deliberately not const: const instances are canonicalized,
+                  // which would hand the widget the same Fruit objects every
+                  // build and defeat the point. These are new objects each
+                  // time, so neither list identity nor element equality can
+                  // tell that nothing really changed.
+                  // ignore: prefer_const_constructors
+                  return FlutterDropdownButton<Fruit>(
+                    // ignore: prefer_const_constructors
+                    items: [Fruit('Apple'), Fruit('Banana')],
+                    itemBuilder: (fruit, _) => Text(fruit.name),
+                    hintWidget: const Text('Pick a fruit'),
+                    searchable: true,
+                    searchFilter: (fruit, query) =>
+                        fruit.name.toLowerCase().contains(query.toLowerCase()),
+                    onChanged: (_) {},
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await openDropdown(tester, find.byType(FlutterDropdownButton<Fruit>));
+      await tester.enterText(find.byType(TextField), 'App');
+      await tester.pumpAndSettle();
+
+      rebuildParent(() {});
+      await tester.pumpAndSettle();
+
+      expect(searchFieldText(tester), 'App');
+      expect(find.text('Banana'), findsNothing);
+    });
+  });
+
+  group('search is still cleared where it should be', () {
+    testWidgets('reopening the dropdown starts from an empty query',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: FlutterDropdownButton<String>.text(
+                items: const ['Apple', 'Banana', 'Cherry'],
+                hint: 'Pick a fruit',
+                searchable: true,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await openDropdown(tester);
+      await tester.enterText(find.byType(TextField), 'App');
+      await tester.pumpAndSettle();
+
+      // Tap outside to dismiss, then open again.
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+      await openDropdown(tester);
+
+      expect(searchFieldText(tester), isEmpty);
+      expect(find.text('Banana'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #2.

## The defect

`didUpdateWidget` compared `items` by **list identity**:

```dart
if (oldWidget.items != widget.items) {
  _filteredItems = List<T>.from(widget.items);
  _searchQuery = '';
  _searchController?.clear();
}
```

Any caller passing a derived list — `source.map(...).toList()`, or a plain non-const literal — hands the widget a new `List` instance on every build. The guard is therefore always true, so **any ancestor rebuild wipes the search box while the user is typing**.

It hid in plain sight because `example/` only ever passes `const [...]` literals, which Dart canonicalizes, and a stable field it never mutates.

## The fix

Recompute unconditionally; keep the query.

```dart
_filteredItems = _applyFilter(widget.items, _searchQuery);
```

Making the comparison *more accurate* would not have worked. `listEquals` falls back to per-element `==`, so a list of freshly-constructed items whose type does not override `==` still compares unequal. Re-applying the current query is correct regardless of any equality semantics of `T`, and costs what one keystroke already costs.

Clearing the query belongs to open, close and select — `_resetSearch()` already does that, and a test now pins it.

Preserving the query is also better behaviour on its own terms: when `items` arrive asynchronously, a query the user already typed should survive their arrival.

## Correction to the issue

The issue also claimed a mirror defect: that mutating the list in place leaves items stale so a new item never appears. **Writing the test disproved it.** `openDropdown()` calls `_resetSearch()`, which repopulates the cache, and there is no reachable path to the stale list. That test passes against the unfixed code and is kept as a characterisation test. See the comment on #2.

## Verification

Five widget tests, all at the public widget interface — none reach into `didUpdateWidget` or `_filteredItems`, so they survive the extraction planned in #8.

Three of them were checked against the unfixed code and fail there:

- typed query is kept when items arrive as a fresh list
- the filtered results survive the rebuild too
- holds for a `T` that does not override `==` (uses deliberately non-const instances; `const` would canonicalize them and defeat the test)

Two pass both before and after, by design — they guard existing behaviour:

- an item added in place shows up on the next open
- reopening the dropdown starts from an empty query

`flutter test` 24 passing · `flutter analyze` clean · `dart format` no changes.

Not touched: `CHANGELOG.md` and the version. This is user-visible and warrants `2.3.2`, but release sequencing depends on whether #4 and #5 ship alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)