### PR TITLE
Overlay lifecycle test net, and fix closeAll(animate:) on the widget facade

### DIFF
--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -330,11 +330,19 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   ///
   /// Useful before navigation to ensure no orphaned overlays remain.
   ///
+  /// With [animate] true (the default) the menu plays its close animation, so
+  /// the trailing icon rotates back. Pass false to remove the overlay at once
+  /// — the widget may be disposed before an animation could finish.
+  ///
   /// ```dart
   /// FlutterDropdownButton.closeAll();
-  /// Navigator.pushReplacementNamed(context, '/home');
+  ///
+  /// // Right before navigating away:
+  /// FlutterDropdownButton.closeAll(animate: false);
+  /// Navigator.pushNamedAndRemoveUntil(context, '/home', (route) => false);
   /// ```
-  static void closeAll() => DropdownMixin.closeAll();
+  static void closeAll({bool animate = true}) =>
+      DropdownMixin.closeAll(animate: animate);
 
   @override
   State<FlutterDropdownButton<T>> createState() =>

--- a/test/overlay_lifecycle_test.dart
+++ b/test/overlay_lifecycle_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Characterisation tests for the overlay's lifecycle: single-open
+/// coordination, `closeAll`, and cleanup on dispose.
+///
+/// These lock in behaviour that has never had a test, so that the controller
+/// extraction in #6 can be verified rather than hoped at.
+
+Widget twoDropdowns() {
+  return MaterialApp(
+    home: Scaffold(
+      body: Row(
+        children: [
+          FlutterDropdownButton<String>.text(
+            width: 150,
+            items: const ['Alpha 1', 'Alpha 2'],
+            hint: 'Alpha',
+            onChanged: (_) {},
+          ),
+          FlutterDropdownButton<String>.text(
+            width: 150,
+            items: const ['Beta 1', 'Beta 2'],
+            hint: 'Beta',
+            onChanged: (_) {},
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+Finder alphaButton() => find.byType(FlutterDropdownButton<String>).first;
+Finder betaButton() => find.byType(FlutterDropdownButton<String>).last;
+
+/// An item only ever rendered inside the open menu.
+bool alphaMenuOpen() => find.text('Alpha 2').evaluate().isNotEmpty;
+bool betaMenuOpen() => find.text('Beta 2').evaluate().isNotEmpty;
+
+void main() {
+  testWidgets('a menu opens and closes on tap', (tester) async {
+    await tester.pumpWidget(twoDropdowns());
+
+    await tester.tap(alphaButton());
+    await tester.pumpAndSettle();
+    expect(alphaMenuOpen(), isTrue);
+
+    await tester.tapAt(const Offset(700, 500));
+    await tester.pumpAndSettle();
+    expect(alphaMenuOpen(), isFalse);
+  });
+
+  testWidgets('only one menu is open at a time', (tester) async {
+    await tester.pumpWidget(twoDropdowns());
+
+    await tester.tap(alphaButton());
+    await tester.pumpAndSettle();
+    expect(alphaMenuOpen(), isTrue);
+
+    // The open menu covers the screen with a dismiss barrier, so reaching the
+    // other button may take two taps. Either way, both menus must never be
+    // open together.
+    await tester.tap(betaButton(), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    if (!betaMenuOpen()) {
+      await tester.tap(betaButton());
+      await tester.pumpAndSettle();
+    }
+
+    expect(betaMenuOpen(), isTrue);
+    expect(alphaMenuOpen(), isFalse);
+  });
+
+  testWidgets('closeAll() closes the open menu', (tester) async {
+    await tester.pumpWidget(twoDropdowns());
+
+    await tester.tap(alphaButton());
+    await tester.pumpAndSettle();
+    expect(alphaMenuOpen(), isTrue);
+
+    FlutterDropdownButton.closeAll();
+    await tester.pumpAndSettle();
+
+    expect(alphaMenuOpen(), isFalse);
+  });
+
+  testWidgets('closeAll(animate: false) removes the menu at once',
+      (tester) async {
+    await tester.pumpWidget(twoDropdowns());
+
+    await tester.tap(alphaButton());
+    await tester.pumpAndSettle();
+
+    FlutterDropdownButton.closeAll(animate: false);
+    await tester.pump(); // one frame, no time for a close animation
+
+    expect(alphaMenuOpen(), isFalse);
+  });
+
+  testWidgets('closeAll() leaves the dropdown reopenable', (tester) async {
+    await tester.pumpWidget(twoDropdowns());
+
+    await tester.tap(alphaButton());
+    await tester.pumpAndSettle();
+    FlutterDropdownButton.closeAll();
+    await tester.pumpAndSettle();
+
+    await tester.tap(alphaButton());
+    await tester.pumpAndSettle();
+
+    expect(alphaMenuOpen(), isTrue);
+  });
+
+  testWidgets('disposing the widget while open tears the overlay down',
+      (tester) async {
+    await tester.pumpWidget(twoDropdowns());
+
+    await tester.tap(alphaButton());
+    await tester.pumpAndSettle();
+    expect(alphaMenuOpen(), isTrue);
+
+    // Navigate away, disposing both dropdowns mid-animation.
+    await tester.pumpWidget(const MaterialApp(home: Scaffold(body: Text('x'))));
+    await tester.pumpAndSettle();
+
+    expect(alphaMenuOpen(), isFalse);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Groundwork for #6. Does **not** close it — the controller extraction follows in its own PR, under the net this one builds.

## Why this is separate

#6 is a structural refactor with no user-visible behaviour change, so there is no failing test to write first. The `/tdd` loop does not apply; what applies is a characterisation net: lock the current behaviour at the public seam, then move the implementation underneath it.

Before this PR, **none of the 37 tests touched the overlay's lifecycle**. Not `closeAll`, not single-open coordination, not cleanup on dispose. That is precisely the code #6 rips out and rebuilds. Extracting a controller with no coverage there would have been a guess.

## The net

Five characterisation tests, all passing against unchanged code:

- a menu opens and closes on tap
- only one menu is open at a time
- `closeAll()` closes the open menu
- `closeAll()` leaves the dropdown reopenable — the state reset fixed in 2.2.1, previously untested
- disposing the widget while open tears the overlay down, without exceptions

The single-open test tolerates the dismiss barrier needing an extra tap to reach the other button, and asserts the invariant that matters: **both menus are never open together.**

## The bug found on the way

`README.md` has documented this since 2.2.1:

```dart
FlutterDropdownButton.closeAll(animate: false);
Navigator.pushNamedAndRemoveUntil(context, '/home', (route) => false);
```

It does not compile. `DropdownMixin.closeAll({bool animate = true})` gained the parameter; the widget's facade never forwarded it:

```dart
static void closeAll() => DropdownMixin.closeAll();
```

`CHANGELOG.md` for 2.2.1 says *"Added `animate` parameter to `closeAll()`"* without saying which one. Anyone following the README reached for the widget's static — the one the docs use everywhere else — and hit a compile error.

Fixed, with a test that fails to compile before the change:

```dart
static void closeAll({bool animate = true}) =>
    DropdownMixin.closeAll(animate: animate);
```

The test pumps exactly one frame after `closeAll(animate: false)` and asserts the menu is already gone — an animated close could not have finished.

## Verification

`flutter test` 43 passing (was 37) · `flutter analyze` clean · `dart format` no changes.

`pubspec.yaml` and `CHANGELOG.md` untouched; both are updated in the 2.4.0 release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)