### PR TITLE
The trailing icon honours single-item auto-disable

### DIFF
--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -724,7 +724,9 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
                         Icon(
                           effectiveTheme.icon ?? Icons.keyboard_arrow_down,
                           size: effectiveIconSize,
-                          color: widget.enabled
+                          // `isEnabled`, not `widget.enabled`: a single-item
+                          // dropdown disabled by policy is disabled here too.
+                          color: isEnabled
                               ? (effectiveTheme.iconColor ??
                                   Theme.of(context).iconTheme.color)
                               : (effectiveTheme.iconDisabledColor ??

--- a/test/disabled_state_test.dart
+++ b/test/disabled_state_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const enabledIcon = Color(0xFFE53935);
+const disabledIcon = Color(0xFF9E9E9E);
+
+final theme = DropdownStyleTheme(
+  dropdown: const DropdownTheme(
+    iconColor: enabledIcon,
+    iconDisabledColor: disabledIcon,
+  ),
+);
+
+Widget host(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+Color? arrowColour(WidgetTester tester) =>
+    tester.widget<Icon>(find.byType(Icon)).color;
+
+void main() {
+  group('the arrow icon agrees with the rest of the button', () {
+    testWidgets('enabled dropdown draws the enabled icon colour',
+        (tester) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana'],
+            hint: 'Pick a fruit',
+            theme: theme,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(arrowColour(tester), enabledIcon);
+    });
+
+    testWidgets('disabled dropdown draws the disabled icon colour',
+        (tester) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana'],
+            hint: 'Pick a fruit',
+            enabled: false,
+            theme: theme,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(arrowColour(tester), disabledIcon);
+    });
+
+    testWidgets(
+        'a single-item dropdown disabled by policy draws the '
+        'disabled icon colour too', (tester) async {
+      // `disableWhenSingleItem` makes the button non-interactive: the tap is
+      // blocked, the decoration switches to its disabled form, and the text
+      // takes `disabledTextStyle`. The icon must not be the odd one out.
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Only one'],
+            hint: 'Pick a fruit',
+            disableWhenSingleItem: true,
+            hideIconWhenSingleItem: false,
+            theme: theme,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(arrowColour(tester), disabledIcon);
+    });
+  });
+}


### PR DESCRIPTION
Groundwork for #5, and a bug it exposed.

## The defect

The widget decides "is this dropdown disabled?" in five places. Four of them ask `isEnabled`:

```dart
bool get isEnabled => !_isSingleItemDisabled && widget.enabled;
```

The trailing icon asked `widget.enabled`.

So a dropdown disabled by `disableWhenSingleItem` blocks taps, switches its decoration to the disabled form and applies `disabledTextStyle` — while the arrow keeps its **enabled** colour. Visible whenever `hideIconWhenSingleItem: false`.

`CHANGELOG.md` for 1.6.0 records fixing exactly this class of bug twice — *"Fixed disabled opacity check using `widget.enabled` instead of `isEnabled`"*. One survived.

## Why it survived

This is the argument for #5, in miniature. Fifteen fallback chains are inlined across seven build methods, each deciding independently what "disabled" means. Nothing forces them to agree, and nothing noticed when one didn't.

Once `DropdownTheme` resolves itself — the actual subject of #5 — that decision exists in one place and cannot drift.

## Verification

Three widget tests. One fails before the change:

- `a single-item dropdown disabled by policy draws the disabled icon colour too` — expected grey, got red

Two pass both before and after, guarding the paths that were already right:

- `enabled dropdown draws the enabled icon colour`
- `disabled dropdown draws the disabled icon colour`

`flutter test` 53 passing (was 50) · `flutter analyze` clean · `dart format` no changes.

The `resolve()` extraction follows in its own PR, under these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)