### PR TITLE
Bring CLAUDE.md and the reference docs in line with the current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,120 +4,134 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Package Overview
 
-This is a Flutter package (`flutter_dropdown_button`) that provides highly customizable dropdown widgets with overlay-based rendering. The package consists of two main dropdown variants and a shared architecture for common functionality.
+`flutter_dropdown_button` is a Flutter package providing a single, highly customizable dropdown widget rendered through an `OverlayEntry` rather than Flutter's built-in menu machinery.
+
+There is **one** widget — `FlutterDropdownButton<T>` — with two constructors:
+
+- `FlutterDropdownButton<T>(...)` — custom mode. `itemBuilder` renders each item as an arbitrary widget.
+- `FlutterDropdownButton<T>.text(...)` — text mode. Items render as text through `SmartTooltipText`, gaining overflow handling, an automatic tooltip, and a default search filter. A `label` callback extracts the string, so `T` need not be `String`.
+
+The two are distinguished internally by `isTextMode`, which is `itemBuilder == null`.
 
 ## Core Architecture
 
-### Main Components
+The widget is a thin shell over three modules, each of which takes plain values and can be tested without mounting a widget.
 
-- **BasicDropdownButton**: Generic dropdown supporting any widget as items
-- **TextOnlyDropdownButton**: Specialized dropdown for text content with precise text rendering control
-- **DropdownMixin**: Shared functionality mixin that eliminates code duplication between dropdown variants
-- **DropdownTheme**: Shared theme system for consistent styling across variants
-- **TextDropdownConfig**: Text-specific configuration for overflow, styling, and alignment
-- **DropdownItem**: Generic model for BasicDropdownButton items
+### `DropdownPlacement` — `lib/src/placement/`
 
-### Shared Architecture Pattern
+Pure geometry. Given a screen size, safe insets, a button rectangle and item metrics, it returns where the menu goes: height, open direction, transform alignment, top, left, width.
 
-Both dropdown variants use the `DropdownMixin` which provides:
-- Smart positioning logic (automatically opens upward when insufficient space below)
-- Animation management (scale and opacity animations)
-- Overlay lifecycle management
-- Outside-tap dismissal functionality
-- Dynamic height adjustment to prevent screen overflow
+No `BuildContext`, no `MediaQuery`, no `State`. It does not know which coordinate space its inputs came from — that is the caller's business, and getting it wrong was the cause of a real bug (menus drawn off-screen inside a nested `Overlay`).
 
-The mixin eliminates ~150 lines of duplicate code between the two dropdown variants.
+Its `chromeHeight` input covers everything in the overlay that is *not* an item: the search field, the border, the overlay's own padding. Omitting it is a compile error rather than a layout bug.
+
+### `DropdownOverlayController` — `lib/src/overlay/`
+
+Owns the overlay's lifetime, the open/close animation, the widget tree the menu is drawn into, and the rule that only one menu is open at a time within an `Overlay`.
+
+**A `State` holds one; it does not inherit from it.** The controller is exported, so a third party building their own dropdown holds the same object `FlutterDropdownButton` does.
+
+It takes a `DropdownOverlaySpec` **callback**, not a value — the item count, the theme and the search field's height change while the menu is open, and `measurePlacement()` re-reads them on every overlay build. That is why an open menu re-sizes when its items change, and flips above the button when the taller menu no longer fits below.
+
+Single-open coordination lives in a registry keyed by `Overlay`, not in a process-wide static.
+
+### Theme resolution — `lib/src/theme/`
+
+`DropdownStyleTheme` composes four themes: `DropdownTheme`, `DropdownScrollTheme`, `DropdownTooltipTheme`, `SearchFieldTheme`.
+
+`DropdownTheme` **resolves itself**. `resolveButton()`, `resolveOverlay()` and `resolveItem()` return styles whose slots are all filled in; the widget reads the result rather than deciding. Resolution takes a `DropdownAmbientColors` — a plain palette lifted out of `ThemeData` — rather than a `BuildContext`, so it is a pure function.
+
+`SearchFieldTheme` and `DropdownScrollTheme` have **not** been converted yet; they still inline their fallbacks in `build()`. See issue #26.
+
+### The recurring pattern
+
+Every module here separates **reading from the element tree** from **deciding with what was read**. Pulling `MediaQuery.size` out of a context needs a context; computing a menu's height from it does not. Pulling `Theme.of(context).dividerColor` needs a context; choosing between it and a themed override does not.
+
+The second half is where the bugs are, and it is the half worth testing. When adding a module, keep the split.
+
+## Deprecated
+
+`DropdownMixin` (`lib/src/buttons/dropdown_mixin.dart`) is deprecated as of 2.4.0 and slated for removal in 3.0.0 (issue #7). It survives only as a delegating shim over `DropdownOverlayController`, and shares the controller's registry so that mixin-based and controller-based menus obey the same single-open rule.
+
+Nothing in this package uses it. Do not build on it.
 
 ## Development Commands
 
-### Package Development
 ```bash
-# Install dependencies
-flutter pub get
+flutter pub get              # install dependencies
+flutter test                 # run the suite (75 tests)
+flutter analyze              # static analysis; must be clean
+dart format .                # formatting; must produce no changes
+flutter pub publish --dry-run   # validate the package before release
 
-# Run static analysis
-flutter analyze
-
-# Run linter
-flutter pub run flutter_lints
-
-# Format code
-dart format .
-
-# Run tests (minimal test suite currently exists)
-flutter test
-
-# Run tests for specific file
-flutter test test/flutter_dropdown_button_test.dart
+cd example && flutter run    # run the playground app
 ```
 
-### Example App Development
-```bash
-# Run example app
-cd example && flutter run
+## Testing
 
-# Build example app
-cd example && flutter build web
-```
+75 tests. Around half run without mounting a widget at all.
 
-### Documentation
-The package includes comprehensive documentation in the `documentation/` directory:
-- `api_reference.md`: Complete API documentation
-- `theming.md`: Theming and styling guide
-- `text_configuration.md`: Text-specific configuration guide
-- `migration.md`: Migration guide from Flutter's built-in DropdownButton
+| Suite | What it covers |
+| --- | --- |
+| `test/placement/` | The geometry module, exhaustively. No widgets. |
+| `test/theme/` | `DropdownTheme.resolve*()`. No widgets. |
+| `test/overlay/` | The controller's lifecycle. No widgets. |
+| `test/overlay_bounds_test.dart` | Menus near screen edges, and inside a nested `Overlay` |
+| `test/overlay_resize_test.dart` | An open menu growing, shrinking, and flipping |
+| `test/overlay_lifecycle_test.dart` | Single-open, `closeAll`, dispose |
+| `test/search_invalidation_test.dart` | The query surviving rebuilds |
+| `test/text_label_test.dart` | `label` with a non-`String` `T` |
+| `test/theme_resolution_test.dart` | Resolution rules, observed at the rendered widget |
+| `test/disabled_state_test.dart` | The disabled state, including single-item auto-disable |
 
-## Key Implementation Details
+**Conventions that matter here:**
 
-### Overlay-Based Rendering
-Unlike Flutter's built-in DropdownButton, these widgets use `OverlayEntry` for better positioning control and visual effects. The overlay system allows for smart positioning that adapts to available screen space.
-
-### Positioning Algorithm
-The `DropdownMixin.calculateDropdownPosition()` method implements smart positioning:
-1. Calculates available space above and below the button
-2. Prefers to open downward if sufficient space exists
-3. Falls back to opening upward if more space is available above
-4. Dynamically adjusts height when space is constrained
-5. Ensures minimum visibility of items
-
-### Breaking Changes
-Version 1.0.0 includes breaking changes from initial development:
-- `CustomDropdown` → `BasicDropdownButton`  
-- `TextOnlyDropdown` → `TextOnlyDropdownButton`
-
-When making changes to class names or public APIs, ensure all documentation files are updated accordingly.
+- **Test at the public seam.** Widget tests assert on what is rendered — the `BoxDecoration` on the button, the presence of a `ListView` — never on private state. That is why the test suite survived the controller extraction and the theme resolution rewrite without a single edit.
+- **Prove a test can fail.** A test written *after* a fix has never been red. Before trusting it, revert the fix (`git stash` the lib change) and confirm the test catches the bug. Two tests in this repo were found to be vacuous this way.
+- **Say when a test cannot fail.** Some tests guard behaviour that was never broken, or exercise a capability that did not previously compile. Label them; do not let them masquerade as regression tests.
 
 ## Package Structure
+
 ```
 lib/
-├── flutter_dropdown_button.dart          # Main export file
+├── flutter_dropdown_button.dart          # public exports
 └── src/
-    ├── basic_dropdown_button.dart        # Generic dropdown widget
-    ├── text_only_dropdown_button.dart    # Text-specific dropdown widget
-    ├── dropdown_mixin.dart               # Shared functionality mixin
-    ├── dropdown_theme.dart               # Shared theme system
-    ├── text_dropdown_config.dart         # Text-specific configuration
-    └── dropdown_item.dart                # Item model for BasicDropdownButton
+    ├── flutter_dropdown_button.dart      # the widget
+    ├── placement/dropdown_placement.dart # pure geometry
+    ├── overlay/
+    │   └── dropdown_overlay_controller.dart  # overlay lifetime, animation, spec
+    ├── theme/
+    │   ├── dropdown_style_theme.dart     # composes the four below
+    │   ├── dropdown_theme.dart           # + resolveButton/Overlay/Item
+    │   ├── resolved_dropdown_style.dart  # ambient palette + resolved styles
+    │   ├── dropdown_scroll_theme.dart
+    │   ├── search_field_theme.dart
+    │   └── tooltip_theme.dart
+    ├── config/text_dropdown_config.dart  # text overflow, alignment, styles
+    ├── buttons/
+    │   ├── dropdown_mixin.dart           # DEPRECATED shim; removed in 3.0.0
+    │   └── menu_alignment.dart
+    └── widgets/smart_tooltip_text.dart   # tooltip on overflow
 ```
+
+## Documentation
+
+- `README.md` — features, quick start, full parameter tables
+- `documentation/api_reference.md`
+- `documentation/theming.md`
+- `documentation/text_configuration.md`
+- `documentation/migration.md`
+- `documentation/use_cases.md`
+
+`docs/agents/` holds configuration for coding agents (issue tracker, triage labels, domain docs). It is excluded from the published package by `docs/.pubignore`.
+
+When changing a public class name or signature, update `README.md` and `documentation/` in the same change. These files have drifted before, and stale docs sent readers to APIs that had been deleted three major versions earlier.
 
 ## Version Management
 
-- Current version: 1.0.0
-- Uses semantic versioning
-- Breaking changes require major version bump
-- Update version in both `pubspec.yaml` and documentation when releasing
-- CHANGELOG.md follows the format: `* **TYPE**: Description` (e.g., `* **FEAT**: New feature`)
-
-## Agent skills
-
-### Issue tracker
-
-Issues live in GitHub Issues on `kihyun1998/flutter_dropdown_button`, via the `gh` CLI. External pull requests are **not** a triage surface. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-The five canonical triage roles use their default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context: `CONTEXT.md` and `docs/adr/` at the repo root, created lazily. See `docs/agents/domain.md`.
+- Semantic versioning. The version lives in `pubspec.yaml`; do not restate it in prose.
+- Breaking changes require a major bump. Adding a member, or deprecating one, does not.
+- `CHANGELOG.md` entries take the form `* **TYPE**: Description`, where TYPE is one of `FEAT`, `FIX`, `BREAKING`, `DEPRECATED`, `REFACTOR`, `PERF`, `CHANGE`, `TEST`, `MIGRATION`.
+- Record deprecations and behaviour changes even when they are small. A silent deprecation surprises people; a four-pixel layout change that nobody wrote down is a bug report waiting to happen.
+- Cut a release in its own commit (`chore: release X.Y.Z`) that bumps `pubspec.yaml`, adds the `CHANGELOG.md` section, and updates the version in `README.md`'s quick start.
+- Run `flutter pub publish --dry-run` before releasing; it must report zero warnings.

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -2,156 +2,48 @@
 
 Complete reference for all classes and widgets in the flutter_dropdown_button package.
 
-## BaseDropdownButton<T>
+> Classes removed in 2.0.0 — `BaseDropdownButton`, `BasicDropdownButton`, `TextOnlyDropdownButton`, `DynamicTextBaseDropdownButton`, `DropdownItem` — were documented here long after they ceased to exist. See `documentation/migration.md`.
 
-Abstract base class for all dropdown button variants. Provides common properties and structure while allowing each variant to customize their specific rendering and behavior.
+## FlutterDropdownButton<T>
 
-### Constructor
+The one dropdown widget. Two constructors.
 
 ```dart
-BaseDropdownButton<T>({
-  Key? key,
+// Custom mode — render each item as any widget
+FlutterDropdownButton<T>({
+  required List<T> items,
   required ValueChanged<T?> onChanged,
-  T? value,
-  double height = 200.0,
-  double itemHeight = 48.0,
-  Duration animationDuration = const Duration(milliseconds: 200),
-  double? width,
-  double? maxWidth,
-  double? minWidth,
-  DropdownTheme? theme,
-  bool enabled = true,
+  required Widget Function(T item, bool isSelected) itemBuilder,
+  Widget Function(T item)? selectedBuilder,
+  Widget? hintWidget,
+  ...
 })
-```
 
-### Properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `onChanged` | `ValueChanged<T?>` | required | Callback when selection changes |
-| `value` | `T?` | null | Currently selected value |
-| `height` | `double` | 200.0 | Maximum height of dropdown overlay |
-| `itemHeight` | `double` | 48.0 | Height of each dropdown item |
-| `animationDuration` | `Duration` | 200ms | Animation duration for show/hide |
-| `width` | `double?` | null | Fixed width for dropdown |
-| `maxWidth` | `double?` | null | Maximum width constraint |
-| `minWidth` | `double?` | null | Minimum width constraint |
-| `theme` | `DropdownTheme?` | null | Custom theme configuration |
-| `enabled` | `bool` | true | Whether dropdown is interactive |
-
-### Creating Custom Dropdowns
-
-To create a custom dropdown widget, extend `BaseDropdownButton` and implement the required abstract methods:
-
-```dart
-class MyCustomDropdown extends BaseDropdownButton<MyItemType> {
-  // Your custom properties
-}
-
-class _MyCustomDropdownState extends BaseDropdownButtonState<MyCustomDropdown, MyItemType> {
-  @override
-  Widget buildSelectedWidget() {
-    // Return widget for selected value display
-  }
-  
-  @override
-  Widget buildItemWidget(MyItemType item, bool isSelected) {
-    // Return widget for individual dropdown items
-  }
-  
-  @override
-  List<MyItemType> getItems() {
-    // Return list of available items
-  }
-}
-```
-
-## BasicDropdownButton<T>
-
-A highly customizable dropdown widget using OverlayEntry for better control.
-
-### Constructor
-
-```dart
-BasicDropdownButton<T>({
-  Key? key,
-  required List<DropdownItem<T>> items,
+// Text mode — items render as text, with tooltips and search for free
+FlutterDropdownButton<T>.text({
+  required List<T> items,
   required ValueChanged<T?> onChanged,
-  T? value,
-  Widget? hint,
-  double height = 200.0,
-  double itemHeight = 48.0,
-  double borderRadius = 8.0,
-  Duration animationDuration = const Duration(milliseconds: 200),
-  BoxDecoration? decoration,
-  double? width,
-  double? maxWidth,
-  double? minWidth,
-})
-```
-
-### Properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `items` | `List<DropdownItem<T>>` | required | List of dropdown items |
-| `onChanged` | `ValueChanged<T?>` | required | Callback when selection changes |
-| `value` | `T?` | null | Currently selected value |
-| `hint` | `Widget?` | null | Widget to show when no item selected |
-| `height` | `double` | 200.0 | Maximum height of dropdown overlay |
-| `itemHeight` | `double` | 48.0 | Height of each dropdown item |
-| `borderRadius` | `double` | 8.0 | Border radius for button and overlay |
-| `animationDuration` | `Duration` | 200ms | Animation duration for show/hide |
-| `decoration` | `BoxDecoration?` | null | Custom decoration for overlay |
-| `width` | `double?` | null | Fixed width for dropdown |
-| `maxWidth` | `double?` | null | Maximum width constraint |
-| `minWidth` | `double?` | null | Minimum width constraint |
-
-## TextOnlyDropdownButton
-
-A dropdown widget specifically designed for text-only content with precise text control.
-
-### Constructor
-
-```dart
-TextOnlyDropdownButton({
-  Key? key,
-  required List<String> items,
-  required ValueChanged<String?> onChanged,
-  String? value,
   String? hint,
-  DropdownTheme? theme,
+  String Function(T item)? label,   // required unless T is String
   TextDropdownConfig? config,
-  double? width,
-  double? maxWidth,
-  double? minWidth,
-  double height = 200.0,
-  double itemHeight = 48.0,
-  bool enabled = true,
+  Widget? leading,
+  Widget? selectedLeading,
+  EdgeInsets? leadingPadding,
+  ...
 })
 ```
 
-### Properties
+Full parameter tables live in `README.md`. The two constructors share every layout, theming and search parameter; only the rendering parameters differ.
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `items` | `List<T>` | required | List of options |
-| `onChanged` | `ValueChanged<T?>` | required | Callback when selection changes |
-| `value` | `T?` | null | Currently selected value |
-| `hint` | `String?` | null | Hint text when no item selected |
-| `label` | `String Function(T)?` | null | Extracts the text to display for an item. Required unless `T` is `String` |
-| `theme` | `DropdownTheme?` | null | Visual theme configuration |
-| `config` | `TextDropdownConfig?` | null | Text-specific configuration |
-| `width` | `double?` | null | Fixed width for dropdown |
-| `maxWidth` | `double?` | null | Maximum width constraint |
-| `minWidth` | `double?` | null | Minimum width constraint |
-| `height` | `double` | 200.0 | Maximum height of dropdown overlay |
-| `itemHeight` | `double` | 48.0 | Height of each dropdown item |
-| `enabled` | `bool` | true | Whether dropdown is interactive |
+### Statics
+
+| Member | Description |
+|--------|-------------|
+| `closeAll({bool animate = true})` | Closes every open menu. Pass `animate: false` right before navigation, when the widget may be disposed before an animation could finish |
 
 ## DropdownPositionResult
 
-Position calculation result for dropdown overlay positioning.
+Position calculation result, returned by the deprecated `DropdownMixin.calculateDropdownPosition()`. New code reads a `DropdownPlacementResult` from `DropdownOverlayController.measurePlacement()` instead. Removed alongside the mixin in 3.0.0.
 
 ### Properties
 
@@ -161,28 +53,6 @@ Position calculation result for dropdown overlay positioning.
 | `openDown` | `bool` | Whether the dropdown should open downward (true) or upward (false) |
 | `transformAlignment` | `Alignment` | The transform alignment for animations |
 | `topPosition` | `double` | The calculated top position for the overlay |
-
-## DropdownItem<T>
-
-Represents an item in a BasicDropdownButton.
-
-### Constructor
-
-```dart
-DropdownItem<T>({
-  required T value,
-  required Widget child,
-  VoidCallback? onTap,
-})
-```
-
-### Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `value` | `T` | The value associated with this item |
-| `child` | `Widget` | The widget to display for this item |
-| `onTap` | `VoidCallback?` | Optional callback when item is tapped |
 
 ## DropdownTheme
 
@@ -227,6 +97,42 @@ DropdownTheme({
 | `itemBorderRadius` | `double?` | null | Individual border radius for items |
 | `itemSplashColor` | `Color?` | null | Splash color for item interactions |
 | `itemHighlightColor` | `Color?` | null | Highlight color for item touch |
+
+## Theme resolution
+
+`DropdownTheme` fills in its own gaps. The widget reads a resolved style rather than deciding between a themed value and a framework default at each call site — so the rule for "what colour is the arrow when disabled?" exists in exactly one place.
+
+Resolution takes a **plain palette**, not a `BuildContext`. Reading values out of a `ThemeData` needs an element tree; deciding with them does not, and only the second half is worth testing.
+
+```dart
+final ambient = DropdownAmbientColors.of(context);   // once, in build
+final style = theme.resolveButton(ambient, enabled: isEnabled);
+
+Container(decoration: style.decoration, ...);
+```
+
+### Methods on DropdownTheme
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `resolveButton(ambient, {required bool enabled})` | `ResolvedButtonStyle` | The button's box, ink colours, content height, and arrow. `enabled` must be the *effective* state — a single-item dropdown disabled by policy is disabled here too |
+| `resolveOverlay(ambient)` | `ResolvedOverlayStyle` | The menu container, plus the border thickness the placement module reserves |
+| `resolveItem(ambient, {required bool selected, required bool isFirst, required bool isLast})` | `ResolvedItemStyle` | One item row. The end rows are rounded to meet the menu's corners unless `itemBorderRadius` overrides |
+
+### DropdownAmbientColors
+
+The ambient palette, lifted out of `ThemeData`. Construct it with `.of(context)`, or by hand in a test.
+
+| Property | Description |
+|----------|-------------|
+| `card` | Background of surfaces above the page — the menu |
+| `divider` | Hairline borders |
+| `splash` / `highlight` / `hover` | Ink states |
+| `primary` | Accent, tinting the selected item at 10% opacity |
+| `disabled` | Foreground of anything switched off |
+| `icon` | Default icon colour; null when the ambient theme leaves it unset |
+
+`SearchFieldTheme` and `DropdownScrollTheme` do not resolve themselves yet — see issue #26.
 
 ## DropdownOverlayController
 

--- a/documentation/text_configuration.md
+++ b/documentation/text_configuration.md
@@ -1,17 +1,19 @@
 # Text Configuration Guide
 
-Comprehensive guide for configuring text behavior in TextOnlyDropdownButton widgets.
+Comprehensive guide for configuring text behavior in `FlutterDropdownButton.text()`.
 
 ## TextDropdownConfig Overview
 
-The `TextDropdownConfig` class provides precise control over text rendering, overflow behavior, and styling in `TextOnlyDropdownButton` widgets.
+The `TextDropdownConfig` class provides precise control over text rendering, overflow behavior, and styling in text mode.
+
+Since 2.4.0 text mode is not limited to `String`: pass a `label` callback and any `T` renders as text, keeping the tooltip, the overflow handling and the default search filter.
 
 ## Basic Configuration
 
 ### Default Configuration
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: ['Short', 'Medium text', 'Very long text that might overflow'],
   onChanged: (value) {},
   // Uses TextDropdownConfig.defaultConfig by default
@@ -21,7 +23,7 @@ TextOnlyDropdownButton(
 ### Custom Configuration
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: ['Option 1', 'Option 2'],
   onChanged: (value) {},
   config: TextDropdownConfig(
@@ -109,7 +111,7 @@ TextDropdownConfig(
 Handle `\n` characters in text:
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: [
     'Single line',
     'Multi-line text\nwith explicit\nbreaks',
@@ -208,7 +210,7 @@ TextDropdownConfig(
 ### Default Single-line
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   config: TextDropdownConfig.defaultConfig,
   // Equivalent to:
   // TextDropdownConfig(
@@ -221,7 +223,7 @@ TextOnlyDropdownButton(
 ### Multi-line Display
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   config: TextDropdownConfig.multiLine,
   itemHeight: 80, // Increase height for multi-line
   // Equivalent to:
@@ -236,7 +238,7 @@ TextOnlyDropdownButton(
 ### Center Aligned
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   config: TextDropdownConfig.centered,
   // Equivalent to:
   // TextDropdownConfig(
@@ -248,7 +250,7 @@ TextOnlyDropdownButton(
 ### Fade Overflow
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   config: TextDropdownConfig.fadeOverflow,
   // Equivalent to:
   // TextDropdownConfig(
@@ -328,7 +330,7 @@ TextDropdownConfig buildThemedConfig(BuildContext context) {
 ### Search Dropdown with Long Options
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: [
     'Apple Inc. (AAPL)',
     'Microsoft Corporation (MSFT)',
@@ -346,7 +348,7 @@ TextOnlyDropdownButton(
 ### Multi-line Description Dropdown
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: [
     'Option 1\nShort description',
     'Option 2\nA longer description that explains the purpose of this option',
@@ -364,7 +366,7 @@ TextOnlyDropdownButton(
 ### Language Selector
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: ['English', '中文', 'العربية', 'עברית'],
   config: TextDropdownConfig(
     textAlign: TextAlign.center,

--- a/documentation/theming.md
+++ b/documentation/theming.md
@@ -12,7 +12,7 @@ The `DropdownTheme` class provides a unified way to style all dropdown variants.
 
 ```dart
 // Uses default Material Design styling
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: ['Option 1', 'Option 2'],
   onChanged: (value) {},
 )
@@ -21,13 +21,15 @@ TextOnlyDropdownButton(
 ### Custom Theme
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   items: ['Option 1', 'Option 2'],
   onChanged: (value) {},
-  theme: DropdownTheme(
-    borderRadius: 12.0,
-    elevation: 4.0,
-    animationDuration: Duration(milliseconds: 300),
+  animationDuration: const Duration(milliseconds: 300),
+  theme: DropdownStyleTheme(
+    dropdown: DropdownTheme(
+      borderRadius: 12.0,
+      elevation: 4.0,
+    ),
   ),
 )
 ```
@@ -38,9 +40,16 @@ TextOnlyDropdownButton(
 
 ```dart
 DropdownTheme(
-  animationDuration: Duration(milliseconds: 250),  // Slower animations
-  borderRadius: 16.0,                              // More rounded corners
-  elevation: 12.0,                                 // Higher shadow
+  borderRadius: 16.0,   // More rounded corners
+  elevation: 12.0,      // Higher shadow
+)
+
+// Animation timing is a widget parameter, not a theme field.
+// `DropdownTheme.animationDuration` exists but is never read — see issue #27.
+FlutterDropdownButton<String>.text(
+  items: items,
+  animationDuration: const Duration(milliseconds: 250),
+  onChanged: (_) {},
 )
 ```
 
@@ -141,7 +150,6 @@ class AppThemes {
   static const primaryDropdownTheme = DropdownTheme(
     borderRadius: 12.0,
     elevation: 4.0,
-    animationDuration: Duration(milliseconds: 250),
     backgroundColor: Colors.white,
     selectedItemColor: Color(0xFF1976D2),
   );
@@ -157,7 +165,7 @@ class AppThemes {
 ### Usage
 
 ```dart
-TextOnlyDropdownButton(
+FlutterDropdownButton<String>.text(
   theme: AppThemes.primaryDropdownTheme,
   // ... other properties
 )
@@ -225,14 +233,16 @@ DropdownTheme(
 Widget buildDropdown(BuildContext context) {
   final isDark = Theme.of(context).brightness == Brightness.dark;
   
-  return TextOnlyDropdownButton(
-    theme: DropdownTheme(
-      backgroundColor: isDark ? Colors.grey[800] : Colors.white,
-      selectedItemColor: isDark 
-          ? Colors.blue[800] 
-          : Colors.blue[50],
-      border: Border.all(
-        color: isDark ? Colors.grey[600]! : Colors.grey[300]!,
+  return FlutterDropdownButton<String>.text(
+    theme: DropdownStyleTheme(
+      dropdown: DropdownTheme(
+        backgroundColor: isDark ? Colors.grey[800] : Colors.white,
+        selectedItemColor: isDark 
+            ? Colors.blue[800] 
+            : Colors.blue[50],
+        border: Border.all(
+          color: isDark ? Colors.grey[600]! : Colors.grey[300]!,
+        ),
       ),
     ),
     // ... other properties
@@ -247,13 +257,15 @@ Widget buildResponsiveDropdown(BuildContext context) {
   final screenWidth = MediaQuery.of(context).size.width;
   final isTablet = screenWidth > 600;
   
-  return TextOnlyDropdownButton(
-    theme: DropdownTheme(
-      borderRadius: isTablet ? 12.0 : 8.0,
-      elevation: isTablet ? 8.0 : 4.0,
-      itemPadding: EdgeInsets.symmetric(
-        horizontal: isTablet ? 20 : 16,
-        vertical: isTablet ? 16 : 12,
+  return FlutterDropdownButton<String>.text(
+    theme: DropdownStyleTheme(
+      dropdown: DropdownTheme(
+        borderRadius: isTablet ? 12.0 : 8.0,
+        elevation: isTablet ? 8.0 : 4.0,
+        itemPadding: EdgeInsets.symmetric(
+          horizontal: isTablet ? 20 : 16,
+          vertical: isTablet ? 16 : 12,
+        ),
       ),
     ),
     // ... other properties


### PR DESCRIPTION
Closes #10.

## The drift

`CLAUDE.md` is loaded into an agent's context at the start of every session in this repo. It described `BasicDropdownButton` and `TextOnlyDropdownButton` as the two main widgets, a flat six-file `lib/src/`, and version 1.0.0. None of that has been true since 2.0.0. A stale map is worse than no map: an agent asked to fix the text dropdown looks for `text_only_dropdown_button.dart`, fails, and guesses.

`documentation/api_reference.md` was worse. It documented **five classes that no longer exist** — `BaseDropdownButton`, `BasicDropdownButton`, `TextOnlyDropdownButton`, `DynamicTextBaseDropdownButton`, `DropdownItem` — and never mentioned `FlutterDropdownButton`, the only widget the package ships.

`documentation/theming.md` and `text_configuration.md` had seventeen code examples calling `TextOnlyDropdownButton(...)`. None compile.

## What changed

**`CLAUDE.md`** rewritten around what is actually here: the widget as a thin shell over three modules — `DropdownPlacement`, `DropdownOverlayController`, theme resolution — and the pattern they share.

That pattern is the point, and it is now stated once where an agent will read it:

> Every module here separates **reading from the element tree** from **deciding with what was read**. Pulling `MediaQuery.size` out of a context needs a context; computing a menu's height from it does not. The second half is where the bugs are, and it is the half worth testing.

Also documents the testing conventions this work established — assert at the public seam; prove a test can fail before trusting it; label the tests that *cannot* fail rather than letting them masquerade as regression tests.

**`api_reference.md`** — the five dead classes are gone, replaced by `FlutterDropdownButton`, a new "Theme resolution" section covering `resolveButton` / `resolveOverlay` / `resolveItem` and `DropdownAmbientColors`, and `DropdownOverlayController`. `DropdownMixin` is marked deprecated with its migration. A one-line note at the top says what was removed and when, so a reader arriving from a search engine's cache is not confused.

**`theming.md`, `text_configuration.md`** — every example now names `FlutterDropdownButton<String>.text(...)`. Three passed `theme: DropdownTheme(...)` directly; the widget takes a `DropdownStyleTheme`, so they were wrapped.

## A dead field, found on the way

`DropdownTheme.animationDuration` exists. **Nothing reads it.**

```
$ grep -rn "\.animationDuration" lib/ | grep -v "widget\." | grep -v "this\."
(no matches)
```

`theming.md` showed it in three examples. A caller who copied one got no effect at all. The examples now pass `animationDuration` to the widget, which is the parameter that works, and the field is filed as #27.

Bringing docs in line with reality is a reliable way to find the places where the code lies.

## Verification

`flutter test` 75 passing · `flutter analyze` clean. No code changed.

Remaining references to the removed classes live in `README.md`'s "Migration from 1.x" section and `documentation/migration.md`, which talk about the past on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)