### PR TITLE
Position the menu in the Overlay's coordinate space, not the window's

### DIFF
--- a/lib/src/buttons/dropdown_mixin.dart
+++ b/lib/src/buttons/dropdown_mixin.dart
@@ -296,6 +296,16 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
     }
   }
 
+  /// The render box of the [Overlay] the menu is inserted into.
+  ///
+  /// This is the coordinate space the menu is laid out in. For an app with a
+  /// single root Overlay it spans the window, so it agrees with `MediaQuery`.
+  /// A nested Overlay — a side panel with its own `Navigator`, a shell route —
+  /// does not, and the menu must be measured and clamped against this box
+  /// rather than against the window.
+  RenderBox? get overlayRenderBox =>
+      Overlay.of(context).context.findRenderObject() as RenderBox?;
+
   /// Opens the dropdown by creating and inserting an overlay entry.
   ///
   /// If another dropdown is already open, it will be closed first.
@@ -310,10 +320,19 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
     final renderBox =
         dropdownButtonKey.currentContext!.findRenderObject() as RenderBox;
     final buttonSize = renderBox.size;
-    final buttonOffset = renderBox.localToGlobal(Offset.zero);
+
+    // The menu is positioned inside this Overlay's Stack, so the button's
+    // offset must be measured against the same origin. Resolving it against
+    // the root view instead would shift the menu by the Overlay's own offset
+    // whenever the Overlay does not start at (0, 0).
+    final overlay = Overlay.of(context);
+    final buttonOffset = renderBox.localToGlobal(
+      Offset.zero,
+      ancestor: overlayRenderBox,
+    );
 
     _overlayEntry = _createOverlayEntry(buttonOffset, buttonSize);
-    Overlay.of(context).insert(_overlayEntry!);
+    overlay.insert(_overlayEntry!);
 
     // Track the current instance for cleanup via closeAll()
     _currentInstance = this;
@@ -389,13 +408,17 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
     // Safe areas (status bar, navigation bar, home indicator). Zero on desktop.
     final mediaQuery = MediaQuery.of(context);
 
+    // Bound the menu by the Overlay it lives in, not by the window. The two
+    // coincide for a root Overlay; only a nested one makes them differ.
+    final bounds = overlayRenderBox?.size ?? mediaQuery.size;
+
     final padding = overlayPadding;
     final overlayPaddingVertical =
         padding != null ? padding.top + padding.bottom : 0.0;
 
     return DropdownPlacement.resolve(
       DropdownPlacementInput(
-        screenSize: mediaQuery.size,
+        screenSize: bounds,
         safeInsetTop: mediaQuery.padding.top,
         safeInsetBottom: mediaQuery.padding.bottom,
         buttonOffset: buttonOffset,
@@ -445,7 +468,7 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
 
     return DropdownPlacement.resolve(
       DropdownPlacementInput(
-        screenSize: mediaQuery.size,
+        screenSize: overlayRenderBox?.size ?? mediaQuery.size,
         safeInsetTop: mediaQuery.padding.top,
         safeInsetBottom: mediaQuery.padding.bottom,
         buttonOffset: Offset(buttonLeft, 0),

--- a/test/overlay_bounds_test.dart
+++ b/test/overlay_bounds_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Ten items overflow the default 200px budget, so the list renders inside a
+/// ListView whose box spans the menu's full width. That box is the menu.
+Widget dropdown() {
+  return FlutterDropdownButton<String>.text(
+    width: 200,
+    items: List<String>.generate(10, (i) => 'Item $i'),
+    hint: 'Pick an item',
+    onChanged: (_) {},
+  );
+}
+
+Future<Rect> openAndMeasureMenu(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterDropdownButton<String>));
+  await tester.pumpAndSettle();
+  return tester.getRect(find.byType(ListView));
+}
+
+void main() {
+  const screenWidth = 800.0;
+
+  testWidgets('menu pinned to the right edge stays on screen', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [dropdown()],
+          ),
+        ),
+      ),
+    );
+
+    final menu = await openAndMeasureMenu(tester);
+
+    expect(menu.right, lessThanOrEqualTo(screenWidth));
+    expect(menu.left, greaterThanOrEqualTo(0));
+  });
+
+  testWidgets('menu inside an offset Overlay stays on screen', (tester) async {
+    // The button's position is read against the root view, but the menu is
+    // placed against the enclosing Overlay's origin. A panel that owns its
+    // own Overlay and starts at x = 400 makes the two disagree.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                left: 400,
+                top: 0,
+                width: 400,
+                height: 600,
+                child: Overlay(
+                  initialEntries: [
+                    OverlayEntry(
+                      builder: (_) => Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [dropdown()],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final menu = await openAndMeasureMenu(tester);
+
+    expect(menu.right, lessThanOrEqualTo(screenWidth),
+        reason: 'menu must not run off the right of the screen');
+    expect(menu.left, greaterThanOrEqualTo(0));
+  });
+}


### PR DESCRIPTION
Relates to #1. Deliberately does **not** close it — the reporter has not yet confirmed their layout matches this repro, and if it doesn't, they have found a different bug.

## The defect

`openDropdown` read the button's position against the root view:

```dart
final buttonOffset = renderBox.localToGlobal(Offset.zero);
```

The menu is then placed with `Positioned` inside the enclosing `Overlay`'s `Stack`, which is relative to **that Overlay's origin**. With a single root Overlay spanning the window the two coordinate spaces coincide and nothing is wrong. Inside a nested Overlay that does not start at (0, 0) — a side panel with its own `Navigator`, a shell route, an embedded view — they disagree, and the menu is drawn shifted by the Overlay's own offset.

The screen-bounds clamp could not catch it, because it measured against `MediaQuery`'s full-window width rather than the Overlay's box.

Reproduced on an 800px screen with the dropdown inside an `Overlay` starting at x=400:

```
screenWidth = 800.0
menu        = Rect.fromLTRB(993.0, 330.0, 1191.0, 530.0)
```

The clamp correctly resolved `left = 592` in root coordinates. The menu rendered at `400 + 592 = 992`. Off by exactly the panel's origin.

## The fix

Two changes, both in the adapter:

- Resolve the button's offset against the Overlay's render box: `localToGlobal(Offset.zero, ancestor: overlayRenderBox)`.
- Bound the menu by that render box's size rather than `MediaQuery.size`.

`DropdownPlacement` is untouched. The pure module takes a screen size and a button rect as plain values and has no opinion about which coordinate space they came from — passing it the wrong one was the adapter's mistake. Its 17 tests did not change by a character. This is what the extraction in #3 bought.

For a root Overlay the box spans the window, so behaviour is identical and every existing test still passes.

## A note on what "screen" now means

Inside a nested Overlay, the menu is confined to the panel rather than the window. That is the correct behaviour: the menu is drawn in the panel's `Stack`, so anything outside it is clipped or mispositioned anyway.

`safeInsetTop` / `safeInsetBottom` still come from `MediaQuery` and so refer to the window. In a nested Overlay this can over-subtract, which errs on the safe side. Getting it exactly right would mean reading the panel's own `MediaQuery`, which is out of scope here.

## Verification

Two widget tests at the public widget interface:

- `menu pinned to the right edge stays on screen` — the layout from issue #1 (a `Row` with `MainAxisAlignment.end`). This **passes on the unfixed code**, and against the 2.2.1 code as well; it guards the path that was never broken.
- `menu inside an offset Overlay stays on screen` — fails on the unfixed code (`1191.0 > 800.0`), passes after.

`flutter test` 26 passing · `flutter analyze` clean, package and example · `dart format` no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)