### PR TITLE
DropdownTheme resolves itself instead of leaking fallback chains into build()

### DIFF
--- a/lib/flutter_dropdown_button.dart
+++ b/lib/flutter_dropdown_button.dart
@@ -8,5 +8,6 @@ export 'src/config/text_dropdown_config.dart';
 export 'src/theme/dropdown_scroll_theme.dart';
 export 'src/theme/dropdown_style_theme.dart';
 export 'src/theme/dropdown_theme.dart';
+export 'src/theme/resolved_dropdown_style.dart';
 export 'src/theme/search_field_theme.dart';
 export 'src/theme/tooltip_theme.dart';

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -7,6 +7,7 @@ import 'overlay/dropdown_overlay_controller.dart';
 import 'theme/dropdown_scroll_theme.dart';
 import 'theme/dropdown_style_theme.dart';
 import 'theme/dropdown_theme.dart';
+import 'theme/resolved_dropdown_style.dart';
 import 'theme/search_field_theme.dart';
 import 'theme/tooltip_theme.dart';
 import 'widgets/smart_tooltip_text.dart';
@@ -377,6 +378,14 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   DropdownTheme get effectiveTheme =>
       widget.theme?.dropdown ?? DropdownTheme.defaultTheme;
 
+  DropdownAmbientColors get _ambient => DropdownAmbientColors.of(context);
+
+  ResolvedButtonStyle get _buttonStyle =>
+      effectiveTheme.resolveButton(_ambient, enabled: isEnabled);
+
+  ResolvedOverlayStyle get _overlayStyle =>
+      effectiveTheme.resolveOverlay(_ambient);
+
   DropdownScrollTheme? get effectiveScrollTheme => widget.theme?.scroll;
 
   DropdownTooltipTheme get effectiveTooltipTheme =>
@@ -420,11 +429,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     return widget.itemHeight + marginHeight;
   }
 
-  double get overlayBorderThickness {
-    final border = _buildOverlayDecoration()?.border;
-    if (border is Border) return border.top.width + border.bottom.width;
-    return 0.0;
-  }
+  double get overlayBorderThickness => _overlayStyle.borderThickness;
 
   /// Read afresh on every overlay build, so a menu open while its items or
   /// theme change re-measures against the new values.
@@ -603,27 +608,18 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
 
   void _toggleDropdown() => _menu.isOpen ? _menu.close() : _openDropdown();
 
-  BoxDecoration? _buildOverlayDecoration() {
-    return effectiveTheme.overlayDecoration ??
-        BoxDecoration(
-          color: effectiveTheme.backgroundColor ?? Theme.of(context).cardColor,
-          borderRadius: BorderRadius.circular(effectiveTheme.borderRadius),
-          border: effectiveTheme.border ??
-              Border.all(
-                color: Theme.of(context).dividerColor,
-                width: 1,
-              ),
-        );
-  }
+  BoxDecoration? _buildOverlayDecoration() => _overlayStyle.decoration;
 
   // ===== Build =====
 
   @override
   Widget build(BuildContext context) {
+    final style = _buttonStyle;
+
     Widget button = Container(
       key: _menu.buttonKey,
       width: widget.width,
-      decoration: _buildButtonDecoration(),
+      decoration: style.decoration,
       child: Material(
         color: Colors.transparent,
         child: InkWell(
@@ -631,16 +627,13 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
           mouseCursor: isEnabled
               ? SystemMouseCursors.click
               : SystemMouseCursors.forbidden,
-          borderRadius: BorderRadius.circular(effectiveTheme.borderRadius),
-          splashColor:
-              effectiveTheme.buttonSplashColor ?? Theme.of(context).splashColor,
-          highlightColor: effectiveTheme.buttonHighlightColor ??
-              Theme.of(context).highlightColor,
-          hoverColor:
-              effectiveTheme.buttonHoverColor ?? Theme.of(context).hoverColor,
+          borderRadius: BorderRadius.circular(style.borderRadius),
+          splashColor: style.splashColor,
+          highlightColor: style.highlightColor,
+          hoverColor: style.hoverColor,
           child: Padding(
-            padding: effectiveTheme.buttonPadding,
-            child: _buildButtonContent(),
+            padding: style.padding,
+            child: _buildButtonContent(style),
           ),
         ),
       ),
@@ -649,34 +642,9 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     return _applyWidthConstraints(button);
   }
 
-  BoxDecoration _buildButtonDecoration() {
-    if (!isEnabled) {
-      if (effectiveTheme.disabledButtonDecoration != null) {
-        return effectiveTheme.disabledButtonDecoration!;
-      }
-      if (effectiveTheme.disabledBackgroundColor != null ||
-          effectiveTheme.disabledBorder != null) {
-        return BoxDecoration(
-          color: effectiveTheme.disabledBackgroundColor,
-          border: effectiveTheme.disabledBorder ??
-              effectiveTheme.border ??
-              Border.all(color: Theme.of(context).dividerColor),
-          borderRadius: BorderRadius.circular(effectiveTheme.borderRadius),
-        );
-      }
-    }
-    return effectiveTheme.buttonDecoration ??
-        BoxDecoration(
-          border: effectiveTheme.border ??
-              Border.all(color: Theme.of(context).dividerColor),
-          borderRadius: BorderRadius.circular(effectiveTheme.borderRadius),
-        );
-  }
-
-  Widget _buildButtonContent() {
-    final effectiveContentHeight =
-        effectiveTheme.buttonHeight ?? effectiveTheme.iconSize ?? 24.0;
-    final effectiveIconSize = effectiveTheme.iconSize ?? 24.0;
+  Widget _buildButtonContent(ResolvedButtonStyle style) {
+    final effectiveContentHeight = style.contentHeight;
+    final effectiveIconSize = style.iconSize;
     final rowHeight = effectiveContentHeight > effectiveIconSize
         ? effectiveContentHeight
         : effectiveIconSize;
@@ -713,8 +681,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
           ),
           if (_showTrailing)
             Padding(
-              padding: effectiveTheme.iconPadding ??
-                  const EdgeInsets.only(left: 8.0),
+              padding: style.iconPadding,
               child: SizedBox(
                 height: effectiveIconSize,
                 child: Center(
@@ -722,15 +689,9 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
                     turns: _iconRotation,
                     child: widget.trailing ??
                         Icon(
-                          effectiveTheme.icon ?? Icons.keyboard_arrow_down,
+                          style.icon,
                           size: effectiveIconSize,
-                          // `isEnabled`, not `widget.enabled`: a single-item
-                          // dropdown disabled by policy is disabled here too.
-                          color: isEnabled
-                              ? (effectiveTheme.iconColor ??
-                                  Theme.of(context).iconTheme.color)
-                              : (effectiveTheme.iconDisabledColor ??
-                                  Theme.of(context).disabledColor),
+                          color: style.iconColor,
                         ),
                   ),
                 ),
@@ -817,7 +778,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
         Padding(
           padding: widget.leadingPadding ?? const EdgeInsets.only(right: 8.0),
           child: SizedBox(
-            height: effectiveTheme.iconSize ?? 24.0,
+            height: _buttonStyle.iconSize,
             child: Center(child: leadingWidget),
           ),
         ),
@@ -860,7 +821,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
         Padding(
           padding: widget.leadingPadding ?? const EdgeInsets.only(right: 8.0),
           child: SizedBox(
-            height: effectiveTheme.iconSize ?? 24.0,
+            height: _buttonStyle.iconSize,
             child: Center(child: widget.leading!),
           ),
         ),
@@ -1087,42 +1048,32 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     required Widget child,
     Alignment alignment = Alignment.centerLeft,
   }) {
+    final style = effectiveTheme.resolveItem(
+      _ambient,
+      selected: isSelected,
+      isFirst: isFirst,
+      isLast: isLast,
+    );
+
     return Material(
       color: Colors.transparent,
       child: Container(
-        margin: effectiveTheme.itemMargin,
+        margin: style.margin,
         child: InkWell(
           onTap: () {
             widget.onChanged(item);
             _onItemSelected();
           },
           mouseCursor: SystemMouseCursors.click,
-          splashColor:
-              effectiveTheme.itemSplashColor ?? Theme.of(context).splashColor,
-          highlightColor: effectiveTheme.itemHighlightColor ??
-              Theme.of(context).highlightColor,
-          hoverColor:
-              effectiveTheme.itemHoverColor ?? Theme.of(context).hoverColor,
-          borderRadius: BorderRadius.circular(
-            effectiveTheme.itemBorderRadius ??
-                (isFirst || isLast ? effectiveTheme.borderRadius : 0.0),
-          ),
+          splashColor: style.splashColor,
+          highlightColor: style.highlightColor,
+          hoverColor: style.hoverColor,
+          borderRadius: BorderRadius.circular(style.inkBorderRadius),
           child: Ink(
             height: widget.itemHeight,
             width: double.infinity,
-            padding: effectiveTheme.itemPadding,
-            decoration: BoxDecoration(
-              color: isSelected
-                  ? effectiveTheme.selectedItemColor ??
-                      Theme.of(context).primaryColor.withValues(alpha: 0.1)
-                  : Colors.transparent,
-              borderRadius: effectiveTheme.itemBorderRadius != null
-                  ? BorderRadius.circular(effectiveTheme.itemBorderRadius!)
-                  : null,
-              border: (isLast && effectiveTheme.excludeLastItemBorder)
-                  ? null
-                  : effectiveTheme.itemBorder,
-            ),
+            padding: style.padding,
+            decoration: style.decoration,
             child: Align(
               alignment: alignment,
               child: child,
@@ -1274,14 +1225,13 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
         scrollTheme.gradientColors!.isNotEmpty) {
       gradientColors = scrollTheme.gradientColors!;
     } else {
-      final baseColor =
-          effectiveTheme.backgroundColor ?? Theme.of(context).cardColor;
+      final baseColor = _overlayStyle.backgroundColor;
       gradientColors = [
         baseColor.withValues(alpha: 0.0),
         baseColor,
       ];
     }
-    final borderRadius = BorderRadius.circular(effectiveTheme.borderRadius);
+    final borderRadius = BorderRadius.circular(_overlayStyle.borderRadius);
 
     return ClipRRect(
       borderRadius: borderRadius,

--- a/lib/src/theme/dropdown_theme.dart
+++ b/lib/src/theme/dropdown_theme.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'resolved_dropdown_style.dart';
+
 /// Shared theme configuration for all dropdown widgets.
 ///
 /// This class contains styling and behavior properties that are common
@@ -350,4 +352,121 @@ class DropdownTheme {
 
   /// Default theme that works well with Material Design.
   static const DropdownTheme defaultTheme = DropdownTheme();
+
+  // ===== Resolution =====
+  //
+  // Every fallback the doc comments above promise is honoured here, once.
+  // Callers read the result; they do not decide. None of this needs a
+  // BuildContext — hand it a [DropdownAmbientColors] and it is a pure
+  // function, testable without mounting a widget.
+
+  /// The button as it should be drawn.
+  ///
+  /// [enabled] must be the button's *effective* enabled state: a single-item
+  /// dropdown disabled by policy is disabled here too.
+  ResolvedButtonStyle resolveButton(
+    DropdownAmbientColors ambient, {
+    required bool enabled,
+  }) {
+    final resolvedIconSize = iconSize ?? 24.0;
+
+    return ResolvedButtonStyle(
+      decoration: _buttonDecoration(ambient, enabled: enabled),
+      padding: buttonPadding,
+      borderRadius: borderRadius,
+      splashColor: buttonSplashColor ?? ambient.splash,
+      highlightColor: buttonHighlightColor ?? ambient.highlight,
+      hoverColor: buttonHoverColor ?? ambient.hover,
+      contentHeight: buttonHeight ?? resolvedIconSize,
+      iconSize: resolvedIconSize,
+      icon: icon ?? Icons.keyboard_arrow_down,
+      iconPadding: iconPadding ?? const EdgeInsets.only(left: 8.0),
+      iconColor: enabled
+          ? (iconColor ?? ambient.icon)
+          : (iconDisabledColor ?? ambient.disabled),
+    );
+  }
+
+  BoxDecoration _buttonDecoration(
+    DropdownAmbientColors ambient, {
+    required bool enabled,
+  }) {
+    if (!enabled) {
+      // A full decoration overrides everything else.
+      if (disabledButtonDecoration != null) return disabledButtonDecoration!;
+
+      // Otherwise a disabled colour or border is enough to build one.
+      if (disabledBackgroundColor != null || disabledBorder != null) {
+        return BoxDecoration(
+          color: disabledBackgroundColor,
+          border:
+              disabledBorder ?? border ?? Border.all(color: ambient.divider),
+          borderRadius: BorderRadius.circular(borderRadius),
+        );
+      }
+      // With no disabled styling at all, fall through to the enabled look.
+    }
+
+    return buttonDecoration ??
+        BoxDecoration(
+          border: border ?? Border.all(color: ambient.divider),
+          borderRadius: BorderRadius.circular(borderRadius),
+        );
+  }
+
+  /// The menu container as it should be drawn.
+  ResolvedOverlayStyle resolveOverlay(DropdownAmbientColors ambient) {
+    final background = backgroundColor ?? ambient.card;
+    final decoration = overlayDecoration ??
+        BoxDecoration(
+          color: background,
+          borderRadius: BorderRadius.circular(borderRadius),
+          border: border ?? Border.all(color: ambient.divider, width: 1),
+        );
+
+    final decorationBorder = decoration.border;
+
+    return ResolvedOverlayStyle(
+      decoration: decoration,
+      backgroundColor: background,
+      borderRadius: borderRadius,
+      elevation: elevation,
+      shadowColor: shadowColor,
+      padding: overlayPadding,
+      borderThickness: decorationBorder is Border
+          ? decorationBorder.top.width + decorationBorder.bottom.width
+          : 0.0,
+    );
+  }
+
+  /// One item row as it should be drawn.
+  ///
+  /// [isFirst] and [isLast] matter because, absent an explicit
+  /// [itemBorderRadius], only the end rows are rounded — they sit against the
+  /// menu's own corners.
+  ResolvedItemStyle resolveItem(
+    DropdownAmbientColors ambient, {
+    required bool selected,
+    required bool isFirst,
+    required bool isLast,
+  }) {
+    return ResolvedItemStyle(
+      decoration: BoxDecoration(
+        color: selected
+            ? selectedItemColor ?? ambient.primary.withValues(alpha: 0.1)
+            : Colors.transparent,
+        borderRadius: itemBorderRadius != null
+            ? BorderRadius.circular(itemBorderRadius!)
+            : null,
+        border: (isLast && excludeLastItemBorder) ? null : itemBorder,
+      ),
+      padding: itemPadding,
+      margin: itemMargin,
+      inkBorderRadius:
+          itemBorderRadius ?? (isFirst || isLast ? borderRadius : 0.0),
+      splashColor: itemSplashColor ?? ambient.splash,
+      highlightColor: itemHighlightColor ?? ambient.highlight,
+      hoverColor: itemHoverColor ?? ambient.hover,
+    );
+  }
 }

--- a/lib/src/theme/resolved_dropdown_style.dart
+++ b/lib/src/theme/resolved_dropdown_style.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+/// The ambient values a dropdown falls back to when its theme leaves a slot
+/// empty, lifted out of [ThemeData] as plain colours.
+///
+/// Resolution takes one of these rather than a [BuildContext]. Pulling values
+/// *out of* a context depends on the element tree; *deciding* with them does
+/// not, and only the second half is worth testing.
+class DropdownAmbientColors {
+  /// Creates the ambient palette.
+  const DropdownAmbientColors({
+    required this.card,
+    required this.divider,
+    required this.splash,
+    required this.highlight,
+    required this.hover,
+    required this.primary,
+    required this.disabled,
+    this.icon,
+  });
+
+  /// Reads the palette from the enclosing [Theme].
+  factory DropdownAmbientColors.of(BuildContext context) {
+    final theme = Theme.of(context);
+    return DropdownAmbientColors(
+      card: theme.cardColor,
+      divider: theme.dividerColor,
+      splash: theme.splashColor,
+      highlight: theme.highlightColor,
+      hover: theme.hoverColor,
+      primary: theme.primaryColor,
+      disabled: theme.disabledColor,
+      icon: theme.iconTheme.color,
+    );
+  }
+
+  /// Background of surfaces that sit above the page — the menu.
+  final Color card;
+
+  /// Hairline borders.
+  final Color divider;
+
+  /// Ink ripple.
+  final Color splash;
+
+  /// Focus highlight.
+  final Color highlight;
+
+  /// Pointer hover wash.
+  final Color hover;
+
+  /// Accent, used to tint the selected item.
+  final Color primary;
+
+  /// Foreground of anything switched off.
+  final Color disabled;
+
+  /// Default icon colour. Null when the ambient theme leaves it unset.
+  final Color? icon;
+}
+
+/// The button's appearance, with every slot filled in.
+class ResolvedButtonStyle {
+  /// Creates a resolved button style.
+  const ResolvedButtonStyle({
+    required this.decoration,
+    required this.padding,
+    required this.borderRadius,
+    required this.splashColor,
+    required this.highlightColor,
+    required this.hoverColor,
+    required this.contentHeight,
+    required this.iconSize,
+    required this.icon,
+    required this.iconPadding,
+    this.iconColor,
+  });
+
+  /// The button's box, already switched for enabled or disabled.
+  final BoxDecoration decoration;
+
+  /// Space between the button's edge and its content.
+  final EdgeInsets padding;
+
+  /// Corner radius, shared with the ink ripple.
+  final double borderRadius;
+
+  /// Ink ripple colour.
+  final Color splashColor;
+
+  /// Focus highlight colour.
+  final Color highlightColor;
+
+  /// Pointer hover colour.
+  final Color hoverColor;
+
+  /// Height of the row holding the selected value and the arrow.
+  final double contentHeight;
+
+  /// Size of the trailing arrow.
+  final double iconSize;
+
+  /// The trailing arrow.
+  final IconData icon;
+
+  /// Space between the value and the arrow.
+  final EdgeInsets iconPadding;
+
+  /// Arrow colour, already switched for enabled or disabled.
+  final Color? iconColor;
+}
+
+/// The menu container's appearance, with every slot filled in.
+class ResolvedOverlayStyle {
+  /// Creates a resolved overlay style.
+  const ResolvedOverlayStyle({
+    required this.decoration,
+    required this.backgroundColor,
+    required this.borderRadius,
+    required this.elevation,
+    required this.borderThickness,
+    this.shadowColor,
+    this.padding,
+  });
+
+  /// The menu's box.
+  final BoxDecoration decoration;
+
+  /// The menu's fill, exposed for the scroll gradient to fade into.
+  final Color backgroundColor;
+
+  /// Corner radius.
+  final double borderRadius;
+
+  /// Shadow depth.
+  final double elevation;
+
+  /// Top plus bottom border width, which the placement module reserves.
+  final double borderThickness;
+
+  /// Shadow colour.
+  final Color? shadowColor;
+
+  /// Space between the menu's edge and its item list.
+  final EdgeInsets? padding;
+}
+
+/// One item row's appearance, with every slot filled in.
+class ResolvedItemStyle {
+  /// Creates a resolved item style.
+  const ResolvedItemStyle({
+    required this.decoration,
+    required this.padding,
+    required this.inkBorderRadius,
+    required this.splashColor,
+    required this.highlightColor,
+    required this.hoverColor,
+    this.margin,
+  });
+
+  /// The row's box, already switched for selection and for its position.
+  final BoxDecoration decoration;
+
+  /// Space between the row's edge and its content.
+  final EdgeInsets padding;
+
+  /// Corner radius of the ink ripple, which is not always the box's.
+  final double inkBorderRadius;
+
+  /// Ink ripple colour.
+  final Color splashColor;
+
+  /// Focus highlight colour.
+  final Color highlightColor;
+
+  /// Pointer hover colour.
+  final Color hoverColor;
+
+  /// Space around the row.
+  final EdgeInsets? margin;
+}

--- a/test/theme/dropdown_theme_resolve_test.dart
+++ b/test/theme/dropdown_theme_resolve_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Resolution takes plain values, so these run with no widget tree, no
+/// `pumpWidget`, and no `BuildContext`.
+
+const ambient = DropdownAmbientColors(
+  card: Color(0xFFFFFFFF),
+  divider: Color(0xFFBDBDBD),
+  splash: Color(0xFFE0E0E0),
+  highlight: Color(0xFFEEEEEE),
+  hover: Color(0xFFF5F5F5),
+  primary: Color(0xFF2196F3),
+  disabled: Color(0xFF9E9E9E),
+  icon: Color(0xFF212121),
+);
+
+const red = Color(0xFFE53935);
+const green = Color(0xFF43A047);
+
+void main() {
+  group('button', () {
+    test('falls back to the ambient palette', () {
+      final style = const DropdownTheme().resolveButton(ambient, enabled: true);
+
+      expect(style.splashColor, ambient.splash);
+      expect(style.hoverColor, ambient.hover);
+      expect(style.iconColor, ambient.icon);
+      expect(style.icon, Icons.keyboard_arrow_down);
+      expect(style.iconSize, 24.0);
+    });
+
+    test('contentHeight prefers buttonHeight, then iconSize, then 24', () {
+      expect(
+        const DropdownTheme(buttonHeight: 40, iconSize: 30)
+            .resolveButton(ambient, enabled: true)
+            .contentHeight,
+        40,
+      );
+      expect(
+        const DropdownTheme(iconSize: 30)
+            .resolveButton(ambient, enabled: true)
+            .contentHeight,
+        30,
+      );
+      expect(
+        const DropdownTheme()
+            .resolveButton(ambient, enabled: true)
+            .contentHeight,
+        24,
+      );
+    });
+
+    test('the icon switches colour with the enabled state', () {
+      const theme = DropdownTheme(iconColor: red, iconDisabledColor: green);
+
+      expect(theme.resolveButton(ambient, enabled: true).iconColor, red);
+      expect(theme.resolveButton(ambient, enabled: false).iconColor, green);
+    });
+
+    test('disabledButtonDecoration wins outright', () {
+      final theme = DropdownTheme(
+        disabledButtonDecoration: const BoxDecoration(color: red),
+        disabledBackgroundColor: green,
+        border: Border.all(color: green),
+      );
+
+      final decoration =
+          theme.resolveButton(ambient, enabled: false).decoration;
+      expect(decoration.color, red);
+      expect(decoration.border, isNull);
+    });
+
+    test('disabledBorder falls back to border, then to the ambient divider',
+        () {
+      final withBorder = DropdownTheme(
+        disabledBackgroundColor: green,
+        border: Border.all(color: red),
+      ).resolveButton(ambient, enabled: false).decoration.border! as Border;
+      expect(withBorder.top.color, red);
+
+      final bare = const DropdownTheme(disabledBackgroundColor: green)
+          .resolveButton(ambient, enabled: false)
+          .decoration
+          .border! as Border;
+      expect(bare.top.color, ambient.divider);
+    });
+
+    test('with no disabled styling, the enabled decoration stands', () {
+      final theme = DropdownTheme(border: Border.all(color: red));
+
+      final disabled = theme.resolveButton(ambient, enabled: false).decoration;
+      final enabled = theme.resolveButton(ambient, enabled: true).decoration;
+
+      expect(disabled.color, isNull);
+      expect(disabled.border, enabled.border);
+    });
+  });
+
+  group('overlay', () {
+    test('reports the border thickness the placement module reserves', () {
+      final theme = DropdownTheme(
+        border: Border.all(color: red, width: 3),
+      );
+
+      expect(theme.resolveOverlay(ambient).borderThickness, 6);
+    });
+
+    test('a borderless custom decoration reserves nothing', () {
+      const theme = DropdownTheme(overlayDecoration: BoxDecoration(color: red));
+
+      expect(theme.resolveOverlay(ambient).borderThickness, 0);
+    });
+
+    test('backgroundColor falls back to the ambient card colour', () {
+      expect(const DropdownTheme().resolveOverlay(ambient).backgroundColor,
+          ambient.card);
+      expect(
+        const DropdownTheme(backgroundColor: red)
+            .resolveOverlay(ambient)
+            .backgroundColor,
+        red,
+      );
+    });
+  });
+
+  group('item', () {
+    ResolvedItemStyle resolve(
+      DropdownTheme theme, {
+      bool selected = false,
+      bool isFirst = false,
+      bool isLast = false,
+    }) =>
+        theme.resolveItem(ambient,
+            selected: selected, isFirst: isFirst, isLast: isLast);
+
+    test('only the selected item is tinted', () {
+      const theme = DropdownTheme(selectedItemColor: red);
+
+      expect(resolve(theme, selected: true).decoration.color, red);
+      expect(resolve(theme).decoration.color, Colors.transparent);
+    });
+
+    test('an untinted selection falls back to the ambient primary at 10%', () {
+      final colour =
+          resolve(const DropdownTheme(), selected: true).decoration.color!;
+
+      expect(colour.a, closeTo(0.1, 0.001));
+    });
+
+    test('without itemBorderRadius, only the end rows are rounded', () {
+      const theme = DropdownTheme(borderRadius: 10);
+
+      expect(resolve(theme, isFirst: true).inkBorderRadius, 10);
+      expect(resolve(theme, isLast: true).inkBorderRadius, 10);
+      expect(resolve(theme).inkBorderRadius, 0);
+    });
+
+    test('itemBorderRadius rounds every row', () {
+      const theme = DropdownTheme(borderRadius: 10, itemBorderRadius: 4);
+
+      expect(resolve(theme).inkBorderRadius, 4);
+      expect(resolve(theme, isFirst: true).inkBorderRadius, 4);
+    });
+
+    test('the last row drops itemBorder unless told otherwise', () {
+      final excluding = DropdownTheme(
+        itemBorder: const Border(bottom: BorderSide(color: red)),
+      );
+      final keeping = DropdownTheme(
+        itemBorder: const Border(bottom: BorderSide(color: red)),
+        excludeLastItemBorder: false,
+      );
+
+      expect(resolve(excluding, isLast: true).decoration.border, isNull);
+      expect(resolve(excluding).decoration.border, isNotNull);
+      expect(resolve(keeping, isLast: true).decoration.border, isNotNull);
+    });
+  });
+}

--- a/test/theme_resolution_test.dart
+++ b/test/theme_resolution_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Characterisation tests for the fifteen fallback chains inlined across the
+/// widget's build methods. They pin the rules down at the rendered widget, not
+/// at the code that computes them, so they survive the move into `resolve()`.
+
+const red = Color(0xFFE53935);
+const green = Color(0xFF43A047);
+const blue = Color(0xFF1E88E5);
+
+Widget host(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+Widget dropdown({
+  DropdownStyleTheme? theme,
+  bool enabled = true,
+  List<String> items = const ['Apple', 'Banana', 'Cherry'],
+  String? value,
+}) {
+  return FlutterDropdownButton<String>.text(
+    width: 200,
+    items: items,
+    value: value,
+    hint: 'Pick a fruit',
+    enabled: enabled,
+    theme: theme,
+    onChanged: (_) {},
+  );
+}
+
+/// The button's own Container — the outermost one the widget builds.
+BoxDecoration buttonDecoration(WidgetTester tester) {
+  final container = tester.widget<Container>(
+    find
+        .descendant(
+          of: find.byType(FlutterDropdownButton<String>),
+          matching: find.byType(Container),
+        )
+        .first,
+  );
+  return container.decoration! as BoxDecoration;
+}
+
+/// The item rows inside the open menu, in order.
+List<BoxDecoration> itemDecorations(WidgetTester tester) {
+  return tester
+      .widgetList<Ink>(find.byType(Ink))
+      .map((ink) => ink.decoration! as BoxDecoration)
+      .toList();
+}
+
+Future<void> openMenu(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterDropdownButton<String>));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('button decoration when disabled', () {
+    testWidgets('disabledButtonDecoration wins outright', (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            enabled: false,
+            theme: DropdownStyleTheme(
+              dropdown: DropdownTheme(
+                disabledButtonDecoration: const BoxDecoration(color: red),
+                disabledBackgroundColor: green,
+                border: Border.all(color: blue),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final decoration = buttonDecoration(tester);
+      expect(decoration.color, red);
+      expect(decoration.border, isNull, reason: 'the override replaces all');
+    });
+
+    testWidgets('disabledBackgroundColor and disabledBorder build one together',
+        (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            enabled: false,
+            theme: DropdownStyleTheme(
+              dropdown: DropdownTheme(
+                disabledBackgroundColor: green,
+                disabledBorder: Border.all(color: red),
+                borderRadius: 12,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final decoration = buttonDecoration(tester);
+      expect(decoration.color, green);
+      expect((decoration.border! as Border).top.color, red);
+      expect(decoration.borderRadius, BorderRadius.circular(12));
+    });
+
+    testWidgets('disabledBorder falls back to border', (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            enabled: false,
+            theme: DropdownStyleTheme(
+              dropdown: DropdownTheme(
+                disabledBackgroundColor: green,
+                border: Border.all(color: blue),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect((buttonDecoration(tester).border! as Border).top.color, blue);
+    });
+
+    testWidgets(
+        'with no disabled styling at all, the enabled decoration stands',
+        (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            enabled: false,
+            theme: DropdownStyleTheme(
+              dropdown: DropdownTheme(border: Border.all(color: blue)),
+            ),
+          ),
+        ),
+      );
+
+      final decoration = buttonDecoration(tester);
+      expect(decoration.color, isNull);
+      expect((decoration.border! as Border).top.color, blue);
+    });
+  });
+
+  group('item decoration', () {
+    testWidgets('the selected item takes selectedItemColor', (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            value: 'Banana',
+            theme: const DropdownStyleTheme(
+              dropdown: DropdownTheme(selectedItemColor: red),
+            ),
+          ),
+        ),
+      );
+      await openMenu(tester);
+
+      final decorations = itemDecorations(tester);
+      expect(decorations[0].color, Colors.transparent);
+      expect(decorations[1].color, red, reason: 'Banana is selected');
+      expect(decorations[2].color, Colors.transparent);
+    });
+
+    testWidgets('the last item skips itemBorder by default', (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            theme: DropdownStyleTheme(
+              dropdown: DropdownTheme(
+                itemBorder: Border(bottom: BorderSide(color: blue)),
+              ),
+            ),
+          ),
+        ),
+      );
+      await openMenu(tester);
+
+      final decorations = itemDecorations(tester);
+      expect(decorations[0].border, isNotNull);
+      expect(decorations[1].border, isNotNull);
+      expect(decorations[2].border, isNull, reason: 'excludeLastItemBorder');
+    });
+
+    testWidgets('excludeLastItemBorder false keeps the last border',
+        (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            theme: DropdownStyleTheme(
+              dropdown: DropdownTheme(
+                itemBorder: Border(bottom: BorderSide(color: blue)),
+                excludeLastItemBorder: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      await openMenu(tester);
+
+      expect(itemDecorations(tester)[2].border, isNotNull);
+    });
+
+    testWidgets('itemBorderRadius applies to every item', (tester) async {
+      await tester.pumpWidget(
+        host(
+          dropdown(
+            theme: const DropdownStyleTheme(
+              dropdown: DropdownTheme(itemBorderRadius: 6),
+            ),
+          ),
+        ),
+      );
+      await openMenu(tester);
+
+      for (final decoration in itemDecorations(tester)) {
+        expect(decoration.borderRadius, BorderRadius.circular(6));
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #5. Follows the icon fix in #24, which was the red this refactor deserved.

## What changed

`DropdownTheme` gained `resolveButton()`, `resolveOverlay()` and `resolveItem()`. Each returns a style whose slots are all filled in. The widget reads the result; it no longer decides.

Measured on `lib/src/flutter_dropdown_button.dart`:

| | Before | After |
| --- | --- | --- |
| `Theme.of(context)` calls | 18 | 4 |
| `effectiveTheme.<field> ??` chains | 13 | **0** |

The four surviving `Theme.of` calls belong to the search field and the empty-search hint — `SearchFieldTheme`'s chains, not `DropdownTheme`'s. Left for a follow-up; noted below.

## `resolve()` takes no `BuildContext`

This was the correction made to the issue before starting, and it is the whole point.

Pulling values *out of* a `ThemeData` depends on the element tree. *Deciding* with them does not. Splitting the two makes the second half pure:

```dart
final style = theme.resolveButton(ambient, enabled: isEnabled);
```

`DropdownAmbientColors` is a plain palette — `card`, `divider`, `splash`, `highlight`, `hover`, `primary`, `disabled`, `icon` — with a `.of(context)` factory the widget calls once. Resolution never sees a context.

Had `resolve()` taken a context, it would have reproduced exactly the defect #3 removed from `DropdownMixin`: logic welded to the element tree, unrunnable and therefore untested. Same surgery, same seam.

## Dropped from the issue's scope

The issue also asked for `==` and `hashCode` on the theme classes. That was unjustified and is not here — nothing in the package compares themes. Reasoning is recorded in the issue body.

## Verification

75 tests, up from 53.

**Eight characterisation tests** written first, at the rendered widget rather than at the code that computes it — button decoration precedence (all four branches of the disabled chain), selected-item tint, `excludeLastItemBorder`, `itemBorderRadius`. They passed before the refactor and after; that is what made moving the implementation checkable rather than hopeful. Because they assert on the `BoxDecoration` the widget actually draws, they were indifferent to where it came from.

**Fourteen unit tests** on `resolve()` itself, with **no widget tree, no `pumpWidget`, no `BuildContext`** — a `const DropdownAmbientColors` and a method call. That was the acceptance criterion, and it is now the cheapest place in this package to pin a styling rule.

`flutter test` 75 passing · `flutter analyze` clean, package and example · `dart format` no changes.

## Follow-up

`SearchFieldTheme` and `DropdownScrollTheme` still inline their own fallbacks (search field height, margin, radius, content padding; scrollbar thumb and track widths). They are the same shape of problem and should get the same treatment, but they are a smaller pile and a separate change. I'll file it.

Public API is additive: `DropdownAmbientColors`, `ResolvedButtonStyle`, `ResolvedOverlayStyle`, `ResolvedItemStyle` are exported; nothing is removed or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)