### PR TITLE
Replace DropdownMixin with a composed DropdownOverlayController

### DIFF
--- a/example/lib/pages/bug_test_page.dart
+++ b/example/lib/pages/bug_test_page.dart
@@ -49,7 +49,7 @@ class _DropdownBugTestPageState extends State<DropdownBugTestPage> {
       if (_countdown == 1) {
         timer.cancel();
         // Use closeAll() before navigation to manually close dropdown
-        DropdownMixin.closeAll();
+        FlutterDropdownButton.closeAll();
         Navigator.pushNamedAndRemoveUntil(
           context,
           '/result-page',
@@ -67,7 +67,7 @@ class _DropdownBugTestPageState extends State<DropdownBugTestPage> {
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (_countdown == 1) {
         timer.cancel();
-        DropdownMixin.closeAll();
+        FlutterDropdownButton.closeAll();
         setState(() => _countdown = null);
       } else {
         setState(() => _countdown = _countdown! - 1);

--- a/lib/flutter_dropdown_button.dart
+++ b/lib/flutter_dropdown_button.dart
@@ -3,6 +3,7 @@ library;
 export 'src/flutter_dropdown_button.dart';
 export 'src/buttons/dropdown_mixin.dart';
 export 'src/buttons/menu_alignment.dart';
+export 'src/overlay/dropdown_overlay_controller.dart';
 export 'src/config/text_dropdown_config.dart';
 export 'src/theme/dropdown_scroll_theme.dart';
 export 'src/theme/dropdown_style_theme.dart';

--- a/lib/src/buttons/dropdown_mixin.dart
+++ b/lib/src/buttons/dropdown_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../overlay/dropdown_overlay_controller.dart';
 import '../placement/dropdown_placement.dart';
 import 'menu_alignment.dart';
 
@@ -26,58 +27,89 @@ class DropdownPositionResult {
   final double topPosition;
 }
 
-/// A mixin that provides common dropdown functionality including positioning,
-/// animations, and overlay management.
+/// A mixin that provides dropdown positioning, animation and overlay
+/// management to a [State].
 ///
-/// This mixin eliminates code duplication between different dropdown variants
-/// by providing shared functionality for:
-/// - Smart positioning based on available screen space
-/// - Animation setup and management
-/// - Overlay entry creation and lifecycle
-/// - Common state management
+/// **Deprecated.** Hold a [DropdownOverlayController] instead of inheriting
+/// from this. The controller does the same work behind four members rather
+/// than twenty-three, can be tested without a [State], and is what this
+/// package's own dropdown uses.
 ///
-/// Usage:
 /// ```dart
+/// // Before
 /// class _MyDropdownState extends State<MyDropdown>
 ///     with SingleTickerProviderStateMixin, DropdownMixin<MyDropdown> {
-///
 ///   @override
-///   Widget buildOverlayContent(double height) {
-///     return Container(height: height, child: ListView(...));
-///   }
-///
+///   Widget buildOverlayContent(double height) => ListView(...);
 ///   @override
-///   Duration get animationDuration => Duration(milliseconds: 200);
-///   // ... other required implementations
+///   int get itemCount => widget.items.length;
+///   // ...twenty more members
+/// }
+///
+/// // After
+/// class _MyDropdownState extends State<MyDropdown>
+///     with SingleTickerProviderStateMixin {
+///   late final _menu = DropdownOverlayController(
+///     vsync: this,
+///     spec: () => DropdownOverlaySpec(
+///       itemCount: widget.items.length,
+///       actualItemHeight: 48,
+///       maxDropdownHeight: 200,
+///     ),
+///     contentBuilder: (height) => ListView(...),
+///     decorationBuilder: () => null,
+///     onOpenStateChanged: (_) => setState(() {}),
+///   );
 /// }
 /// ```
+///
+/// This mixin now delegates to a controller, so a dropdown built on it and one
+/// built on the controller share the same "only one menu open" rule and both
+/// respond to [closeAll]. It will be removed in 3.0.0.
+@Deprecated(
+  'Hold a DropdownOverlayController instead of mixing this in. '
+  'This mixin will be removed in 3.0.0.',
+)
 mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
+  DropdownOverlayController? _controller;
+
+  DropdownOverlayController get _menu {
+    final controller = _controller;
+    assert(controller != null, 'Call initializeDropdown() from initState().');
+    return controller!;
+  }
+
   /// Global key to access the dropdown button's render object for positioning.
-  final GlobalKey dropdownButtonKey = GlobalKey();
-
-  /// The overlay entry that contains the dropdown options when open.
-  OverlayEntry? _overlayEntry;
-
-  /// Tracks the currently open dropdown instance for cleanup via [closeAll].
-  /// Only one dropdown can be open at a time due to overlay behavior.
-  static DropdownMixin? _currentInstance;
+  GlobalKey get dropdownButtonKey => _menu.buttonKey;
 
   /// Whether the dropdown is currently open.
-  bool get isDropdownOpen => _overlayEntry != null;
+  bool get isDropdownOpen => _controller?.isOpen ?? false;
 
   /// Controls the dropdown show/hide animations.
-  late AnimationController dropdownAnimationController;
+  AnimationController get dropdownAnimationController => _menu.animation;
 
   /// Animation for the dropdown scale effect (grows from 0.8 to 1.0).
-  late Animation<double> dropdownScaleAnimation;
+  Animation<double> get dropdownScaleAnimation => _scale;
 
   /// Animation for the dropdown opacity (fades from 0.0 to 1.0).
-  late Animation<double> dropdownOpacityAnimation;
+  Animation<double> get dropdownOpacityAnimation => _opacity;
 
   /// Animation for the dropdown icon rotation (rotates 180 degrees).
-  late Animation<double> dropdownIconRotationAnimation;
+  Animation<double> get dropdownIconRotationAnimation => _iconRotation;
 
-  // Abstract getters that must be implemented by the using class
+  late final Animation<double> _scale = Tween<double>(begin: 0.8, end: 1.0)
+      .animate(
+          CurvedAnimation(parent: _menu.animation, curve: Curves.easeOutBack));
+
+  late final Animation<double> _opacity = Tween<double>(begin: 0.0, end: 1.0)
+      .animate(CurvedAnimation(parent: _menu.animation, curve: Curves.easeOut));
+
+  late final Animation<double> _iconRotation =
+      Tween<double>(begin: 0.0, end: 0.5).animate(
+          CurvedAnimation(parent: _menu.animation, curve: Curves.easeInOut));
+
+  // Abstract members the using class supplies. All of these collapse into a
+  // single DropdownOverlaySpec when you move to the controller.
 
   /// The duration of the dropdown animations.
   Duration get animationDuration;
@@ -85,10 +117,7 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
   /// The height of each individual dropdown item.
   double get itemHeight;
 
-  /// The actual height of each dropdown item including margins.
-  ///
-  /// This should return the total vertical space each item occupies,
-  /// including any margins applied to the item.
+  /// The total vertical space each item occupies, including margins.
   double get actualItemHeight;
 
   /// The maximum height of the dropdown overlay.
@@ -115,283 +144,140 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
   /// The border radius for the dropdown overlay.
   double get overlayBorderRadius => 8.0;
 
-  /// The total vertical border thickness (top + bottom) for the dropdown overlay.
-  ///
-  /// This is used to calculate the available content height within the overlay.
-  /// Returns 0.0 if no border is applied.
+  /// The total vertical border thickness (top + bottom) of the overlay.
   double get overlayBorderThickness => 0.0;
 
   /// The shadow color for the dropdown overlay Material.
   Color? get overlayShadowColor => null;
 
   /// The padding applied to the dropdown overlay container.
-  ///
-  /// This padding creates internal spacing between the overlay edges
-  /// and the item list. If null, no padding is applied.
   EdgeInsets? get overlayPadding => null;
 
-  /// Vertical space inside the overlay taken by furniture that is not an
-  /// item — a search field, for example.
-  ///
-  /// The overlay grows to hold it rather than shrinking the item list, so a
-  /// short list does not acquire a scrollbar just because search is enabled.
-  /// The border and [overlayPadding] are accounted for separately.
+  /// Vertical space inside the overlay taken by furniture that is not an item.
   double get chromeHeight => 0.0;
 
   /// The minimum width of the dropdown menu overlay.
-  ///
-  /// When set, the menu will be at least this wide even if the button
-  /// is narrower. If null, the menu width matches the button width.
   double? get minMenuWidth => null;
 
   /// The maximum width of the dropdown menu overlay.
-  ///
-  /// When set, the menu will not exceed this width even if the button
-  /// is wider. If null, no maximum width constraint is applied.
   double? get maxMenuWidth => null;
 
   /// The alignment of the menu relative to the button when wider.
-  ///
-  /// This only applies when the menu is wider than the button.
-  /// Defaults to [MenuAlignment.left].
   MenuAlignment get menuAlignment => MenuAlignment.left;
 
-  // Abstract methods that must be implemented by the using class
-
   /// Builds the content of the dropdown overlay with the given height.
-  ///
-  /// This method should return the scrollable content that will be displayed
-  /// inside the dropdown overlay. The [height] parameter specifies the
-  /// calculated optimal height for the overlay.
   Widget buildOverlayContent(double height);
 
   /// Builds the decoration for the dropdown overlay container.
-  ///
-  /// Return null to use the default theme-based decoration.
   BoxDecoration? buildOverlayDecoration();
 
   /// Called when an item is selected from the dropdown.
-  ///
-  /// Implementations should handle the selection logic and call
-  /// [closeDropdown] to close the overlay.
   void onDropdownItemSelected();
 
-  /// Initializes the dropdown animations and controllers.
-  ///
-  /// This should be called in the [initState] method of the using class.
+  DropdownOverlaySpec _buildSpec() => DropdownOverlaySpec(
+        itemCount: itemCount,
+        actualItemHeight: actualItemHeight,
+        maxDropdownHeight: maxDropdownHeight,
+        chromeHeight: chromeHeight,
+        borderThickness: overlayBorderThickness,
+        overlayPadding: overlayPadding,
+        screenMargin: screenMargin,
+        buttonGap: buttonGap,
+        minVisibleItems: minVisibleItems,
+        minMenuWidth: minMenuWidth,
+        maxMenuWidth: maxMenuWidth,
+        menuAlignment: menuAlignment,
+        elevation: overlayElevation,
+        borderRadius: overlayBorderRadius,
+        shadowColor: overlayShadowColor,
+      );
+
+  /// Initializes the dropdown. Call from [initState].
   void initializeDropdown() {
-    dropdownAnimationController = AnimationController(
-      duration: animationDuration,
+    _controller = DropdownOverlayController(
       vsync: this,
-    );
-
-    dropdownScaleAnimation = Tween<double>(begin: 0.8, end: 1.0).animate(
-      CurvedAnimation(
-        parent: dropdownAnimationController,
-        curve: Curves.easeOutBack,
-      ),
-    );
-
-    dropdownOpacityAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
-      CurvedAnimation(
-        parent: dropdownAnimationController,
-        curve: Curves.easeOut,
-      ),
-    );
-
-    dropdownIconRotationAnimation = Tween<double>(begin: 0.0, end: 0.5).animate(
-      CurvedAnimation(
-        parent: dropdownAnimationController,
-        curve: Curves.easeInOut,
-      ),
+      animationDuration: animationDuration,
+      spec: _buildSpec,
+      contentBuilder: buildOverlayContent,
+      decorationBuilder: buildOverlayDecoration,
+      onOpenStateChanged: (_) {
+        if (mounted) setState(() {});
+      },
     );
   }
 
-  /// Disposes of the dropdown resources.
-  ///
-  /// This should be called in the [dispose] method of the using class.
-  void disposeDropdown() {
-    // Immediately remove overlay without animation when disposing
-    // to prevent overlay from remaining after screen transitions
-    if (_overlayEntry != null) {
-      // Clear the tracked instance if it matches before removing
-      if (_currentInstance == this) {
-        _currentInstance = null;
-      }
+  /// Disposes of the dropdown resources. Call from [dispose].
+  void disposeDropdown() => _controller?.dispose();
 
-      try {
-        if (_overlayEntry != null) {
-          _overlayEntry!.remove();
-        }
-      } catch (e) {
-        // Overlay may have already been removed, ignore the error
-      } finally {
-        _overlayEntry = null;
-      }
-    }
-    dropdownAnimationController.dispose();
-  }
-
-  /// Closes the currently open dropdown.
+  /// Closes whichever dropdown menus are open.
   ///
-  /// When [animate] is true (default), closes with the reverse animation
-  /// so the trailing icon and all state update properly.
-  /// When [animate] is false, removes the overlay immediately without
-  /// animation — useful right before navigation where the widget may
-  /// be disposed before the animation completes.
-  ///
-  /// Example usage:
-  /// ```dart
-  /// // Close with animation (icon rotates back)
-  /// DropdownMixin.closeAll();
-  ///
-  /// // Close immediately before navigation
-  /// DropdownMixin.closeAll(animate: false);
-  /// Navigator.pushNamedAndRemoveUntil(context, '/home', (route) => false);
-  /// ```
-  static void closeAll({bool animate = true}) {
-    if (_currentInstance == null) return;
-
-    final instance = _currentInstance!;
-    if (!instance.isDropdownOpen) {
-      _currentInstance = null;
-      return;
-    }
-
-    if (animate && instance.mounted) {
-      instance.closeDropdown();
-    } else {
-      // Immediate removal without animation
-      try {
-        instance._overlayEntry?.remove();
-      } catch (e) {
-        // Overlay may have already been removed, ignore the error
-      } finally {
-        instance.dropdownAnimationController.reset();
-        instance._overlayEntry = null;
-        _currentInstance = null;
-        if (instance.mounted) {
-          instance.setState(() {});
-        }
-      }
-    }
-  }
+  /// Menus built on this mixin and menus built directly on
+  /// [DropdownOverlayController] share one registry, so this closes both.
+  static void closeAll({bool animate = true}) =>
+      DropdownOverlayController.closeAll(animate: animate);
 
   /// Marks the overlay entry as needing rebuild.
-  ///
-  /// Call this when the overlay content has changed (e.g., filtered items)
-  /// and the overlay needs to reflect those changes.
-  void rebuildOverlay() {
-    _overlayEntry?.markNeedsBuild();
-  }
+  void rebuildOverlay() => _controller?.rebuild();
 
   /// Toggles the dropdown between open and closed states.
   void toggleDropdown() {
     if (!isEnabled) return;
-
-    if (isDropdownOpen) {
-      closeDropdown();
-    } else {
-      openDropdown();
-    }
+    _menu.toggle(context);
   }
 
+  /// Opens the dropdown.
+  void openDropdown() {
+    if (!isEnabled) return;
+    _menu.open(context);
+  }
+
+  /// Closes the dropdown.
+  void closeDropdown() => _controller?.close();
+
+  /// Measures the button and resolves where the menu should sit.
+  DropdownPlacementResult? measurePlacement() =>
+      _controller?.measurePlacement();
+
   /// The render box of the [Overlay] the menu is inserted into.
-  ///
-  /// This is the coordinate space the menu is laid out in. For an app with a
-  /// single root Overlay it spans the window, so it agrees with `MediaQuery`.
-  /// A nested Overlay — a side panel with its own `Navigator`, a shell route —
-  /// does not, and the menu must be measured and clamped against this box
-  /// rather than against the window.
   RenderBox? get overlayRenderBox =>
       Overlay.of(context).context.findRenderObject() as RenderBox?;
 
-  /// Measures the button and resolves where the menu should sit.
-  ///
-  /// Called afresh on every overlay build rather than once when the dropdown
-  /// opens, so a menu whose item list changes underneath it re-sizes and, if
-  /// it no longer fits below the button, flips above it.
-  ///
-  /// Returns null when the button has not been laid out.
-  DropdownPlacementResult? measurePlacement() {
-    final renderBox =
-        dropdownButtonKey.currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null || !renderBox.hasSize) return null;
+  DropdownPlacementResult _resolve(
+    Offset buttonOffset,
+    Size buttonSize, {
+    double? pinnedWidth,
+  }) {
+    final overlayBox = overlayRenderBox;
+    final mediaQuery = MediaQuery.of(context);
+    final spec = _buildSpec();
 
-    return resolvePlacement(
-      renderBox.localToGlobal(Offset.zero, ancestor: overlayRenderBox),
-      renderBox.size,
+    return DropdownPlacement.resolve(
+      DropdownPlacementInput(
+        screenSize: overlayBox?.size ?? mediaQuery.size,
+        safeInsetTop: mediaQuery.padding.top,
+        safeInsetBottom: mediaQuery.padding.bottom,
+        buttonOffset: buttonOffset,
+        buttonSize: buttonSize,
+        itemCount: spec.itemCount,
+        actualItemHeight: spec.actualItemHeight,
+        maxDropdownHeight: spec.maxDropdownHeight,
+        chromeHeight: spec.totalChromeHeight,
+        screenMargin: spec.screenMargin,
+        buttonGap: spec.buttonGap,
+        minVisibleItems: spec.minVisibleItems,
+        minMenuWidth: pinnedWidth ?? spec.minMenuWidth,
+        maxMenuWidth: pinnedWidth ?? spec.maxMenuWidth,
+        menuAlignment: spec.menuAlignment,
+      ),
     );
   }
 
-  /// Opens the dropdown by creating and inserting an overlay entry.
-  ///
-  /// If another dropdown is already open, it will be closed first.
-  void openDropdown() {
-    if (isDropdownOpen || !isEnabled) return;
-
-    // Close any previously open dropdown before opening a new one
-    if (_currentInstance != null && _currentInstance != this) {
-      _currentInstance!.closeDropdown();
-    }
-
-    _overlayEntry = _createOverlayEntry();
-    Overlay.of(context).insert(_overlayEntry!);
-
-    // Track the current instance for cleanup via closeAll()
-    _currentInstance = this;
-
-    dropdownAnimationController.forward();
-
-    // Update UI to reflect dropdown state change
-    if (mounted) {
-      setState(() {});
-    }
-  }
-
-  /// Closes the dropdown by reversing the animation and removing the overlay.
-  void closeDropdown() {
-    if (!isDropdownOpen) return;
-
-    dropdownAnimationController.reverse().then((_) {
-      // Check if widget is still mounted before removing overlay
-      if (!mounted) return;
-
-      // Clear the tracked instance if it matches before removing
-      if (_currentInstance == this) {
-        _currentInstance = null;
-      }
-
-      // Safely remove overlay with error handling
-      try {
-        if (_overlayEntry != null) {
-          _overlayEntry!.remove();
-        }
-      } catch (e) {
-        // Overlay may have already been removed (e.g., during dispose), ignore the error
-      } finally {
-        _overlayEntry = null;
-      }
-
-      // Update UI to reflect dropdown state change
-      if (mounted) {
-        setState(() {});
-      }
-    });
-  }
-
   /// Calculates the optimal position and height for the dropdown overlay.
-  ///
-  /// This method performs smart positioning based on available screen space:
-  /// - Prefers to open downward if there's sufficient space
-  /// - Falls back to opening upward if there's more space above
-  /// - Adjusts height dynamically when space is constrained
-  /// - Ensures minimum visibility of items
   DropdownPositionResult calculateDropdownPosition(
     Offset buttonOffset,
     Size buttonSize,
   ) {
-    final placement = resolvePlacement(buttonOffset, buttonSize);
+    final placement = _resolve(buttonOffset, buttonSize);
 
     return DropdownPositionResult(
       height: placement.height,
@@ -401,157 +287,27 @@ mixin DropdownMixin<T extends StatefulWidget> on State<T>, TickerProvider {
     );
   }
 
-  /// Reads the screen from [MediaQuery] and resolves the menu's full geometry.
-  ///
-  /// This is the adapter: it gathers plain values and hands them to
-  /// [DropdownPlacement], which does the arithmetic without a [BuildContext].
-  DropdownPlacementResult resolvePlacement(
-    Offset buttonOffset,
-    Size buttonSize,
-  ) {
-    // Safe areas (status bar, navigation bar, home indicator). Zero on desktop.
-    final mediaQuery = MediaQuery.of(context);
-
-    // Bound the menu by the Overlay it lives in, not by the window. The two
-    // coincide for a root Overlay; only a nested one makes them differ.
-    final bounds = overlayRenderBox?.size ?? mediaQuery.size;
-
-    final padding = overlayPadding;
-    final overlayPaddingVertical =
-        padding != null ? padding.top + padding.bottom : 0.0;
-
-    return DropdownPlacement.resolve(
-      DropdownPlacementInput(
-        screenSize: bounds,
-        safeInsetTop: mediaQuery.padding.top,
-        safeInsetBottom: mediaQuery.padding.bottom,
-        buttonOffset: buttonOffset,
-        buttonSize: buttonSize,
-        itemCount: itemCount,
-        actualItemHeight: actualItemHeight,
-        maxDropdownHeight: maxDropdownHeight,
-        // The border and the overlay's padding occupy the overlay the same
-        // way a search field does; the module need not tell them apart.
-        chromeHeight:
-            chromeHeight + overlayBorderThickness + overlayPaddingVertical,
-        screenMargin: screenMargin,
-        buttonGap: buttonGap,
-        minVisibleItems: minVisibleItems,
-        minMenuWidth: minMenuWidth,
-        maxMenuWidth: maxMenuWidth,
-        menuAlignment: menuAlignment,
-      ),
-    );
-  }
-
   /// Calculates the effective width for the dropdown menu.
-  ///
-  /// Applies [minMenuWidth] and [maxMenuWidth] constraints to the button width.
   @Deprecated(
-    'Use resolvePlacement() and read .width. '
+    'Use DropdownOverlayController.measurePlacement() and read .width. '
     'This method will be removed in 3.0.0.',
   )
-  double calculateMenuWidth(double buttonWidth) {
-    return resolvePlacement(Offset.zero, Size(buttonWidth, 0)).width;
-  }
+  double calculateMenuWidth(double buttonWidth) =>
+      _resolve(Offset.zero, Size(buttonWidth, 0)).width;
 
-  /// Calculates the left position for the dropdown menu based on alignment,
-  /// keeping the menu inside the screen.
+  /// Calculates the left position for the dropdown menu based on alignment.
   @Deprecated(
-    'Use resolvePlacement() and read .left. '
+    'Use DropdownOverlayController.measurePlacement() and read .left. '
     'This method will be removed in 3.0.0.',
   )
   double calculateMenuLeftPosition(
     double buttonLeft,
     double buttonWidth,
     double menuWidth,
-  ) {
-    // Pinning both bounds to menuWidth makes the resolved width exactly the
-    // width the caller asked about, so .left is computed against it.
-    final mediaQuery = MediaQuery.of(context);
-
-    return DropdownPlacement.resolve(
-      DropdownPlacementInput(
-        screenSize: overlayRenderBox?.size ?? mediaQuery.size,
-        safeInsetTop: mediaQuery.padding.top,
-        safeInsetBottom: mediaQuery.padding.bottom,
-        buttonOffset: Offset(buttonLeft, 0),
-        buttonSize: Size(buttonWidth, 0),
-        itemCount: itemCount,
-        actualItemHeight: actualItemHeight,
-        maxDropdownHeight: maxDropdownHeight,
-        screenMargin: screenMargin,
-        buttonGap: buttonGap,
-        minMenuWidth: menuWidth,
-        maxMenuWidth: menuWidth,
-        menuAlignment: menuAlignment,
-      ),
-    ).left;
-  }
-
-  /// Creates the overlay entry that contains the dropdown options.
-  OverlayEntry _createOverlayEntry() {
-    return OverlayEntry(
-      builder: (context) {
-        // Measured on every build, not captured once at open time. A menu
-        // whose items change underneath it must re-size, and flip above the
-        // button if the taller menu no longer fits below.
-        final position = measurePlacement();
-        if (position == null) return const SizedBox.shrink();
-
-        return GestureDetector(
-          // Detect taps outside the dropdown to close it
-          onTap: closeDropdown,
-          behavior: HitTestBehavior.translucent,
-          child: SizedBox.expand(
-            child: Stack(
-              children: [
-                Positioned(
-                  left: position.left,
-                  top: position.top,
-                  width: position.width,
-                  child: AnimatedBuilder(
-                    animation: dropdownAnimationController,
-                    // Build overlay content once and reuse it during animation
-                    child: Material(
-                      elevation: overlayElevation,
-                      shadowColor: overlayShadowColor,
-                      color: Colors.transparent,
-                      borderRadius: BorderRadius.circular(overlayBorderRadius),
-                      child: Container(
-                        constraints: BoxConstraints(
-                          maxHeight: position.height,
-                        ),
-                        decoration: buildOverlayDecoration() ??
-                            BoxDecoration(
-                              color: Theme.of(context).cardColor,
-                              borderRadius:
-                                  BorderRadius.circular(overlayBorderRadius),
-                              border: Border.all(
-                                color: Theme.of(context).dividerColor,
-                                width: 1,
-                              ),
-                            ),
-                        child: buildOverlayContent(position.height),
-                      ),
-                    ),
-                    builder: (context, child) {
-                      return Transform.scale(
-                        scale: dropdownScaleAnimation.value,
-                        alignment: position.transformAlignment,
-                        child: Opacity(
-                          opacity: dropdownOpacityAnimation.value,
-                          child: child,
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
+  ) =>
+      _resolve(
+        Offset(buttonLeft, 0),
+        Size(buttonWidth, 0),
+        pinnedWidth: menuWidth,
+      ).left;
 }

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
-import 'buttons/dropdown_mixin.dart';
 import 'buttons/menu_alignment.dart';
 import 'config/text_dropdown_config.dart';
+import 'overlay/dropdown_overlay_controller.dart';
 import 'theme/dropdown_scroll_theme.dart';
 import 'theme/dropdown_style_theme.dart';
 import 'theme/dropdown_theme.dart';
@@ -342,7 +342,7 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   /// Navigator.pushNamedAndRemoveUntil(context, '/home', (route) => false);
   /// ```
   static void closeAll({bool animate = true}) =>
-      DropdownMixin.closeAll(animate: animate);
+      DropdownOverlayController.closeAll(animate: animate);
 
   @override
   State<FlutterDropdownButton<T>> createState() =>
@@ -350,9 +350,28 @@ class FlutterDropdownButton<T> extends StatefulWidget {
 }
 
 class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
-    with
-        SingleTickerProviderStateMixin,
-        DropdownMixin<FlutterDropdownButton<T>> {
+    with SingleTickerProviderStateMixin {
+  late final DropdownOverlayController _menu = DropdownOverlayController(
+    vsync: this,
+    animationDuration: widget.animationDuration,
+    spec: _buildSpec,
+    contentBuilder: _buildOverlayContent,
+    decorationBuilder: _buildOverlayDecoration,
+    // Opening, closing and selecting all start the search over. The overlay's
+    // dismiss barrier closes the menu without going through this State, so the
+    // reset has to be driven from the controller rather than from our callers.
+    onOpenStateChanged: (_) {
+      _resetSearch();
+      if (mounted) setState(() {});
+    },
+  );
+
+  /// The trailing icon turns half a revolution while the menu is open.
+  late final Animation<double> _iconRotation =
+      Tween<double>(begin: 0.0, end: 0.5).animate(
+    CurvedAnimation(parent: _menu.animation, curve: Curves.easeInOut),
+  );
+
   // ===== Theme =====
 
   DropdownTheme get effectiveTheme =>
@@ -390,24 +409,10 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     );
   }
 
-  // ===== DropdownMixin implementation =====
+  // ===== Overlay =====
 
-  @override
-  Duration get animationDuration => widget.animationDuration;
-
-  @override
-  double get itemHeight => widget.itemHeight;
-
-  @override
-  double get maxDropdownHeight => widget.height;
-
-  @override
-  int get itemCount => widget.items.length;
-
-  @override
   bool get isEnabled => !_isSingleItemDisabled && widget.enabled;
 
-  @override
   double get actualItemHeight {
     final itemMargin = effectiveTheme.itemMargin;
     final marginHeight =
@@ -415,41 +420,30 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     return widget.itemHeight + marginHeight;
   }
 
-  @override
-  double get overlayElevation => effectiveTheme.elevation;
-
-  @override
-  double get overlayBorderRadius => effectiveTheme.borderRadius;
-
-  @override
   double get overlayBorderThickness {
-    final decoration = _buildOverlayDecoration();
-    if (decoration?.border != null) {
-      final border = decoration!.border!;
-      if (border is Border) {
-        return border.top.width + border.bottom.width;
-      }
-    }
+    final border = _buildOverlayDecoration()?.border;
+    if (border is Border) return border.top.width + border.bottom.width;
     return 0.0;
   }
 
-  @override
-  Color? get overlayShadowColor => effectiveTheme.shadowColor;
-
-  @override
-  EdgeInsets? get overlayPadding => effectiveTheme.overlayPadding;
-
-  @override
-  double get chromeHeight => _searchFieldHeight;
-
-  @override
-  double? get minMenuWidth => widget.minMenuWidth;
-
-  @override
-  double? get maxMenuWidth => widget.maxMenuWidth;
-
-  @override
-  MenuAlignment get menuAlignment => widget.menuAlignment;
+  /// Read afresh on every overlay build, so a menu open while its items or
+  /// theme change re-measures against the new values.
+  DropdownOverlaySpec _buildSpec() {
+    return DropdownOverlaySpec(
+      itemCount: widget.items.length,
+      actualItemHeight: actualItemHeight,
+      maxDropdownHeight: widget.height,
+      chromeHeight: _searchFieldHeight,
+      borderThickness: overlayBorderThickness,
+      overlayPadding: effectiveTheme.overlayPadding,
+      minMenuWidth: widget.minMenuWidth,
+      maxMenuWidth: widget.maxMenuWidth,
+      menuAlignment: widget.menuAlignment,
+      elevation: effectiveTheme.elevation,
+      borderRadius: effectiveTheme.borderRadius,
+      shadowColor: effectiveTheme.shadowColor,
+    );
+  }
 
   // ===== Single-item mode =====
 
@@ -511,7 +505,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     }
 
     // Rebuild overlay with new filtered items
-    rebuildOverlay();
+    _menu.rebuild();
   }
 
   // ===== Lifecycle =====
@@ -530,7 +524,6 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
       'into a String. Supply `label: (item) => item.someTextProperty`, or '
       'use the default constructor with `itemBuilder` instead.',
     );
-    initializeDropdown();
     _autoSelectSingleItem();
     if (widget.searchable) {
       _searchController = TextEditingController();
@@ -554,9 +547,9 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     //
     // Deferred to after the frame: the overlay's element is not a descendant
     // of this one, so marking it dirty mid-build is not allowed.
-    if (isDropdownOpen) {
+    if (_menu.isOpen) {
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (mounted) rebuildOverlay();
+        if (mounted) _menu.rebuild();
       });
     }
 
@@ -575,7 +568,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     _canScrollDown.dispose();
     _searchController?.dispose();
     _searchFocusNode?.dispose();
-    disposeDropdown();
+    _menu.dispose();
     super.dispose();
   }
 
@@ -591,21 +584,15 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
 
   // ===== Overlay =====
 
-  @override
-  void onDropdownItemSelected() {
-    _resetSearch();
-    closeDropdown();
-  }
+  void _onItemSelected() => _menu.close();
 
   void _resetSearch() {
     _searchQuery = '';
     _searchController?.clear();
   }
 
-  @override
-  void openDropdown() {
-    _resetSearch();
-    super.openDropdown();
+  void _openDropdown() {
+    _menu.open(context);
     if (widget.searchable && effectiveSearchTheme.autofocus) {
       // Request focus after overlay is inserted
       SchedulerBinding.instance.addPostFrameCallback((_) {
@@ -614,14 +601,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     }
   }
 
-  @override
-  void closeDropdown() {
-    _resetSearch();
-    super.closeDropdown();
-  }
-
-  @override
-  BoxDecoration? buildOverlayDecoration() => _buildOverlayDecoration();
+  void _toggleDropdown() => _menu.isOpen ? _menu.close() : _openDropdown();
 
   BoxDecoration? _buildOverlayDecoration() {
     return effectiveTheme.overlayDecoration ??
@@ -641,13 +621,13 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   @override
   Widget build(BuildContext context) {
     Widget button = Container(
-      key: dropdownButtonKey,
+      key: _menu.buttonKey,
       width: widget.width,
       decoration: _buildButtonDecoration(),
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          onTap: isEnabled ? toggleDropdown : null,
+          onTap: isEnabled ? _toggleDropdown : null,
           mouseCursor: isEnabled
               ? SystemMouseCursors.click
               : SystemMouseCursors.forbidden,
@@ -739,7 +719,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
                 height: effectiveIconSize,
                 child: Center(
                   child: RotationTransition(
-                    turns: dropdownIconRotationAnimation,
+                    turns: _iconRotation,
                     child: widget.trailing ??
                         Icon(
                           effectiveTheme.icon ?? Icons.keyboard_arrow_down,
@@ -889,8 +869,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
 
   // ===== Overlay content =====
 
-  @override
-  Widget buildOverlayContent(double height) {
+  Widget _buildOverlayContent(double height) {
     final items = _visibleItems;
     final scrollTheme = effectiveScrollTheme;
     final padding = effectiveTheme.overlayPadding;
@@ -1113,7 +1092,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
         child: InkWell(
           onTap: () {
             widget.onChanged(item);
-            onDropdownItemSelected();
+            _onItemSelected();
           },
           mouseCursor: SystemMouseCursors.click,
           splashColor:
@@ -1300,7 +1279,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
         baseColor,
       ];
     }
-    final borderRadius = BorderRadius.circular(overlayBorderRadius);
+    final borderRadius = BorderRadius.circular(effectiveTheme.borderRadius);
 
     return ClipRRect(
       borderRadius: borderRadius,

--- a/lib/src/overlay/dropdown_overlay_controller.dart
+++ b/lib/src/overlay/dropdown_overlay_controller.dart
@@ -1,0 +1,329 @@
+import 'package:flutter/material.dart';
+
+import '../buttons/menu_alignment.dart';
+import '../placement/dropdown_placement.dart';
+
+/// Everything the overlay needs to know about the menu it is about to show.
+///
+/// Read afresh on every overlay build — the item count, the theme and the
+/// search field's height all change while the menu is open — so a controller
+/// takes a [DropdownOverlaySpecBuilder] rather than one of these directly.
+class DropdownOverlaySpec {
+  /// Describes one rendering of the menu.
+  const DropdownOverlaySpec({
+    required this.itemCount,
+    required this.actualItemHeight,
+    required this.maxDropdownHeight,
+    this.chromeHeight = 0.0,
+    this.borderThickness = 0.0,
+    this.overlayPadding,
+    this.screenMargin = 8.0,
+    this.buttonGap = 4.0,
+    this.minVisibleItems = 2,
+    this.minMenuWidth,
+    this.maxMenuWidth,
+    this.menuAlignment = MenuAlignment.left,
+    this.elevation = 8.0,
+    this.borderRadius = 8.0,
+    this.shadowColor,
+  });
+
+  /// How many items the menu holds.
+  final int itemCount;
+
+  /// The vertical space one item occupies, including its margin.
+  final double actualItemHeight;
+
+  /// The tallest the item list may grow.
+  final double maxDropdownHeight;
+
+  /// Vertical space taken by furniture that is not an item — a search field.
+  final double chromeHeight;
+
+  /// Total thickness of the overlay's top and bottom borders.
+  final double borderThickness;
+
+  /// Padding inside the overlay container.
+  final EdgeInsets? overlayPadding;
+
+  /// The gap kept between the menu and the edge of the safe area.
+  final double screenMargin;
+
+  /// The gap kept between the button and the menu.
+  final double buttonGap;
+
+  /// How many items stay visible when space runs out.
+  final int minVisibleItems;
+
+  /// The narrowest the menu may be, even if the button is narrower.
+  final double? minMenuWidth;
+
+  /// The widest the menu may be, even if the button is wider.
+  final double? maxMenuWidth;
+
+  /// How the menu lines up with the button when it is the wider of the two.
+  final MenuAlignment menuAlignment;
+
+  /// Shadow depth of the overlay material.
+  final double elevation;
+
+  /// Corner radius of the overlay.
+  final double borderRadius;
+
+  /// Shadow colour of the overlay material.
+  final Color? shadowColor;
+
+  /// Everything in the overlay that is not an item.
+  double get totalChromeHeight =>
+      chromeHeight +
+      borderThickness +
+      (overlayPadding == null
+          ? 0.0
+          : overlayPadding!.top + overlayPadding!.bottom);
+}
+
+/// Supplies a fresh [DropdownOverlaySpec] each time the overlay builds.
+typedef DropdownOverlaySpecBuilder = DropdownOverlaySpec Function();
+
+/// Drives a dropdown menu: its overlay's lifetime, its open/close animation,
+/// the widget tree it is drawn into, and the rule that only one menu is open
+/// at a time within an [Overlay].
+///
+/// Hold one; do not inherit from it. A widget's `State` owns a controller the
+/// same way this package's own dropdown does, so third parties build on the
+/// same module rather than on a copy of it.
+///
+/// ```dart
+/// late final _menu = DropdownOverlayController(
+///   vsync: this,
+///   spec: () => DropdownOverlaySpec(itemCount: items.length, ...),
+///   contentBuilder: (height) => ListView(...),
+///   decorationBuilder: () => null,
+///   onOpenStateChanged: (_) => setState(() {}),
+/// );
+/// ```
+class DropdownOverlayController {
+  /// Creates a controller. Call [dispose] from the owner's `dispose`.
+  DropdownOverlayController({
+    required TickerProvider vsync,
+    required this.spec,
+    required this.contentBuilder,
+    required this.decorationBuilder,
+    Duration animationDuration = const Duration(milliseconds: 200),
+    this.onOpenStateChanged,
+  }) : _animation =
+            AnimationController(duration: animationDuration, vsync: vsync);
+
+  /// Attach this to the button so the controller can measure it.
+  final GlobalKey buttonKey = GlobalKey();
+
+  /// Describes the menu as it should be drawn right now.
+  final DropdownOverlaySpecBuilder spec;
+
+  /// Builds the menu's scrollable content, given the height available to it.
+  final Widget Function(double height) contentBuilder;
+
+  /// Decorates the overlay container. Return null for a themed default.
+  final BoxDecoration? Function() decorationBuilder;
+
+  /// Called after the menu opens or closes, so the owner can rebuild.
+  final ValueChanged<bool>? onOpenStateChanged;
+
+  final AnimationController _animation;
+  OverlayEntry? _entry;
+  BuildContext? _context;
+  bool _disposed = false;
+
+  /// The open menu in each [Overlay], so opening one closes its neighbour.
+  ///
+  /// Keyed by Overlay rather than held in a single static field: two menus in
+  /// two different Overlays — a side panel and the root — do not contend.
+  static final Map<OverlayState, DropdownOverlayController> _openPerOverlay =
+      {};
+
+  /// Whether the menu is showing.
+  bool get isOpen => _entry != null;
+
+  /// Runs forward as the menu opens and backward as it closes.
+  ///
+  /// Owners drive their own transitions from it — a trailing icon that rotates
+  /// while the menu is open, say. The menu's own scale and fade are internal.
+  AnimationController get animation => _animation;
+
+  late final Animation<double> _scale = Tween<double>(begin: 0.8, end: 1.0)
+      .animate(CurvedAnimation(parent: _animation, curve: Curves.easeOutBack));
+
+  late final Animation<double> _opacity = Tween<double>(begin: 0.0, end: 1.0)
+      .animate(CurvedAnimation(parent: _animation, curve: Curves.easeOut));
+
+  /// Shows the menu, closing whichever menu is open in the same [Overlay].
+  void open(BuildContext context) {
+    if (isOpen) return;
+
+    final overlay = Overlay.of(context);
+    _openPerOverlay[overlay]?.close();
+
+    _context = context;
+    _entry = _buildEntry();
+    overlay.insert(_entry!);
+    _openPerOverlay[overlay] = this;
+
+    _animation.forward();
+    onOpenStateChanged?.call(true);
+  }
+
+  /// Hides the menu.
+  ///
+  /// With [animate] true the close animation plays first, so the trailing icon
+  /// rotates back. Pass false to tear the overlay down at once — the owner may
+  /// be disposed before an animation could finish.
+  void close({bool animate = true}) {
+    if (!isOpen) return;
+
+    if (!animate) {
+      _animation.reset();
+      _teardown();
+      return;
+    }
+
+    _animation.reverse().then((_) {
+      // The owner may have been disposed while the animation ran.
+      if (!_disposed && isOpen) _teardown();
+    });
+  }
+
+  /// Opens the menu if closed, closes it if open.
+  void toggle(BuildContext context) => isOpen ? close() : open(context);
+
+  /// Rebuilds the menu in place, re-measuring it.
+  ///
+  /// The overlay is not a descendant of its owner, so it does not rebuild when
+  /// the owner does. Call this after the items or the theme change. Not legal
+  /// during a build — defer to a post-frame callback.
+  void rebuild() => _entry?.markNeedsBuild();
+
+  /// Releases the animation and removes the overlay without animating.
+  void dispose() {
+    _disposed = true;
+    // Silent: the owner is being torn down and must not be asked to rebuild.
+    if (isOpen) _teardown(notify: false);
+    _animation.dispose();
+  }
+
+  /// Closes whichever menus are open, in every [Overlay].
+  static void closeAll({bool animate = true}) {
+    for (final controller in _openPerOverlay.values.toList()) {
+      controller.close(animate: animate);
+    }
+  }
+
+  void _teardown({bool notify = true}) {
+    try {
+      _entry?.remove();
+    } catch (_) {
+      // The overlay may already be gone — during a route transition, say.
+    } finally {
+      _entry = null;
+      _openPerOverlay
+          .removeWhere((_, controller) => identical(controller, this));
+      if (notify) onOpenStateChanged?.call(false);
+    }
+  }
+
+  /// Measures the button and resolves where the menu should sit.
+  ///
+  /// Called on every overlay build rather than once at open time, so a menu
+  /// whose items change underneath it re-sizes and, if the taller menu no
+  /// longer fits below the button, flips above it.
+  DropdownPlacementResult? measurePlacement() {
+    final context = _context;
+    if (context == null || !context.mounted) return null;
+
+    final button = buttonKey.currentContext?.findRenderObject() as RenderBox?;
+    if (button == null || !button.attached || !button.hasSize) return null;
+
+    // The menu is positioned inside the Overlay's Stack, so the button must be
+    // measured against the same origin. Against the root view instead, the menu
+    // would shift by the Overlay's own offset whenever it is not at (0, 0).
+    final overlayBox =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    final mediaQuery = MediaQuery.of(context);
+    final current = spec();
+
+    return DropdownPlacement.resolve(
+      DropdownPlacementInput(
+        screenSize: overlayBox?.size ?? mediaQuery.size,
+        safeInsetTop: mediaQuery.padding.top,
+        safeInsetBottom: mediaQuery.padding.bottom,
+        buttonOffset: button.localToGlobal(Offset.zero, ancestor: overlayBox),
+        buttonSize: button.size,
+        itemCount: current.itemCount,
+        actualItemHeight: current.actualItemHeight,
+        maxDropdownHeight: current.maxDropdownHeight,
+        chromeHeight: current.totalChromeHeight,
+        screenMargin: current.screenMargin,
+        buttonGap: current.buttonGap,
+        minVisibleItems: current.minVisibleItems,
+        minMenuWidth: current.minMenuWidth,
+        maxMenuWidth: current.maxMenuWidth,
+        menuAlignment: current.menuAlignment,
+      ),
+    );
+  }
+
+  OverlayEntry _buildEntry() {
+    return OverlayEntry(
+      builder: (context) {
+        final position = measurePlacement();
+        if (position == null) return const SizedBox.shrink();
+
+        final current = spec();
+
+        return GestureDetector(
+          onTap: close,
+          behavior: HitTestBehavior.translucent,
+          child: SizedBox.expand(
+            child: Stack(
+              children: [
+                Positioned(
+                  left: position.left,
+                  top: position.top,
+                  width: position.width,
+                  child: AnimatedBuilder(
+                    animation: _animation,
+                    // Built once and reused across animation frames.
+                    child: Material(
+                      elevation: current.elevation,
+                      shadowColor: current.shadowColor,
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(current.borderRadius),
+                      child: Container(
+                        constraints: BoxConstraints(maxHeight: position.height),
+                        decoration: decorationBuilder() ??
+                            BoxDecoration(
+                              color: Theme.of(context).cardColor,
+                              borderRadius:
+                                  BorderRadius.circular(current.borderRadius),
+                              border: Border.all(
+                                color: Theme.of(context).dividerColor,
+                                width: 1,
+                              ),
+                            ),
+                        child: contentBuilder(position.height),
+                      ),
+                    ),
+                    builder: (context, child) => Transform.scale(
+                      scale: _scale.value,
+                      alignment: position.transformAlignment,
+                      child: Opacity(opacity: _opacity.value, child: child),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/test/overlay/dropdown_overlay_controller_test.dart
+++ b/test/overlay/dropdown_overlay_controller_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The controller is a plain object. Constructing and driving it needs a
+/// ticker, nothing more — no `State`, no widget tree, no `pumpWidget`.
+DropdownOverlayController makeController({
+  ValueChanged<bool>? onOpenStateChanged,
+}) {
+  return DropdownOverlayController(
+    vsync: const TestVSync(),
+    spec: () => const DropdownOverlaySpec(
+      itemCount: 3,
+      actualItemHeight: 48,
+      maxDropdownHeight: 200,
+    ),
+    contentBuilder: (_) => const SizedBox.shrink(),
+    decorationBuilder: () => null,
+    onOpenStateChanged: onOpenStateChanged,
+  );
+}
+
+void main() {
+  test('a fresh controller is closed', () {
+    final controller = makeController();
+    addTearDown(controller.dispose);
+
+    expect(controller.isOpen, isFalse);
+  });
+
+  test('closing a closed controller is a no-op', () {
+    var notifications = 0;
+    final controller =
+        makeController(onOpenStateChanged: (_) => ++notifications);
+    addTearDown(controller.dispose);
+
+    controller.close();
+
+    expect(controller.isOpen, isFalse);
+    expect(notifications, 0);
+  });
+
+  test('rebuild on a closed controller does nothing', () {
+    final controller = makeController();
+    addTearDown(controller.dispose);
+
+    expect(controller.rebuild, returnsNormally);
+  });
+
+  test('measuring without an open menu yields no placement', () {
+    final controller = makeController();
+    addTearDown(controller.dispose);
+
+    expect(controller.measurePlacement(), isNull);
+  });
+
+  test('closeAll with nothing open is a no-op', () {
+    expect(DropdownOverlayController.closeAll, returnsNormally);
+  });
+
+  test('disposing does not notify the owner', () {
+    var notifications = 0;
+    final controller =
+        makeController(onOpenStateChanged: (_) => ++notifications);
+
+    controller.dispose();
+
+    expect(notifications, 0);
+  });
+
+  test('the spec sums everything that is not an item', () {
+    const spec = DropdownOverlaySpec(
+      itemCount: 3,
+      actualItemHeight: 48,
+      maxDropdownHeight: 200,
+      chromeHeight: 48, // search field
+      borderThickness: 2,
+      overlayPadding: EdgeInsets.symmetric(vertical: 4),
+    );
+
+    expect(spec.totalChromeHeight, 58);
+  });
+}


### PR DESCRIPTION
Closes #6. Builds on the test net from #21.

## What changed

`DropdownOverlayController` is a plain object a `State` **holds**, not a mixin it **is**. It owns the overlay's lifetime, the open/close animation, the widget tree the menu is drawn into, and the rule that only one menu is open at a time.

`_FlutterDropdownButtonState` no longer mixes in `DropdownMixin`. Its **fourteen one-line forwarders are gone**, folded into a single `_buildSpec()`.

## Why a mixin was the wrong shape

- **The interface was not negotiable.** `with DropdownMixin` took all twenty-three members; a caller could not use half.
- **Only a `State` could extend it.** The declaration was `on State<T>, TickerProvider`, so nothing could be tested without constructing a `State`.
- **The global was a symptom.** `static DropdownMixin? _currentInstance` existed because a mixin has no owner, so "which menu is open" had nowhere to live but a static field. It is gone, replaced by a registry keyed by `Overlay` — two menus in two different Overlays no longer contend for one slot.
- **The stated rationale had expired.** The dartdoc said the mixin "eliminates code duplication between different dropdown variants". Those variants were merged into `FlutterDropdownButton` three majors ago. One implementer remained.

## The seam is still public — and better

`DropdownOverlayController` is exported. `DropdownMixin` was documented as an extension point (`api_reference.md` showed users mixing it into their own `State`), and that capability is not removed, it is improved: third parties now hold the same controller this package's own dropdown holds. Two adapters, one seam, for real.

Its interface: `buttonKey`, `isOpen`, `animation`, `open`, `close`, `toggle`, `rebuild`, `dispose`, plus the static `closeAll`. The menu's scale and fade stay internal; only the raw `AnimationController` is exposed, because an owner genuinely needs it to drive a trailing icon.

The twenty-three getters collapse into one `DropdownOverlaySpec`, supplied as a **callback** rather than a value: the item count, the theme and the search field's height all change while the menu is open, and `measurePlacement()` re-reads them on every overlay build.

## What composition made explicit

Inheritance was quietly doing two things that had to be wired by hand:

**Virtual dispatch.** The dismiss barrier called `closeDropdown()`, which reached `_FlutterDropdownButtonState`'s override and reset the search. A controller knows nothing of its owner's methods, so it now reports open/close through `onOpenStateChanged`.

**Lifecycle.** `disposeDropdown()` tore the overlay down silently. Once teardown notified the owner, disposing a dropdown called `setState()` on a defunct element, and a pending close animation woke up after `dispose()`. Both are guarded now — `dispose()` tears down without notifying, and the animation's continuation checks first. **The test net caught both**: 21 of the 43 tests failed on the first pass.

## Migration

`DropdownMixin` remains, marked `@Deprecated`, delegating to a controller. Existing `with DropdownMixin` code compiles with a warning, not an error. Crucially both share one registry, so a mixin-based menu and a controller-based one obey the same single-open rule and both answer `closeAll()`.

Public signatures are preserved, including `calculateDropdownPosition(Offset, Size)` and `DropdownPositionResult`. `2.4.0` is a minor release and breaks nothing.

Removal is #7, in 3.0.0.

## Verification

50 tests passing (was 43). Seven are new and exercise the controller **without a `State`, a widget tree, or `pumpWidget`** — `const TestVSync()` and a plain constructor are enough. That was the point.

The 43 characterisation and regression tests from #21 and earlier pass unchanged. They are what made this refactor checkable rather than hopeful.

`flutter analyze` clean, package and example · `dart format` no changes.

`example/lib/pages/bug_test_page.dart` moved off `DropdownMixin.closeAll()` to the documented `FlutterDropdownButton.closeAll()`.

## Not in this PR

`pubspec.yaml` and `CHANGELOG.md`. `2.4.0` is cut in its own commit, alongside #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)