### PR TITLE
Let text mode render any T through a label extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ FlutterDropdownButton<String>.text(
 )
 ```
 
+### Text Dropdown of a Domain Type
+
+Pass a `label` to render any type as text. Overflow handling, the tooltip, and
+the default search filter all work off the label.
+
+```dart
+FlutterDropdownButton<User>.text(
+  items: users,
+  value: selectedUser,
+  label: (user) => user.name,
+  hint: 'Select a user',
+  searchable: true,          // filters by name, no searchFilter needed
+  onChanged: (value) {
+    setState(() => selectedUser = value);
+  },
+)
+```
+
+Reach for the default constructor only when an item needs more than text —
+an avatar, an icon, a two-line layout.
+
 ### Custom Widget Dropdown
 
 ```dart
@@ -139,9 +160,10 @@ The unified dropdown widget. Use the default constructor for custom widget rende
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| **`items`** | `List<T>` | **required** | List of string items |
+| **`items`** | `List<T>` | **required** | List of item values |
 | **`onChanged`** | `ValueChanged<T?>` | **required** | Called when an item is selected |
 | `hint` | `String?` | `null` | Text shown when no item is selected |
+| `label` | `String Function(T)?` | `null` | Extracts the text to display for an item. Required unless `T` is `String` |
 | `config` | `TextDropdownConfig?` | `null` | Text rendering configuration |
 | `leading` | `Widget?` | `null` | Widget before text in all items |
 | `selectedLeading` | `Widget?` | `null` | Widget before text in selected item (falls back to `leading`) |

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -135,10 +135,11 @@ TextOnlyDropdownButton({
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `items` | `List<String>` | required | List of text options |
-| `onChanged` | `ValueChanged<String?>` | required | Callback when selection changes |
-| `value` | `String?` | null | Currently selected value |
+| `items` | `List<T>` | required | List of options |
+| `onChanged` | `ValueChanged<T?>` | required | Callback when selection changes |
+| `value` | `T?` | null | Currently selected value |
 | `hint` | `String?` | null | Hint text when no item selected |
+| `label` | `String Function(T)?` | null | Extracts the text to display for an item. Required unless `T` is `String` |
 | `theme` | `DropdownTheme?` | null | Visual theme configuration |
 | `config` | `TextDropdownConfig?` | null | Text-specific configuration |
 | `width` | `double?` | null | Fixed width for dropdown |

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -84,6 +84,7 @@ class FlutterDropdownButton<T> extends StatefulWidget {
     this.searchFilter,
     this.emptyBuilder,
   })  : hintText = null,
+        label = null,
         config = null,
         leading = null,
         selectedLeading = null,
@@ -107,6 +108,7 @@ class FlutterDropdownButton<T> extends StatefulWidget {
     required this.items,
     required this.onChanged,
     String? hint,
+    this.label,
     this.config,
     this.leading,
     this.selectedLeading,
@@ -171,6 +173,24 @@ class FlutterDropdownButton<T> extends StatefulWidget {
 
   /// Text displayed when no item is selected (text mode only).
   final String? hintText;
+
+  /// Extracts the text to display for an item (text mode only).
+  ///
+  /// Supply this to use text mode with any type:
+  ///
+  /// ```dart
+  /// FlutterDropdownButton<User>.text(
+  ///   items: users,
+  ///   label: (user) => user.name,
+  /// )
+  /// ```
+  ///
+  /// The label drives rendering, overflow handling, the tooltip, and the
+  /// default search filter.
+  ///
+  /// May be omitted only when `T` is [String], in which case the item is its
+  /// own label. Omitting it for any other type throws in debug builds.
+  final String Function(T item)? label;
 
   /// Text rendering configuration (text mode only).
   ///
@@ -341,6 +361,27 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   TextDropdownConfig get _textConfig =>
       widget.config ?? TextDropdownConfig.defaultConfig;
 
+  /// The text to display for [item] in text mode.
+  ///
+  /// Uses [FlutterDropdownButton.label] when given. Without it, `T` must be
+  /// [String] — a string is its own label.
+  String _labelOf(T item) {
+    final label = widget.label;
+    if (label != null) return label(item);
+    if (item is String) return item;
+
+    throw FlutterError(
+      'FlutterDropdownButton<$T>.text() needs a `label` callback.\n'
+      'Text mode renders items as text, so it must know how to turn a $T '
+      'into a String. Supply one:\n\n'
+      '  FlutterDropdownButton<$T>.text(\n'
+      '    items: items,\n'
+      '    label: (item) => item.someTextProperty,\n'
+      '  )\n\n'
+      '`label` may only be omitted when T is String.',
+    );
+  }
+
   // ===== DropdownMixin implementation =====
 
   @override
@@ -427,8 +468,10 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     return fieldHeight + margin.top + margin.bottom + dividerHeight;
   }
 
+  /// Case-insensitive `contains` over the item's label. The default in text
+  /// mode, whatever `T` is.
   bool _defaultTextFilter(T item, String query) {
-    return (item as String).toLowerCase().contains(query.toLowerCase());
+    return _labelOf(item).toLowerCase().contains(query.toLowerCase());
   }
 
   /// The items [query] leaves visible. A pure function of its arguments.
@@ -464,6 +507,13 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   @override
   void initState() {
     super.initState();
+    assert(
+      !widget.isTextMode || widget.label != null || T == String,
+      'FlutterDropdownButton<$T>.text() needs a `label` callback.\n'
+      'Text mode renders items as text, so it must know how to turn a $T '
+      'into a String. Supply `label: (item) => item.someTextProperty`, or '
+      'use the default constructor with `itemBuilder` instead.',
+    );
     initializeDropdown();
     _autoSelectSingleItem();
     _filteredItems = List<T>.from(widget.items);
@@ -726,7 +776,8 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   }
 
   Widget _buildTextSelectedWidget() {
-    final selectedText = widget.value as String?;
+    final selected = widget.value;
+    final selectedText = selected == null ? null : _labelOf(selected);
     final displayText = selectedText ?? widget.hintText ?? '';
     final isHint = selectedText == null;
 
@@ -774,14 +825,14 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
 
   Widget _buildItemWidget(T item, bool isSelected) {
     if (widget.isTextMode) {
-      return _buildTextItemWidget(item as String, isSelected);
+      return _buildTextItemWidget(item, isSelected);
     }
     return widget.itemBuilder!(item, isSelected);
   }
 
-  Widget _buildTextItemWidget(String item, bool isSelected) {
+  Widget _buildTextItemWidget(T item, bool isSelected) {
     final textWidget = SmartTooltipText(
-      text: item,
+      text: _labelOf(item),
       tooltipTheme: effectiveTooltipTheme,
       style: isSelected
           ? _textConfig.selectedTextStyle ?? _textConfig.textStyle

--- a/test/text_label_test.dart
+++ b/test/text_label_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A domain type. Not a String, and it does not override `==`.
+class Fruit {
+  const Fruit(this.name);
+  final String name;
+}
+
+const apple = Fruit('Apple');
+const banana = Fruit('Banana');
+const cherry = Fruit('Cherry');
+
+Widget host(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+Future<void> openDropdown(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterDropdownButton<Fruit>));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('text mode renders any T through its label', (tester) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<Fruit>.text(
+          items: const [apple, banana, cherry],
+          label: (fruit) => fruit.name,
+          hint: 'Pick a fruit',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Pick a fruit'), findsOneWidget);
+
+    await openDropdown(tester);
+
+    expect(find.text('Apple'), findsOneWidget);
+    expect(find.text('Banana'), findsOneWidget);
+    expect(find.text('Cherry'), findsOneWidget);
+  });
+
+  testWidgets('the selected item shows its label on the button',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<Fruit>.text(
+          items: const [apple, banana, cherry],
+          value: banana,
+          label: (fruit) => fruit.name,
+          hint: 'Pick a fruit',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('Banana'), findsOneWidget);
+    expect(find.text('Pick a fruit'), findsNothing);
+  });
+
+  testWidgets('search filters by label with no searchFilter supplied',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<Fruit>.text(
+          items: const [apple, banana, cherry],
+          label: (fruit) => fruit.name,
+          hint: 'Pick a fruit',
+          searchable: true,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    await openDropdown(tester);
+    await tester.enterText(find.byType(TextField), 'ban');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Banana'), findsOneWidget);
+    expect(find.text('Apple'), findsNothing);
+    expect(find.text('Cherry'), findsNothing);
+  });
+
+  testWidgets('omitting label for a non-String T fails immediately',
+      (tester) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<int>.text(
+          items: const [1, 2],
+          hint: 'Pick a number',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    // Fails when the widget mounts, not later when an item happens to paint.
+    expect(tester.takeException(), isAssertionError);
+  });
+
+  testWidgets('an overflowing label gets a tooltip', (tester) async {
+    const longName = 'A fruit with a preposterously long name';
+
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<Fruit>.text(
+          width: 100,
+          items: const [Fruit(longName)],
+          label: (fruit) => fruit.name,
+          hint: 'Pick a fruit',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    await openDropdown(tester);
+    expect(find.text(longName), findsOneWidget);
+
+    await tester.longPress(find.text(longName));
+    await tester.pumpAndSettle();
+
+    // The item, plus the tooltip that appeared over it.
+    expect(find.text(longName), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
Closes #13.

## What changed

`.text()` gains an optional `String Function(T) label`. Text mode is no longer chained to `String`.

```dart
// String — unchanged
FlutterDropdownButton.text(items: ['Apple', 'Banana'])

// Any domain type — newly possible
FlutterDropdownButton<User>.text(
  items: users,
  label: (u) => u.name,
  searchable: true,   // filters by name, no searchFilter needed
)
```

The label drives item rendering, the button face, overflow handling, the tooltip, and the default search filter.

## The casts are gone

All three, and `lib/` now contains **zero** occurrences of `as String`:

| Was | Now |
| --- | --- |
| `(item as String).toLowerCase()` (`_defaultTextFilter`) | `_labelOf(item).toLowerCase()` |
| `widget.value as String?` (`_buildTextSelectedWidget`) | `value == null ? null : _labelOf(value)` |
| `item as String` (`_buildItemWidget`) | `_buildTextItemWidget(item, …)` |

`_labelOf` uses `is String` promotion rather than an unchecked cast, so the `String` case is type-safe rather than merely conventional. Where no label is given and `T` is not `String`, it throws a `FlutterError` naming the type and showing the fix.

## Correction to the issue's implementation note

The issue recommended `const` constructor + `assert(label != null || T == String)`, on the grounds that keeping `.text()` const was worth a debug-time check over a compile-time one.

That reasoning had a hole. A `const` constructor's asserts must be potentially-constant expressions, and a type parameter is not — the assert cannot live there. More to the point, **`.text()` can barely be used as `const` anyway**: `onChanged` is required and is a closure, and closures are not constant. The `const` I was protecting was close to worthless.

So: the constructor stays `const` (costs nothing), and the assert moved to `initState`. It fires when the widget mounts, in debug, rather than later when an item happens to paint. In release builds `_labelOf`'s `FlutterError` remains as the backstop.

## Verification

Five widget tests at the public interface. Three of them observed to fail before the change, for the right reasons:

- `the selected item shows its label on the button` — failed with `type 'Fruit' is not a subtype of type 'String?' in type cast`
- `search filters by label with no searchFilter supplied` — failed with the same cast on `Fruit`
- `omitting label for a non-String T fails immediately` — the widget mounted silently; no exception at all

Two cannot fail before the change, because the code they exercise did not compile: `text mode renders any T through its label` and `an overflowing label gets a tooltip`. They are capability tests, not regression tests.

The 26 pre-existing tests — all on the `String` path — pass unchanged. That is the backwards-compatibility evidence.

`flutter test` 31 passing · `flutter analyze` clean · `dart format` no changes.

## Docs

`README.md` gains a "Text Dropdown of a Domain Type" example and a `label` row. `documentation/api_reference.md`'s text-mode table was still typed as `List<String>` / `ValueChanged<String?>`; corrected to `T`. The rest of that file is stale in other ways — see #10.

## Not in this PR

`pubspec.yaml` and `CHANGELOG.md` are untouched. This is additive and belongs in `2.4.0`, alongside #6. The version bump and changelog entry go in the release commit, matching how `2.3.2` was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)