### PR TITLE
Re-measure the menu on every overlay build so it resizes and flips while open

### DIFF
--- a/lib/src/buttons/dropdown_mixin.dart
+++ b/lib/src/buttons/dropdown_mixin.dart
@@ -306,6 +306,24 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
   RenderBox? get overlayRenderBox =>
       Overlay.of(context).context.findRenderObject() as RenderBox?;
 
+  /// Measures the button and resolves where the menu should sit.
+  ///
+  /// Called afresh on every overlay build rather than once when the dropdown
+  /// opens, so a menu whose item list changes underneath it re-sizes and, if
+  /// it no longer fits below the button, flips above it.
+  ///
+  /// Returns null when the button has not been laid out.
+  DropdownPlacementResult? measurePlacement() {
+    final renderBox =
+        dropdownButtonKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) return null;
+
+    return resolvePlacement(
+      renderBox.localToGlobal(Offset.zero, ancestor: overlayRenderBox),
+      renderBox.size,
+    );
+  }
+
   /// Opens the dropdown by creating and inserting an overlay entry.
   ///
   /// If another dropdown is already open, it will be closed first.
@@ -317,22 +335,8 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
       _currentInstance!.closeDropdown();
     }
 
-    final renderBox =
-        dropdownButtonKey.currentContext!.findRenderObject() as RenderBox;
-    final buttonSize = renderBox.size;
-
-    // The menu is positioned inside this Overlay's Stack, so the button's
-    // offset must be measured against the same origin. Resolving it against
-    // the root view instead would shift the menu by the Overlay's own offset
-    // whenever the Overlay does not start at (0, 0).
-    final overlay = Overlay.of(context);
-    final buttonOffset = renderBox.localToGlobal(
-      Offset.zero,
-      ancestor: overlayRenderBox,
-    );
-
-    _overlayEntry = _createOverlayEntry(buttonOffset, buttonSize);
-    overlay.insert(_overlayEntry!);
+    _overlayEntry = _createOverlayEntry();
+    Overlay.of(context).insert(_overlayEntry!);
 
     // Track the current instance for cleanup via closeAll()
     _currentInstance = this;
@@ -486,64 +490,68 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
   }
 
   /// Creates the overlay entry that contains the dropdown options.
-  OverlayEntry _createOverlayEntry(Offset buttonOffset, Size buttonSize) {
-    final position = resolvePlacement(buttonOffset, buttonSize);
-    final menuWidth = position.width;
-    final leftPosition = position.left;
-
+  OverlayEntry _createOverlayEntry() {
     return OverlayEntry(
-      builder: (context) => GestureDetector(
-        // Detect taps outside the dropdown to close it
-        onTap: closeDropdown,
-        behavior: HitTestBehavior.translucent,
-        child: SizedBox.expand(
-          child: Stack(
-            children: [
-              Positioned(
-                left: leftPosition,
-                top: position.top,
-                width: menuWidth,
-                child: AnimatedBuilder(
-                  animation: dropdownAnimationController,
-                  // Build overlay content once and reuse it during animation
-                  child: Material(
-                    elevation: overlayElevation,
-                    shadowColor: overlayShadowColor,
-                    color: Colors.transparent,
-                    borderRadius: BorderRadius.circular(overlayBorderRadius),
-                    child: Container(
-                      constraints: BoxConstraints(
-                        maxHeight: position.height,
-                      ),
-                      decoration: buildOverlayDecoration() ??
-                          BoxDecoration(
-                            color: Theme.of(context).cardColor,
-                            borderRadius:
-                                BorderRadius.circular(overlayBorderRadius),
-                            border: Border.all(
-                              color: Theme.of(context).dividerColor,
-                              width: 1,
+      builder: (context) {
+        // Measured on every build, not captured once at open time. A menu
+        // whose items change underneath it must re-size, and flip above the
+        // button if the taller menu no longer fits below.
+        final position = measurePlacement();
+        if (position == null) return const SizedBox.shrink();
+
+        return GestureDetector(
+          // Detect taps outside the dropdown to close it
+          onTap: closeDropdown,
+          behavior: HitTestBehavior.translucent,
+          child: SizedBox.expand(
+            child: Stack(
+              children: [
+                Positioned(
+                  left: position.left,
+                  top: position.top,
+                  width: position.width,
+                  child: AnimatedBuilder(
+                    animation: dropdownAnimationController,
+                    // Build overlay content once and reuse it during animation
+                    child: Material(
+                      elevation: overlayElevation,
+                      shadowColor: overlayShadowColor,
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(overlayBorderRadius),
+                      child: Container(
+                        constraints: BoxConstraints(
+                          maxHeight: position.height,
+                        ),
+                        decoration: buildOverlayDecoration() ??
+                            BoxDecoration(
+                              color: Theme.of(context).cardColor,
+                              borderRadius:
+                                  BorderRadius.circular(overlayBorderRadius),
+                              border: Border.all(
+                                color: Theme.of(context).dividerColor,
+                                width: 1,
+                              ),
                             ),
-                          ),
-                      child: buildOverlayContent(position.height),
-                    ),
-                  ),
-                  builder: (context, child) {
-                    return Transform.scale(
-                      scale: dropdownScaleAnimation.value,
-                      alignment: position.transformAlignment,
-                      child: Opacity(
-                        opacity: dropdownOpacityAnimation.value,
-                        child: child,
+                        child: buildOverlayContent(position.height),
                       ),
-                    );
-                  },
+                    ),
+                    builder: (context, child) {
+                      return Transform.scale(
+                        scale: dropdownScaleAnimation.value,
+                        alignment: position.transformAlignment,
+                        child: Opacity(
+                          opacity: dropdownOpacityAnimation.value,
+                          child: child,
+                        ),
+                      );
+                    },
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/test/overlay_resize_test.dart
+++ b/test/overlay_resize_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pumps a dropdown whose items the test can change, positioned [topInset]
+/// pixels down the 800x600 test screen.
+Future<void Function(List<String>)> pumpDropdown(
+  WidgetTester tester, {
+  required List<String> initial,
+  double topInset = 250,
+}) async {
+  var items = initial;
+  late StateSetter setParentState;
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: Padding(
+            padding: EdgeInsets.only(top: topInset, left: 100),
+            child: StatefulBuilder(
+              builder: (context, setState) {
+                setParentState = setState;
+                return FlutterDropdownButton<String>.text(
+                  width: 200,
+                  items: items,
+                  hint: 'Pick a fruit',
+                  onChanged: (_) {},
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  return (next) => setParentState(() => items = next);
+}
+
+Future<void> openDropdown(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterDropdownButton<String>));
+  await tester.pumpAndSettle();
+}
+
+/// The menu's box. Items lay out in a Column when they all fit and a ListView
+/// when they don't.
+Rect menuRect(WidgetTester tester) {
+  final listView = find.byType(ListView);
+  if (listView.evaluate().isNotEmpty) return tester.getRect(listView);
+  return tester.getRect(
+    find.ancestor(of: find.text('Apple'), matching: find.byType(Column)).first,
+  );
+}
+
+Rect buttonRect(WidgetTester tester) =>
+    tester.getRect(find.byType(FlutterDropdownButton<String>));
+
+List<String> manyItems(int n) => List<String>.generate(
+      n,
+      (i) => i == 0 ? 'Apple' : 'Item $i',
+    );
+
+void main() {
+  testWidgets('an open menu grows when an item is added', (tester) async {
+    final setItems = await pumpDropdown(tester, initial: ['Apple', 'Banana']);
+
+    await openDropdown(tester);
+    final before = menuRect(tester).height;
+
+    setItems(['Apple', 'Banana', 'Cherry']);
+    await tester.pumpAndSettle();
+
+    // Three 48px items still fit inside the default 200px budget, so the new
+    // item must be visible without a scrollbar.
+    expect(find.text('Cherry'), findsOneWidget);
+    expect(find.byType(ListView), findsNothing);
+    expect(menuRect(tester).height, greaterThan(before));
+  });
+
+  testWidgets('an open menu shrinks when items are removed', (tester) async {
+    final setItems = await pumpDropdown(tester, initial: manyItems(8));
+
+    await openDropdown(tester);
+    expect(find.byType(ListView), findsOneWidget, reason: 'eight items scroll');
+    final before = menuRect(tester).height;
+
+    setItems(['Apple', 'Banana']);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListView), findsNothing);
+    expect(menuRect(tester).height, lessThan(before));
+  });
+
+  testWidgets('an open menu flips above the button when it no longer fits',
+      (tester) async {
+    // Button occupies y 402..450 on a 600px screen. One item (50px) fits in
+    // the 138px below it; eight items (202px) do not, and 390px sit above.
+    final setItems = await pumpDropdown(
+      tester,
+      initial: ['Apple'],
+      topInset: 402,
+    );
+
+    await openDropdown(tester);
+    final button = buttonRect(tester);
+    expect(menuRect(tester).top, greaterThan(button.bottom),
+        reason: 'one item opens downward');
+
+    setItems(manyItems(8));
+    await tester.pumpAndSettle();
+
+    expect(menuRect(tester).bottom, lessThan(button.top),
+        reason: 'eight items no longer fit below, so the menu flips above');
+  });
+}


### PR DESCRIPTION
Closes #17.

## The defect

`_createOverlayEntry` resolved the placement once and captured it in the `OverlayEntry`'s closure:

```dart
final position = resolvePlacement(buttonOffset, buttonSize);
return OverlayEntry(builder: (context) => ... maxHeight: position.height ...);
```

`markNeedsBuild()` reruns the builder, so the *items* refreshed (that landed in #8). `position` did not — it was computed before the entry was ever built. An open menu therefore could not grow: a newly arrived item was capped by the height the menu had when it opened, pushed below the fold of a `ListView` that appeared for no reason the user could see.

```
opened with 2 items  →  maxHeight = 2 * 48 + border = 98
third item arrives   →  content wants 146, capped at 98
                     →  scrollbar appears, third item is not laid out
```

Shrinking always worked: `maxHeight` is an upper bound and the item `Column` uses `MainAxisSize.min`. **Only growth was trapped.**

## The fix

Measure inside the builder, not before it. `measurePlacement()` reads the button's render box and calls `resolvePlacement()`; the overlay builder calls it on every build and bails to an empty box if the button has not been laid out.

`DropdownPlacement` is untouched again. Because #3 reduced placement to a pure call over plain values, "re-measure" is literally "call it again" — there is no state to invalidate, no cache to reconcile. The whole change is moving one call inside a closure.

## Falling out of it: the menu now flips

Re-measuring re-evaluates `spaceBelow` and `spaceAbove` too. A menu that outgrows the room beneath the button now opens upward instead of scrolling in a cramped box. This was not implemented; it is what calling the pure module again gives you.

Tested explicitly: a button at y 402..450 on a 600px screen opens downward with one item (50px into 138px of room) and flips above with eight (202px into 390px of room above).

## Verification

Three widget tests. Two were run against the unfixed code and fail there:

- `an open menu grows when an item is added`
- `an open menu flips above the button when it no longer fits`

One passes both before and after, deliberately — it guards behaviour that already worked:

- `an open menu shrinks when items are removed`

The 33 pre-existing tests pass unchanged.

`flutter test` 36 passing · `flutter analyze` clean · `dart format` no changes.

## Cost

`measurePlacement()` runs once per overlay build — when the entry is inserted, and on each `markNeedsBuild` (a keystroke while searching, an ancestor rebuild). Not per animation frame: `AnimatedBuilder`'s `child` still shields the menu subtree from rebuilding while the open/close animation runs. The work is one `localToGlobal` plus the pure arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)