### PR TITLE
Deprecate DropdownTheme.animationDuration, which was never read

### DIFF
--- a/lib/src/theme/dropdown_theme.dart
+++ b/lib/src/theme/dropdown_theme.dart
@@ -2,16 +2,15 @@ import 'package:flutter/material.dart';
 
 import 'resolved_dropdown_style.dart';
 
-/// Shared theme configuration for all dropdown widgets.
+/// Visual styling for [FlutterDropdownButton]'s button, overlay and items.
 ///
-/// This class contains styling and behavior properties that are common
-/// across all dropdown variants (BasicDropdownButton, TextOnlyDropdownButton, etc.)
-/// to maintain visual consistency throughout the application.
+/// The theme fills in its own gaps: [resolveButton], [resolveOverlay] and
+/// [resolveItem] return styles whose slots are all filled, so the widget reads
+/// a decision rather than making one.
 ///
 /// Example:
 /// ```dart
 /// DropdownTheme(
-///   animationDuration: Duration(milliseconds: 300),
 ///   borderRadius: 12.0,
 ///   elevation: 4.0,
 ///   backgroundColor: Colors.white,
@@ -21,6 +20,10 @@ import 'resolved_dropdown_style.dart';
 class DropdownTheme {
   /// Creates a dropdown theme configuration.
   const DropdownTheme({
+    @Deprecated(
+      'Never read. Pass animationDuration to FlutterDropdownButton instead. '
+      'This parameter will be removed in 3.0.0.',
+    )
     this.animationDuration = const Duration(milliseconds: 200),
     this.borderRadius = 8.0,
     this.elevation = 8.0,
@@ -57,8 +60,27 @@ class DropdownTheme {
 
   /// The duration of the dropdown show/hide animation.
   ///
-  /// All dropdown variants will use this animation duration for
-  /// consistent behavior across the application.
+  /// **Deprecated, and it never worked.** Nothing has ever read this field;
+  /// the animation is driven by `FlutterDropdownButton.animationDuration`.
+  /// Setting it here has always been silently ignored.
+  ///
+  /// It is being removed rather than wired up. Honouring it now would slow the
+  /// animation for everyone who set it and has been living with the widget's
+  /// 200ms — a change nobody asked for. Pass the duration to the widget:
+  ///
+  /// ```dart
+  /// FlutterDropdownButton<String>.text(
+  ///   items: items,
+  ///   animationDuration: const Duration(milliseconds: 300),
+  ///   onChanged: (_) {},
+  /// )
+  /// ```
+  ///
+  /// `DropdownTheme` describes appearance; the widget owns behaviour.
+  @Deprecated(
+    'Never read. Pass animationDuration to FlutterDropdownButton instead. '
+    'This field will be removed in 3.0.0.',
+  )
   final Duration animationDuration;
 
   /// The border radius for both the dropdown button and overlay.
@@ -280,6 +302,10 @@ class DropdownTheme {
 
   /// Creates a copy of this theme with the given fields replaced.
   DropdownTheme copyWith({
+    @Deprecated(
+      'Never read. Pass animationDuration to FlutterDropdownButton instead. '
+      'This parameter will be removed in 3.0.0.',
+    )
     Duration? animationDuration,
     double? borderRadius,
     double? elevation,
@@ -313,6 +339,7 @@ class DropdownTheme {
     BoxDecoration? disabledButtonDecoration,
   }) {
     return DropdownTheme(
+      // ignore: deprecated_member_use_from_same_package
       animationDuration: animationDuration ?? this.animationDuration,
       borderRadius: borderRadius ?? this.borderRadius,
       elevation: elevation ?? this.elevation,

--- a/test/animation_duration_test.dart
+++ b/test/animation_duration_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget host(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+/// The opacity the menu is drawn at, straight off the widget that applies it.
+double menuOpacity(WidgetTester tester) {
+  return tester
+      .widget<Opacity>(
+        find.descendant(
+          of: find.byType(Overlay),
+          matching: find.byType(Opacity),
+        ),
+      )
+      .opacity;
+}
+
+void main() {
+  testWidgets('the widget parameter drives the open animation', (tester) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>.text(
+          items: const ['Apple', 'Banana'],
+          hint: 'Pick a fruit',
+          animationDuration: const Duration(milliseconds: 1000),
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pump(); // insert the overlay
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(menuOpacity(tester), lessThan(1.0),
+        reason: 'a 1000ms animation is only a fifth of the way through');
+
+    await tester.pumpAndSettle();
+    expect(menuOpacity(tester), 1.0);
+  });
+
+  testWidgets('DropdownTheme.animationDuration has no effect', (tester) async {
+    // The field is deprecated precisely because nothing reads it. Honouring it
+    // now would silently slow the animation for anyone who set it and has been
+    // living with the widget's 200ms all along. This test says so out loud, and
+    // fails if someone quietly wires it up.
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>.text(
+          items: const ['Apple', 'Banana'],
+          hint: 'Pick a fruit',
+          // ignore: deprecated_member_use_from_same_package
+          theme: const DropdownStyleTheme(
+            dropdown: DropdownTheme(
+              // ignore: deprecated_member_use_from_same_package
+              animationDuration: Duration(milliseconds: 1000),
+            ),
+          ),
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    // The widget's default 200ms has already finished. The theme's 1000ms
+    // never entered the picture.
+    expect(menuOpacity(tester), 1.0);
+  });
+}


### PR DESCRIPTION
Closes #27.

## The defect

`DropdownTheme.animationDuration` exists. Nothing in `lib/` reads it. The animation is driven entirely by `FlutterDropdownButton.animationDuration`.

`documentation/theming.md` showed it in three examples until the cleanup in #10. Anyone who copied one set a value and watched nothing happen.

## Why deprecate rather than wire it up

**Honouring it now would be a silent behaviour change.** Someone who set `animationDuration: 300ms` on the theme has been watching a 200ms animation and has come to expect it. Making the field work would slow their menus in a patch release, for a change they never asked for.

**And it cannot be done cleanly anyway.** The widget's `animationDuration` is non-nullable with a `200ms` default, so there is no way to distinguish "unset" from "explicitly 200ms" without changing a public field's type — breaking, in a minor.

A field that has never done anything cannot break anyone by leaving. `DropdownTheme` describes appearance; the widget owns behaviour.

## A deprecation that nobody sees is not a deprecation

Annotating the field alone was not enough. Dart does not propagate `@Deprecated` from a field to its initializing formal, so the common case stayed silent:

```dart
DropdownTheme(animationDuration: ...)   // no warning — how people actually use it
theme.animationDuration                 // warns — how nobody uses it
```

The constructor parameter and the `copyWith` parameter are annotated too. Verified from `example/`, a separate package, which is where a real consumer's analyzer sits: **two warnings, one per call shape.**

## Verification

Two widget tests, observing the opacity the menu is actually drawn at:

- `the widget parameter drives the open animation` — a 1000ms duration is still translucent at 200ms, opaque once settled
- `DropdownTheme.animationDuration has no effect` — a 1000ms theme value leaves the menu fully opaque at 250ms, because the widget's 200ms default is what ran

The second test cements the current behaviour on purpose. It fails if someone later wires the field up quietly, which is exactly the change this issue rejects.

Neither test could have been red: no behaviour changed. They are guards, not regressions.

`flutter test` 77 passing (was 75) · `flutter analyze` clean, package and example · `dart format` no changes.

## Also

`DropdownTheme`'s class dartdoc still described styling "across all dropdown variants (BasicDropdownButton, TextOnlyDropdownButton, etc.)" — both deleted in 2.0.0. Rewritten around what the class does now, including that it resolves itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)