### PR TITLE
Release 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.4.1
+
+* **FIX**: The trailing arrow now honours the single-item auto-disable. A dropdown disabled by `disableWhenSingleItem` blocked taps, switched its decoration to the disabled form and applied `disabledTextStyle`, while the arrow kept its **enabled** colour. Visible whenever `hideIconWhenSingleItem: false`. The icon asked `widget.enabled`; everything else asked `isEnabled`
+* **DEPRECATED**: `DropdownTheme.animationDuration`. Nothing has ever read it — the animation is driven by `FlutterDropdownButton.animationDuration`, and setting it on the theme was silently ignored. It is being removed rather than wired up: honouring it now would slow the animation for everyone who set it and has been living with the widget's 200ms. Pass the duration to the widget. Removed in 3.0.0
+* **REFACTOR**: `DropdownTheme` resolves itself. `resolveButton()`, `resolveOverlay()` and `resolveItem()` return styles whose slots are all filled in, and take a plain `DropdownAmbientColors` palette rather than a `BuildContext` — so styling rules are pure functions, testable without mounting a widget. Thirteen inline `??` fallback chains and fourteen `Theme.of(context)` calls left `build()`. `SearchFieldTheme` and `DropdownScrollTheme` are not converted yet
+* **CHANGE**: Exported `DropdownAmbientColors`, `ResolvedButtonStyle`, `ResolvedOverlayStyle` and `ResolvedItemStyle`. Additive; existing theme fields are unchanged
+* **CHANGE**: `pubspec.yaml`'s description no longer advertises "specialized variants for different content types" — there has been one widget since 2.0.0
+* **TEST**: 77 tests, up from 50. Fourteen exercise theme resolution with no widget tree at all
+* **DOCS**: `CLAUDE.md` and `documentation/` rewritten around the current architecture. `api_reference.md` documented five classes deleted in 2.0.0 (`BaseDropdownButton`, `BasicDropdownButton`, `TextOnlyDropdownButton`, `DynamicTextBaseDropdownButton`, `DropdownItem`) and never mentioned `FlutterDropdownButton`. Seventeen examples in `theming.md` and `text_configuration.md` called widgets that no longer exist; three passed `theme: DropdownTheme(...)` where a `DropdownStyleTheme` is required
+
 ## 2.4.0
 
 * **FEAT**: `FlutterDropdownButton.text()` now accepts a `label` callback, so text mode renders **any** type — not just `String`. Overflow handling, the tooltip and the default search filter all work off the label, so a `List<User>` no longer has to drop to `itemBuilder` and give those up. Omitting `label` for a non-`String` `T` now fails loudly at construction in debug builds instead of throwing a cast error at paint time

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^2.4.0
+  flutter_dropdown_button: ^2.4.1
 ```
 
 Import the package:
@@ -225,6 +225,8 @@ DropdownStyleTheme(
 ### DropdownTheme
 
 Controls general styling for button, overlay, and items.
+
+The theme fills in its own gaps. `resolveButton()`, `resolveOverlay()` and `resolveItem()` return styles whose slots are all filled, taking a plain `DropdownAmbientColors` palette rather than a `BuildContext` — so the rule for "what colour is the arrow when disabled?" lives in one place and can be tested without a widget. You rarely call these directly; the widget does.
 
 #### Button Styling
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
-description: "A highly customizable dropdown package with overlay-based rendering, smooth animations, and specialized variants for different content types."
-version: 2.4.0
+description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
+version: 2.4.1
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues


### PR DESCRIPTION
One fix, one deprecation, a refactor with no behaviour change, and the documentation catching up with three major versions of drift. `flutter pub publish --dry-run` reports **0 warnings**.

## Fix

**The trailing arrow ignored the single-item auto-disable.** A dropdown disabled by `disableWhenSingleItem` blocked taps, switched its decoration to the disabled form and applied `disabledTextStyle` — while the arrow kept its enabled colour. The icon asked `widget.enabled`; the other four places asked `isEnabled`.

`CHANGELOG.md` for 1.6.0 records fixing exactly this class of bug twice. One survived.

That is the argument for the refactor below, in miniature: fifteen fallback chains, each deciding independently what "disabled" means, with nothing forcing them to agree.

## Deprecation

**`DropdownTheme.animationDuration` never did anything.** The animation is driven by the widget's parameter; the theme field was silently ignored, and `documentation/theming.md` showed it in three examples.

Deprecated rather than wired up. Honouring it now would slow the animation for everyone who set it and has been living with the widget's 200ms — a change nobody asked for. And it cannot be done cleanly anyway: the widget's `animationDuration` is non-nullable, so "unset" and "explicitly 200ms" are indistinguishable without a breaking signature change.

Annotating the field alone was not enough — Dart does not propagate `@Deprecated` to an initializing formal, so `DropdownTheme(animationDuration: ...)`, the way people actually write it, stayed silent. The constructor and `copyWith` parameters are annotated too. Verified from `example/`, a separate package: two warnings, one per call shape.

## Refactor

**`DropdownTheme` resolves itself.** `resolveButton()`, `resolveOverlay()` and `resolveItem()` return styles with every slot filled; the widget reads the result rather than deciding.

| | Before | After |
| --- | --- | --- |
| `Theme.of(context)` in the widget | 18 | 4 |
| `effectiveTheme.<field> ??` chains | 13 | **0** |

Resolution takes a plain `DropdownAmbientColors` palette, **not a `BuildContext`**. Reading values out of a `ThemeData` needs an element tree; deciding with them does not. Taking a context would have reproduced exactly the defect removed from `DropdownMixin` in 2.3.2 — logic welded to the tree, unrunnable and therefore untested.

The four surviving `Theme.of` calls belong to the search field. Tracked in #26.

## Docs

`api_reference.md` documented **five classes deleted in 2.0.0** and never mentioned `FlutterDropdownButton`, the only widget the package ships. Seventeen examples across `theming.md` and `text_configuration.md` called widgets that no longer exist; three passed `theme: DropdownTheme(...)` where the widget takes a `DropdownStyleTheme`.

`CLAUDE.md` — loaded into an agent's context at the start of every session here — described a six-file `lib/src/` and version 1.0.0.

Fixing the examples is what surfaced the dead `animationDuration` field. Bringing docs in line with reality is a reliable way to find where the code lies.

`pubspec.yaml`'s description still advertised "specialized variants for different content types". One widget, since 2.0.0. That line is what pub.dev shows in search results.

## Verification

77 tests, up from 50 at 2.4.0.

The refactor changed no behaviour, so there was no failing test to write first. Instead: **eight characterisation tests** at the rendered widget — button decoration precedence through all four branches of the disabled chain, selected-item tint, `excludeLastItemBorder`, `itemBorderRadius` — written before the move and passing on both sides of it. Because they assert on the `BoxDecoration` the widget actually draws, they were indifferent to where it came from.

Then **fourteen unit tests** on `resolve()` itself, with no widget tree, no `pumpWidget`, no `BuildContext`.

The icon fix has a test that fails on the unfixed code. The two `animationDuration` tests cannot fail — nothing changed — and are labelled as guards, one of which fails if someone later wires the dead field up quietly.

`flutter analyze` clean, package and example · `dart format` no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)