### PR TITLE
Release 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.3.2
+
+* **FIX**: Fixed dropdown menu rendering off-screen when the dropdown lives inside a nested `Overlay` or `Navigator` (side panels, shell routes, embedded views) — the button's position was resolved against the root view while the menu was placed against the enclosing `Overlay`'s origin, shifting the menu by that Overlay's offset. Position and screen-bounds clamping now both use the `Overlay`'s render box
+* **FIX**: Fixed `searchable: true` forcing a scrollbar on dropdowns whose items would otherwise fit — the search field's height was subtracted from the item area instead of being added to the overlay height. A 3-item searchable dropdown under default theming no longer scrolls
+* **FIX**: Fixed the search query being cleared whenever an ancestor widget rebuilt. `didUpdateWidget` compared `items` by list identity, so any caller passing a derived list (`source.map(...).toList()`, or a non-const literal) reset the query on every rebuild. The filter is now recomputed from the current query, which is correct regardless of the equality semantics of `T`
+* **FIX**: Fixed the dropdown overrunning `screenMargin` by `buttonGap` (4px) when opening downward, and reserving a double margin (16px) when shrinking to fit. The menu now keeps exactly one `screenMargin` from the safe-area edge in both cases — a menu constrained for space is ~4px taller than before
+* **DEPRECATED**: `DropdownMixin.calculateMenuWidth()` and `DropdownMixin.calculateMenuLeftPosition()` are deprecated in favour of `resolvePlacement()`, which returns the menu's full geometry in one call. They still work and will be removed in 3.0.0
+* **REFACTOR**: Extracted all overlay positioning geometry out of `DropdownMixin` into a pure module that takes plain values and returns plain values — no `BuildContext`, no `MediaQuery`, no `State`. `DropdownMixin` remains as the adapter that reads the screen and delegates
+* **TEST**: Added the package's first test suite — 26 tests, 17 of which exercise the positioning geometry without mounting a widget
+
 ## 2.3.1
 
 * **FIX**: Explicitly set `mouseCursor` on `InkWell` widgets to restore hover cursor behavior on web/desktop after recent Flutter versions changed the default `MaterialStateMouseCursor.clickable` resolution

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^2.3.1
+  flutter_dropdown_button: ^2.3.2
 ```
 
 Import the package:

--- a/docs/.pubignore
+++ b/docs/.pubignore
@@ -1,0 +1,7 @@
+# This directory holds configuration for coding agents working on this repo
+# (issue tracker, triage labels, domain docs). It is repo tooling, not package
+# documentation, and has no value to anyone installing this package — so it is
+# kept out of the published archive.
+#
+# User-facing documentation lives in `documentation/`.
+*

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown package with overlay-based rendering, smooth animations, and specialized variants for different content types."
-version: 2.3.1
+version: 2.3.2
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues


### PR DESCRIPTION
Three user-visible fixes, one behaviour correction, one deprecation, and the package's first test suite.

`flutter pub publish --dry-run` reports **0 warnings**.

## Fixes

**Menu rendered off-screen inside a nested `Overlay`.** The button's position was resolved against the root view while the menu was placed against the enclosing `Overlay`'s origin. With a single root Overlay the two coincide; inside a side panel, shell route or embedded view they do not, and the menu was drawn shifted by the Overlay's offset. The screen-bounds clamp could not catch it because it measured against `MediaQuery`'s window width. Both now use the Overlay's render box. (#1 — reproduced and fixed, but left open pending the reporter's confirmation that this is their case.)

**`searchable: true` forced a scrollbar on lists that fit.** The search field's height was subtracted from the item area rather than added to the overlay height. Three 48px items in the default 200px budget acquired a scrollbar purely because search was enabled.

**The search query was wiped on every ancestor rebuild.** `didUpdateWidget` compared `items` by list identity, so any caller passing a derived list — `source.map(...).toList()`, or a plain non-const literal — reset the query on each rebuild. It now recomputes the filter from the current query, which is correct regardless of the equality semantics of `T`. (Making the comparison *more accurate* would not have worked: `listEquals` falls back to per-element `==`.)

## Behaviour correction

The menu overran `screenMargin` by `buttonGap` (4px) when opening downward, and reserved a doubled margin (16px) when shrinking to fit. Both came from the same missing invariant. The menu now keeps exactly one `screenMargin` from the safe-area edge in either case. **A menu constrained for space is roughly 4px taller than before.** The one deliberate exception — crowding the edge to keep `minVisibleItems` visible — is unchanged and now has a test saying so.

## Deprecation

`DropdownMixin.calculateMenuWidth()` and `calculateMenuLeftPosition()` now warn. Use `resolvePlacement()`, which returns the menu's full geometry in one call. They still work; removal is scheduled for 3.0.0 (#7).

## Under the hood

Overlay positioning geometry moved out of `DropdownMixin` into a pure module: plain values in, plain values out, no `BuildContext`. `DropdownMixin` is now the adapter that reads the screen and delegates.

That extraction paid for itself immediately — the nested-Overlay fix above was a two-line change in the adapter, and the pure module and its 17 tests were untouched.

## Tests

26, up from zero. Seventeen run without mounting a widget.

Every test asserting a bug fix was checked against the unfixed code and observed to fail there. Two tests deliberately pass both before and after; they guard behaviour that was never broken.

## Packaging

Added `docs/.pubignore`. That directory holds agent configuration for this repo, not package documentation, and was being shipped to consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)