### PR TITLE
Cover the AppBar layout named in the right-edge overflow report

### DIFF
--- a/test/overlay_bounds_test.dart
+++ b/test/overlay_bounds_test.dart
@@ -22,6 +22,30 @@ Future<Rect> openAndMeasureMenu(WidgetTester tester) async {
 void main() {
   const screenWidth = 800.0;
 
+  // Issue #1 names two layouts: a Row aligned to the end, and an AppBar.
+  // Both are covered here. Neither reproduces the reported overflow — the
+  // clamp has handled them since 1.4.7. The nested-Overlay case below is the
+  // one that was actually broken.
+
+  testWidgets('menu in AppBar actions stays on screen', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            title: const Text('Title'),
+            actions: [dropdown()],
+          ),
+          body: const SizedBox.expand(),
+        ),
+      ),
+    );
+
+    final menu = await openAndMeasureMenu(tester);
+
+    expect(menu.right, lessThanOrEqualTo(screenWidth));
+    expect(menu.left, greaterThanOrEqualTo(0));
+  });
+
   testWidgets('menu pinned to the right edge stays on screen', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Relates to #1.

The reporter named two layouts: a `Row` with `MainAxisAlignment.end`, and an `AppBar`. Only the first was covered. Both are now.

Neither reproduces the reported overflow, on `main` or against the 2.2.1 code the report was filed against. The AppBar case is pixel-identical across both:

```
screen=800.0  button=Rect.fromLTRB(600.0, 3.0, 800.0, 53.0)
              menu=Rect.fromLTRB(593.0, 58.0, 791.0, 258.0)
```

The nested-`Overlay` case in the same file is the one that was genuinely broken, and it is fixed. Keeping all three together makes the distinction legible: two layouts that were never broken, one that was.

`flutter test` 37 passing · `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)