### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.4.0
+
+* **FEAT**: `FlutterDropdownButton.text()` now accepts a `label` callback, so text mode renders **any** type — not just `String`. Overflow handling, the tooltip and the default search filter all work off the label, so a `List<User>` no longer has to drop to `itemBuilder` and give those up. Omitting `label` for a non-`String` `T` now fails loudly at construction in debug builds instead of throwing a cast error at paint time
+* **FEAT**: Added `DropdownOverlayController` and `DropdownOverlaySpec` — hold a controller instead of mixing in `DropdownMixin` to build your own dropdown. It manages the overlay's lifetime, the open/close animation, and the "only one menu open" rule behind nine members rather than twenty-three, and can be tested without a `State`. See `example/lib/pages/domain_type_page.dart`
+* **FEAT**: Only-one-menu-open is now scoped to the enclosing `Overlay` rather than to the process, so two dropdowns in two different `Overlay`s no longer close each other
+* **FIX**: `FlutterDropdownButton.closeAll()` now accepts `animate`, as `README.md` has documented since 2.2.1. The parameter existed only on `DropdownMixin.closeAll()`; the widget's facade never forwarded it, so the documented call did not compile
+* **FIX**: A dropdown menu that is already open now reflects items that change underneath it. Previously an item list arriving asynchronously never appeared until the user closed and reopened the menu
+* **FIX**: An open menu now grows when its item list gets longer, and flips above the button when the taller menu no longer fits below. Previously the height was fixed when the menu opened, so new items were pushed below the fold of a scrollbar that appeared for no visible reason
+* **DEPRECATED**: `DropdownMixin` is deprecated in favour of `DropdownOverlayController`. It still works — it now delegates to a controller, so mixin-based and controller-based menus share one registry and both answer `closeAll()`. It will be removed in 3.0.0
+* **REFACTOR**: `_FlutterDropdownButtonState` holds a controller instead of inheriting from a mixin. Fourteen one-line forwarders and the `static _currentInstance` global are gone
+* **REFACTOR**: The filtered item list is derived from the items and the query on read rather than cached in a field, removing four hand-written invalidation sites
+* **TEST**: 50 tests, up from 26 — placement geometry, search invalidation, overlay bounds and resizing, label extraction, and the controller itself (unit-tested with no widget tree)
+
 ## 2.3.2
 
 * **FIX**: Fixed dropdown menu rendering off-screen when the dropdown lives inside a nested `Overlay` or `Navigator` (side panels, shell routes, embedded views) — the button's position was resolved against the root view while the menu was placed against the enclosing `Overlay`'s origin, shifting the menu by that Overlay's offset. Position and screen-bounds clamping now both use the `Overlay`'s render box

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A highly customizable dropdown package for Flutter with overlay-based rendering,
 
 - **Single Unified Widget**: One `FlutterDropdownButton<T>` for all use cases
 - **Two Modes**: Custom widget rendering (default) or text-only (`.text()`)
+- **Any Type in Text Mode**: Supply a `label` callback and keep tooltips, overflow handling and search
 - **Overlay-based Rendering**: Better positioning and visual effects than Flutter's built-in DropdownButton
 - **Smart Positioning**: Automatically opens up/down based on available space
 - **Smooth Animations**: Scale and fade effects with configurable timing
@@ -21,6 +22,7 @@ A highly customizable dropdown package for Flutter with overlay-based rendering,
 - **Single-Item Mode**: Auto-disable when only one option exists
 - **Leading Widgets**: Optional icons/widgets before text content
 - **Searchable Dropdown**: Real-time filtering with customizable search field
+- **Build Your Own**: `DropdownOverlayController` exposes the overlay machinery
 
 ## Screenshots
 
@@ -41,7 +43,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^2.3.2
+  flutter_dropdown_button: ^2.4.0
 ```
 
 Import the package:

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -228,72 +228,118 @@ DropdownTheme({
 | `itemSplashColor` | `Color?` | null | Splash color for item interactions |
 | `itemHighlightColor` | `Color?` | null | Highlight color for item touch |
 
-## DropdownMixin<T>
+## DropdownOverlayController
 
-A mixin that provides common dropdown functionality including positioning, animations, and overlay management.
+Drives a dropdown menu: its overlay's lifetime, its open/close animation, the widget tree the menu is drawn into, and the rule that only one menu is open at a time within an `Overlay`.
 
-This mixin eliminates code duplication between different dropdown variants by providing shared functionality for smart positioning, animation setup, overlay management, and common state management.
+**Hold one; do not inherit from it.** This package's own `FlutterDropdownButton` holds the same controller, so a custom dropdown built on it behaves identically.
 
-### Key Features
-
-- **Smart Positioning**: Automatically opens upward when insufficient space below
-- **Dynamic Height Adjustment**: Prevents screen overflow with adaptive height
-- **Animation Management**: Consistent scale and opacity animations
-- **Overlay Lifecycle**: Proper creation, insertion, and disposal
-- **Outside-tap Dismissal**: Automatic closure when tapping outside
+Replaces `DropdownMixin`, which is deprecated and will be removed in 3.0.0.
 
 ### Usage
 
 ```dart
-class _MyDropdownState extends State<MyDropdown> 
-    with SingleTickerProviderStateMixin, DropdownMixin<MyDropdown> {
-  
+class _MyDropdownState extends State<MyDropdown>
+    with SingleTickerProviderStateMixin {
+  late final _menu = DropdownOverlayController(
+    vsync: this,
+    spec: () => DropdownOverlaySpec(
+      itemCount: widget.items.length,
+      actualItemHeight: 48,
+      maxDropdownHeight: 200,
+    ),
+    contentBuilder: (height) => ListView(...),
+    decorationBuilder: () => null,
+    onOpenStateChanged: (_) => setState(() {}),
+  );
+
   @override
-  Widget buildOverlayContent(double height) {
-    return Container(height: height, child: ListView(...));
+  void dispose() {
+    _menu.dispose();
+    super.dispose();
   }
-  
+
   @override
-  Duration get animationDuration => Duration(milliseconds: 200);
-  // ... other required implementations
+  Widget build(BuildContext context) => InkWell(
+        key: _menu.buttonKey,
+        onTap: () => _menu.toggle(context),
+        child: ...,
+      );
 }
 ```
 
-### Abstract Properties
+A working example lives in `example/lib/pages/domain_type_page.dart`.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `animationDuration` | `Duration` | Duration of show/hide animations |
-| `itemHeight` | `double` | Height of each dropdown item |
-| `maxDropdownHeight` | `double` | Maximum height of dropdown overlay |
-| `itemCount` | `int` | Number of items in the dropdown |
-| `isEnabled` | `bool` | Whether dropdown is interactive (default: true) |
-| `screenMargin` | `double` | Safety margin from screen edges (default: 8.0) |
-| `buttonGap` | `double` | Gap between button and overlay (default: 4.0) |
-| `minVisibleItems` | `int` | Minimum visible items when constrained (default: 2) |
-| `overlayElevation` | `double` | Elevation of overlay Material (default: 8.0) |
-| `overlayBorderRadius` | `double` | Border radius for overlay (default: 8.0) |
-| `overlayShadowColor` | `Color?` | Shadow color for overlay (default: null) |
+### Constructor
 
-### Abstract Methods
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **`vsync`** | `TickerProvider` | Drives the open/close animation |
+| **`spec`** | `DropdownOverlaySpec Function()` | Called on every overlay build. A callback, not a value: the item count and theme change while the menu is open |
+| **`contentBuilder`** | `Widget Function(double height)` | Builds the menu's content, given the height available to it |
+| **`decorationBuilder`** | `BoxDecoration? Function()` | Decorates the overlay container. Return null for a themed default |
+| `animationDuration` | `Duration` | Defaults to 200ms |
+| `onOpenStateChanged` | `ValueChanged<bool>?` | Called after the menu opens or closes, so the owner can rebuild |
 
-| Method | Return Type | Description |
-|--------|-------------|-------------|
-| `buildOverlayContent(double height)` | `Widget` | Builds the scrollable content for the overlay |
-| `buildOverlayDecoration()` | `BoxDecoration?` | Builds custom decoration (null for default) |
-| `onDropdownItemSelected()` | `void` | Called when an item is selected |
+### Members
 
-### Available Methods
-
-| Method | Description |
+| Member | Description |
 |--------|-------------|
-| `initializeDropdown()` | Initialize animations and controllers |
-| `disposeDropdown()` | Dispose of dropdown resources |
-| `toggleDropdown()` | Toggle between open/closed states |
-| `openDropdown()` | Open the dropdown overlay |
-| `closeDropdown()` | Close the dropdown overlay |
-| `calculateDropdownPosition()` | Calculate optimal position and height |
-| `closeAll()` (static) | Manually close any open dropdown immediately |
+| `buttonKey` | Attach to the button so the controller can measure it |
+| `isOpen` | Whether the menu is showing |
+| `animation` | Runs forward as the menu opens. Drive your own transitions from it — a rotating trailing icon, say |
+| `open(context)` | Shows the menu, closing whichever menu is open in the same `Overlay` |
+| `close({animate = true})` | Hides the menu. Pass `animate: false` to tear it down at once |
+| `toggle(context)` | Opens if closed, closes if open |
+| `rebuild()` | Rebuilds and re-measures the menu in place. Not legal during a build — defer to a post-frame callback |
+| `dispose()` | Releases the animation and removes the overlay |
+| `closeAll({animate = true})` (static) | Closes every open menu, in every `Overlay` |
+
+### DropdownOverlaySpec
+
+Describes one rendering of the menu. Everything that is not an item — the search field, the border, the overlay's padding — is summed into the space the menu reserves for chrome, so a short list never acquires a scrollbar just because search is enabled.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| **`itemCount`** | `int` | required | How many items the menu holds |
+| **`actualItemHeight`** | `double` | required | Vertical space one item occupies, including its margin |
+| **`maxDropdownHeight`** | `double` | required | The tallest the item list may grow |
+| `chromeHeight` | `double` | `0.0` | Space taken by furniture that is not an item — a search field |
+| `borderThickness` | `double` | `0.0` | Total thickness of the overlay's top and bottom borders |
+| `overlayPadding` | `EdgeInsets?` | `null` | Padding inside the overlay container |
+| `screenMargin` | `double` | `8.0` | Gap kept between the menu and the safe-area edge |
+| `buttonGap` | `double` | `4.0` | Gap kept between the button and the menu |
+| `minVisibleItems` | `int` | `2` | Items kept visible when space runs out, even at the cost of the margin |
+| `minMenuWidth` | `double?` | `null` | Narrowest the menu may be |
+| `maxMenuWidth` | `double?` | `null` | Widest the menu may be |
+| `menuAlignment` | `MenuAlignment` | `.left` | How the menu lines up with a narrower button |
+| `elevation` | `double` | `8.0` | Shadow depth |
+| `borderRadius` | `double` | `8.0` | Corner radius |
+| `shadowColor` | `Color?` | `null` | Shadow colour |
+
+## DropdownMixin<T>
+
+**Deprecated since 2.4.0. Removed in 3.0.0.** Hold a `DropdownOverlayController` instead.
+
+The mixin still works — it now delegates to a controller — so mixin-based and controller-based menus share one "only one menu open" registry and both answer `closeAll()`.
+
+Migration: the twenty-three members the mixin asked you to implement collapse into a single `DropdownOverlaySpec`.
+
+```dart
+// Before
+class _MyDropdownState extends State<MyDropdown>
+    with SingleTickerProviderStateMixin, DropdownMixin<MyDropdown> {
+  @override
+  Widget buildOverlayContent(double height) => ListView(...);
+  @override
+  int get itemCount => widget.items.length;
+  @override
+  Duration get animationDuration => Duration(milliseconds: 200);
+  // ...twenty more
+}
+
+// After — see DropdownOverlayController above
+```
 
 ### Manual Dropdown Cleanup
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'pages/playground_page.dart';
 import 'pages/bug_test_page.dart';
+import 'pages/domain_type_page.dart';
 import 'pages/result_page.dart';
 
 void main() {
@@ -22,6 +23,7 @@ class MyApp extends StatelessWidget {
       home: const PlaygroundPage(),
       routes: {
         '/dropdown-bug-test': (context) => const DropdownBugTestPage(),
+        '/domain-type': (context) => const DomainTypePage(),
         '/result-page': (context) => const ResultPage(),
       },
     );

--- a/example/lib/pages/domain_type_page.dart
+++ b/example/lib/pages/domain_type_page.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+
+/// A domain type. Not a String, and it does not override `==`.
+class Country {
+  const Country(this.code, this.name, this.flag);
+
+  final String code;
+  final String name;
+  final String flag;
+}
+
+const _countries = <Country>[
+  Country('KR', 'South Korea', '🇰🇷'),
+  Country('JP', 'Japan', '🇯🇵'),
+  Country('US', 'United States', '🇺🇸'),
+  Country('DE', 'Germany', '🇩🇪'),
+  Country('FR', 'France', '🇫🇷'),
+  Country('BR', 'Brazil', '🇧🇷'),
+  Country('ZA', 'South Africa', '🇿🇦'),
+  Country('AU', 'Australia', '🇦🇺'),
+];
+
+/// Shows the two features added in 2.4.0:
+///
+/// * `label` — text mode renders any `T`, keeping tooltips and search.
+/// * `DropdownOverlayController` — build your own dropdown by holding one.
+class DomainTypePage extends StatefulWidget {
+  const DomainTypePage({super.key});
+
+  @override
+  State<DomainTypePage> createState() => _DomainTypePageState();
+}
+
+class _DomainTypePageState extends State<DomainTypePage> {
+  Country? _selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: const Text('Domain Types & Controller'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Text mode with a label extractor',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              'Country is not a String. A label callback is all it takes — '
+              'overflow handling, the tooltip and the search filter all follow.',
+            ),
+            const SizedBox(height: 16),
+            FlutterDropdownButton<Country>.text(
+              width: 280,
+              items: _countries,
+              value: _selected,
+              label: (country) => '${country.flag}  ${country.name}',
+              hint: 'Select a country',
+              searchable: true, // filters by label; no searchFilter needed
+              onChanged: (country) => setState(() => _selected = country),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              _selected == null
+                  ? 'Nothing selected'
+                  : 'Selected: ${_selected!.code}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 40),
+            const Text(
+              'A dropdown built on DropdownOverlayController',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              'The controller is the extension point. Hold one; the package\'s '
+              'own dropdown holds the same object.',
+            ),
+            const SizedBox(height: 16),
+            const _ColourMenuButton(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A minimal custom dropdown. It owns a [DropdownOverlayController] rather
+/// than inheriting from anything, and supplies a fresh spec on every build of
+/// the overlay so the menu re-measures itself.
+class _ColourMenuButton extends StatefulWidget {
+  const _ColourMenuButton();
+
+  @override
+  State<_ColourMenuButton> createState() => _ColourMenuButtonState();
+}
+
+class _ColourMenuButtonState extends State<_ColourMenuButton>
+    with SingleTickerProviderStateMixin {
+  static const _colours = <String, Color>{
+    'Crimson': Color(0xFFDC143C),
+    'Teal': Color(0xFF008080),
+    'Amber': Color(0xFFFFBF00),
+    'Indigo': Color(0xFF4B0082),
+  };
+
+  String _selected = 'Teal';
+
+  late final DropdownOverlayController _menu = DropdownOverlayController(
+    vsync: this,
+    spec: () => DropdownOverlaySpec(
+      itemCount: _colours.length,
+      actualItemHeight: 44,
+      maxDropdownHeight: 200,
+      borderThickness: 2,
+    ),
+    contentBuilder: _buildMenu,
+    decorationBuilder: () => BoxDecoration(
+      color: Theme.of(context).cardColor,
+      borderRadius: BorderRadius.circular(8),
+      border: Border.all(color: Theme.of(context).dividerColor),
+    ),
+    onOpenStateChanged: (_) => setState(() {}),
+  );
+
+  @override
+  void dispose() {
+    _menu.dispose();
+    super.dispose();
+  }
+
+  Widget _buildMenu(double height) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final entry in _colours.entries)
+          InkWell(
+            onTap: () {
+              setState(() => _selected = entry.key);
+              _menu.close();
+            },
+            child: SizedBox(
+              height: 44,
+              child: Row(
+                children: [
+                  const SizedBox(width: 12),
+                  CircleAvatar(backgroundColor: entry.value, radius: 8),
+                  const SizedBox(width: 12),
+                  Text(entry.key),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 280,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          key: _menu.buttonKey,
+          onTap: () => _menu.toggle(context),
+          borderRadius: BorderRadius.circular(8),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            decoration: BoxDecoration(
+              border: Border.all(color: Theme.of(context).dividerColor),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                CircleAvatar(backgroundColor: _colours[_selected], radius: 8),
+                const SizedBox(width: 12),
+                Expanded(child: Text(_selected)),
+                RotationTransition(
+                  turns: Tween<double>(begin: 0, end: 0.5).animate(
+                    CurvedAnimation(
+                      parent: _menu.animation,
+                      curve: Curves.easeInOut,
+                    ),
+                  ),
+                  child: const Icon(Icons.keyboard_arrow_down),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/pages/playground_page.dart
+++ b/example/lib/pages/playground_page.dart
@@ -393,6 +393,11 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
         title: const Text('Dropdown Playground'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.travel_explore),
+            tooltip: 'Domain Types & Controller',
+            onPressed: () => Navigator.pushNamed(context, '/domain-type'),
+          ),
+          IconButton(
             icon: const Icon(Icons.bug_report),
             tooltip: 'Overlay Bug Test',
             onPressed: () => Navigator.pushNamed(context, '/dropdown-bug-test'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown package with overlay-based rendering, smooth animations, and specialized variants for different content types."
-version: 2.3.2
+version: 2.4.0
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues


### PR DESCRIPTION
Two features, four fixes, one deprecation. `flutter pub publish --dry-run` reports **0 warnings**.

## Features

**Text mode renders any type.** `.text()` takes a `label` callback, so a `List<User>` gets tooltips, overflow handling and the default search filter without dropping to `itemBuilder`. `String` is the case where the item is its own label. Omitting `label` for another type now fails at construction in debug rather than throwing a cast error at paint time — `lib/` no longer contains a single `as String`.

**`DropdownOverlayController`.** The overlay machinery is now an object you *hold* rather than a mixin you *are*. Nine members instead of twenty-three, testable without a `State`, and it is what `FlutterDropdownButton` itself uses — so a custom dropdown built on it is not building on a copy.

Single-open coordination moved from a process-wide static to a registry keyed by `Overlay`. Two dropdowns in two different `Overlay`s no longer close each other.

## Fixes

**`closeAll(animate:)` did not compile.** `README.md` has shown `FlutterDropdownButton.closeAll(animate: false)` since 2.2.1. The parameter only ever existed on `DropdownMixin.closeAll()`; the widget's facade never forwarded it.

**An open menu ignored items that changed underneath it.** The overlay lives in its own element subtree and does not rebuild when the widget does, so a list arriving asynchronously never appeared until the user closed and reopened the menu.

**An open menu could not grow.** Its height was captured when it opened, so a newly arrived item was pushed below the fold of a scrollbar that appeared for no visible reason. It now re-measures on every overlay build — and, falling out of that, flips above the button when the taller menu no longer fits below.

**Menus rendered off-screen inside a nested `Overlay`.** Position was resolved against the root view while the menu was placed against the enclosing Overlay's origin.

## Deprecation

`DropdownMixin` warns now, removed in 3.0.0 (#7). It delegates to a controller, so mixin-based and controller-based menus share one registry and both answer `closeAll()`. Every public signature is preserved — `2.4.0` is a minor release and breaks nothing.

## Docs and example

`documentation/api_reference.md`'s extension-point section was rewritten around the controller; it had been telling readers to mix in the deprecated API. The rest of that file still documents `BasicDropdownButton`, `TextOnlyDropdownButton` and `DropdownItem`, all removed in 2.0.0 — tracked in #10, out of scope here.

`example/lib/pages/domain_type_page.dart` is new: a searchable dropdown over a `Country` domain type, and a hand-built colour picker that owns a `DropdownOverlayController`. The migration guide is now executable code rather than a snippet nobody compiles.

## Tests

50, up from 26 at the 2.3.2 release and from zero at the start of this work. Seven exercise the controller with no widget tree at all.

Every bug fixed in this release was checked against the unfixed code and observed to fail there. The controller extraction was verified by 43 characterisation tests written first, 21 of which failed on the first attempt — inheritance had been quietly doing virtual dispatch and lifecycle work that composition made explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)