### PR TITLE
SearchFieldTheme and DropdownScrollTheme resolve themselves; fix the divider height reservation

### DIFF
--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -386,6 +386,9 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   ResolvedOverlayStyle get _overlayStyle =>
       effectiveTheme.resolveOverlay(_ambient);
 
+  ResolvedSearchFieldStyle get _searchStyle =>
+      effectiveSearchTheme.resolve(_ambient);
+
   DropdownScrollTheme? get effectiveScrollTheme => widget.theme?.scroll;
 
   DropdownTooltipTheme get effectiveTooltipTheme =>
@@ -475,14 +478,8 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
       : widget.items;
 
   /// The height occupied by the search field including margin and divider.
-  double get _searchFieldHeight {
-    if (!widget.searchable) return 0.0;
-    final searchTheme = effectiveSearchTheme;
-    final margin = searchTheme.margin ?? const EdgeInsets.fromLTRB(8, 8, 8, 4);
-    final fieldHeight = searchTheme.height ?? 36.0;
-    final dividerHeight = searchTheme.divider != null ? 1.0 : 0.0;
-    return fieldHeight + margin.top + margin.bottom + dividerHeight;
-  }
+  double get _searchFieldHeight =>
+      widget.searchable ? _searchStyle.totalHeight : 0.0;
 
   /// Case-insensitive `contains` over the item's label. The default in text
   /// mode, whatever `T` is.
@@ -860,10 +857,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
                 padding: const EdgeInsets.all(16.0),
                 child: Text(
                   'No results found',
-                  style: TextStyle(
-                    color: Theme.of(context).hintColor,
-                    fontSize: 14,
-                  ),
+                  style: TextStyle(color: _ambient.hint, fontSize: 14),
                 ),
               ),
             ),
@@ -954,72 +948,37 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   // ===== Search field =====
 
   Widget _buildSearchField() {
-    final searchTheme = effectiveSearchTheme;
-    final margin = searchTheme.margin ?? const EdgeInsets.fromLTRB(8, 8, 8, 4);
-    final fieldHeight = searchTheme.height ?? 36.0;
-    final borderRadius = searchTheme.borderRadius ?? BorderRadius.circular(8);
-    final contentPadding = searchTheme.contentPadding ??
-        const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
-
-    final defaultDecoration = InputDecoration(
-      hintText: 'Search...',
-      prefixIcon: const Icon(Icons.search, size: 20),
-      prefixIconConstraints: const BoxConstraints(
-        minWidth: 36,
-        minHeight: 0,
-      ),
-      contentPadding: contentPadding,
-      isDense: true,
-      border: OutlineInputBorder(
-        borderRadius: borderRadius,
-        borderSide: BorderSide(
-          color: Theme.of(context).dividerColor,
-        ),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: borderRadius,
-        borderSide: BorderSide(
-          color: searchTheme.border is Border
-              ? (searchTheme.border! as Border).top.color
-              : Theme.of(context).dividerColor,
-        ),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: borderRadius,
-        borderSide: BorderSide(
-          color: searchTheme.focusedBorder is Border
-              ? (searchTheme.focusedBorder! as Border).top.color
-              : Theme.of(context).primaryColor,
-        ),
-      ),
-      filled: searchTheme.backgroundColor != null,
-      fillColor: searchTheme.backgroundColor,
-    );
+    final style = _searchStyle;
 
     Widget field = Container(
-      margin: margin,
-      padding: searchTheme.padding,
-      height: fieldHeight,
+      margin: style.margin,
+      padding: style.padding,
+      height: style.fieldHeight,
       child: TextField(
         controller: _searchController,
         focusNode: _searchFocusNode,
         onChanged: _onSearchChanged,
-        style: searchTheme.textStyle,
-        cursorColor: searchTheme.cursorColor,
-        cursorWidth: searchTheme.cursorWidth ?? 2.0,
-        cursorHeight: searchTheme.cursorHeight,
-        cursorRadius: searchTheme.cursorRadius,
-        textAlign: searchTheme.textAlign,
-        keyboardType: searchTheme.keyboardType ?? TextInputType.text,
-        textInputAction: searchTheme.textInputAction ?? TextInputAction.search,
-        decoration: searchTheme.decoration ?? defaultDecoration,
+        style: style.textStyle,
+        cursorColor: style.cursorColor,
+        cursorWidth: style.cursorWidth,
+        cursorHeight: style.cursorHeight,
+        cursorRadius: style.cursorRadius,
+        textAlign: style.textAlign,
+        keyboardType: style.keyboardType,
+        textInputAction: style.textInputAction,
+        decoration: style.decoration,
       ),
     );
 
-    if (searchTheme.divider != null) {
+    if (style.divider != null) {
       field = Column(
         mainAxisSize: MainAxisSize.min,
-        children: [field, searchTheme.divider!],
+        children: [
+          field,
+          // Constrained to the height reserved for it in the resolved style,
+          // so what the overlay set aside and what gets drawn cannot disagree.
+          SizedBox(height: style.dividerHeight, child: style.divider),
+        ],
       );
     }
 
@@ -1087,10 +1046,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   // ===== Scrollbar =====
 
   Widget _applyScrollbarTheme(Widget content, DropdownScrollTheme scrollTheme) {
-    final bool hasCustomWidths =
-        scrollTheme.thumbWidth != null || scrollTheme.trackWidth != null;
-
-    if (hasCustomWidths) {
+    if (scrollTheme.resolve().hasCustomWidths) {
       return _buildCustomScrollbar(content, scrollTheme);
     }
 
@@ -1136,10 +1092,9 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     Widget child,
     DropdownScrollTheme scrollTheme,
   ) {
-    final double effectiveThumbWidth =
-        scrollTheme.thumbWidth ?? scrollTheme.thickness ?? 8.0;
-    final double effectiveTrackWidth =
-        scrollTheme.trackWidth ?? scrollTheme.thickness ?? 8.0;
+    final resolved = scrollTheme.resolve();
+    final double effectiveThumbWidth = resolved.thumbWidth;
+    final double effectiveTrackWidth = resolved.trackWidth;
 
     final scrollbarThemeData = ScrollbarThemeData(
       thumbColor: scrollTheme.thumbColor != null
@@ -1170,15 +1125,15 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
           controller: _scrollController,
           thickness: effectiveThumbWidth,
           radius: scrollTheme.radius,
-          thumbVisibility: scrollTheme.thumbVisibility ?? false,
-          trackVisibility: scrollTheme.trackVisibility ?? false,
-          interactive: scrollTheme.interactive ?? true,
+          thumbVisibility: resolved.thumbVisibility,
+          trackVisibility: resolved.trackVisibility,
+          interactive: resolved.interactive,
           thumbColor: scrollTheme.thumbColor,
           trackColor: scrollTheme.trackColor,
           trackBorderColor: scrollTheme.trackBorderColor,
-          crossAxisMargin: scrollTheme.crossAxisMargin ?? 0,
-          mainAxisMargin: scrollTheme.mainAxisMargin ?? 0,
-          minThumbLength: scrollTheme.minThumbLength ?? 18,
+          crossAxisMargin: resolved.crossAxisMargin,
+          mainAxisMargin: resolved.mainAxisMargin,
+          minThumbLength: resolved.minThumbLength,
           child: child,
         ),
       );
@@ -1219,7 +1174,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     Widget child,
     DropdownScrollTheme scrollTheme,
   ) {
-    final gradientHeight = scrollTheme.gradientHeight ?? 24.0;
+    final gradientHeight = scrollTheme.resolve().gradientHeight;
     final List<Color> gradientColors;
     if (scrollTheme.gradientColors != null &&
         scrollTheme.gradientColors!.isNotEmpty) {

--- a/lib/src/theme/dropdown_scroll_theme.dart
+++ b/lib/src/theme/dropdown_scroll_theme.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'resolved_dropdown_style.dart';
+
 /// Theme configuration for dropdown scrollbar styling.
 ///
 /// This class contains all properties related to scrollbar appearance
@@ -195,6 +197,24 @@ class DropdownScrollTheme {
       showScrollGradient: showScrollGradient ?? this.showScrollGradient,
       gradientHeight: gradientHeight ?? this.gradientHeight,
       gradientColors: gradientColors ?? this.gradientColors,
+    );
+  }
+
+  /// The scrollbar's measurements as they should be applied.
+  ///
+  /// Pure: it needs no ambient palette and no [BuildContext].
+  ResolvedScrollStyle resolve() {
+    return ResolvedScrollStyle(
+      thumbWidth: thumbWidth ?? thickness ?? 8.0,
+      trackWidth: trackWidth ?? thickness ?? 8.0,
+      gradientHeight: gradientHeight ?? 24.0,
+      hasCustomWidths: thumbWidth != null || trackWidth != null,
+      thumbVisibility: thumbVisibility ?? false,
+      trackVisibility: trackVisibility ?? false,
+      interactive: interactive ?? true,
+      crossAxisMargin: crossAxisMargin ?? 0,
+      mainAxisMargin: mainAxisMargin ?? 0,
+      minThumbLength: minThumbLength ?? 18,
     );
   }
 

--- a/lib/src/theme/resolved_dropdown_style.dart
+++ b/lib/src/theme/resolved_dropdown_style.dart
@@ -17,6 +17,7 @@ class DropdownAmbientColors {
     required this.primary,
     required this.disabled,
     this.icon,
+    this.hint,
   });
 
   /// Reads the palette from the enclosing [Theme].
@@ -31,6 +32,7 @@ class DropdownAmbientColors {
       primary: theme.primaryColor,
       disabled: theme.disabledColor,
       icon: theme.iconTheme.color,
+      hint: theme.hintColor,
     );
   }
 
@@ -57,6 +59,130 @@ class DropdownAmbientColors {
 
   /// Default icon colour. Null when the ambient theme leaves it unset.
   final Color? icon;
+
+  /// Foreground of placeholder text — the empty-search message.
+  final Color? hint;
+}
+
+/// The search field's appearance, with every slot filled in.
+class ResolvedSearchFieldStyle {
+  /// Creates a resolved search field style.
+  const ResolvedSearchFieldStyle({
+    required this.decoration,
+    required this.fieldHeight,
+    required this.margin,
+    required this.cursorWidth,
+    required this.keyboardType,
+    required this.textInputAction,
+    required this.textAlign,
+    required this.autofocus,
+    required this.dividerHeight,
+    required this.totalHeight,
+    this.textStyle,
+    this.cursorColor,
+    this.cursorHeight,
+    this.cursorRadius,
+    this.padding,
+    this.divider,
+  });
+
+  /// The text field's decoration, already merged with the theme's borders.
+  final InputDecoration decoration;
+
+  /// Height of the field itself, excluding margin and divider.
+  final double fieldHeight;
+
+  /// Space around the field.
+  final EdgeInsets margin;
+
+  /// Cursor width.
+  final double cursorWidth;
+
+  /// Soft keyboard type.
+  final TextInputType keyboardType;
+
+  /// Soft keyboard action button.
+  final TextInputAction textInputAction;
+
+  /// Horizontal alignment of the query text.
+  final TextAlign textAlign;
+
+  /// Whether the field takes focus when the menu opens.
+  final bool autofocus;
+
+  /// Height reserved for [divider], and the height it is drawn at.
+  final double dividerHeight;
+
+  /// Everything the search field occupies: field, margin and divider.
+  ///
+  /// This is what the overlay reserves as chrome. Reserving less than the
+  /// field draws overflows the item list.
+  final double totalHeight;
+
+  /// Style of the query text.
+  final TextStyle? textStyle;
+
+  /// Cursor colour.
+  final Color? cursorColor;
+
+  /// Cursor height.
+  final double? cursorHeight;
+
+  /// Cursor corner radius.
+  final Radius? cursorRadius;
+
+  /// Padding inside the field's container.
+  final EdgeInsets? padding;
+
+  /// Separator between the field and the item list.
+  final Widget? divider;
+}
+
+/// The scrollbar's measurements, with every slot filled in.
+class ResolvedScrollStyle {
+  /// Creates a resolved scroll style.
+  const ResolvedScrollStyle({
+    required this.thumbWidth,
+    required this.trackWidth,
+    required this.gradientHeight,
+    required this.hasCustomWidths,
+    required this.thumbVisibility,
+    required this.trackVisibility,
+    required this.interactive,
+    required this.crossAxisMargin,
+    required this.mainAxisMargin,
+    required this.minThumbLength,
+  });
+
+  /// Width of the thumb.
+  final double thumbWidth;
+
+  /// Width of the track.
+  final double trackWidth;
+
+  /// Height of the fade shown when the list can scroll.
+  final double gradientHeight;
+
+  /// Whether the caller asked for widths the stock `Scrollbar` cannot honour.
+  final bool hasCustomWidths;
+
+  /// Whether the thumb is always shown.
+  final bool thumbVisibility;
+
+  /// Whether the track is always shown.
+  final bool trackVisibility;
+
+  /// Whether the thumb can be dragged.
+  final bool interactive;
+
+  /// Distance from the scroll view's edge.
+  final double crossAxisMargin;
+
+  /// Distance from the scroll view's ends.
+  final double mainAxisMargin;
+
+  /// Shortest the thumb is allowed to become.
+  final double minThumbLength;
 }
 
 /// The button's appearance, with every slot filled in.

--- a/lib/src/theme/search_field_theme.dart
+++ b/lib/src/theme/search_field_theme.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'resolved_dropdown_style.dart';
+
 /// Theme configuration for the search field in searchable dropdowns.
 ///
 /// This class provides comprehensive control over the appearance and behavior
@@ -38,6 +40,7 @@ class SearchFieldTheme {
     this.focusedBorder,
     this.contentPadding,
     this.divider,
+    this.dividerHeight = 1.0,
     this.autofocus = true,
     this.keyboardType,
     this.textInputAction,
@@ -124,7 +127,27 @@ class SearchFieldTheme {
   /// A widget displayed between the search field and the items list.
   ///
   /// Typically a [Divider]. If null, no divider is shown.
+  ///
+  /// The widget is laid out at exactly [dividerHeight]; see there for why.
   final Widget? divider;
+
+  /// The height reserved for [divider], in logical pixels.
+  ///
+  /// The overlay reserves this much space and constrains [divider] to it, so
+  /// the space reserved and the space drawn cannot disagree. Getting that
+  /// wrong overflows the item list — Flutter's `Divider` is **16px** tall by
+  /// default, not one, and a hardcoded reservation of 1.0 used to make a
+  /// three-item searchable menu overflow by fifteen pixels.
+  ///
+  /// Raise it if your divider needs more room:
+  ///
+  /// ```dart
+  /// SearchFieldTheme(
+  ///   divider: const Divider(),
+  ///   dividerHeight: 16,
+  /// )
+  /// ```
+  final double dividerHeight;
 
   /// Whether the search field should be focused automatically when
   /// the dropdown opens.
@@ -165,6 +188,7 @@ class SearchFieldTheme {
     BoxBorder? focusedBorder,
     EdgeInsets? contentPadding,
     Widget? divider,
+    double? dividerHeight,
     bool? autofocus,
     TextInputType? keyboardType,
     TextInputAction? textInputAction,
@@ -186,10 +210,74 @@ class SearchFieldTheme {
       focusedBorder: focusedBorder ?? this.focusedBorder,
       contentPadding: contentPadding ?? this.contentPadding,
       divider: divider ?? this.divider,
+      dividerHeight: dividerHeight ?? this.dividerHeight,
       autofocus: autofocus ?? this.autofocus,
       keyboardType: keyboardType ?? this.keyboardType,
       textInputAction: textInputAction ?? this.textInputAction,
       textAlign: textAlign ?? this.textAlign,
+    );
+  }
+
+  /// The search field as it should be drawn.
+  ///
+  /// Pure: hand it the ambient palette, not a [BuildContext].
+  ResolvedSearchFieldStyle resolve(DropdownAmbientColors ambient) {
+    final resolvedMargin = margin ?? const EdgeInsets.fromLTRB(8, 8, 8, 4);
+    final resolvedHeight = height ?? 36.0;
+    final resolvedRadius = borderRadius ?? BorderRadius.circular(8);
+    final resolvedDividerHeight = divider != null ? dividerHeight : 0.0;
+
+    return ResolvedSearchFieldStyle(
+      decoration: decoration ?? _defaultDecoration(ambient, resolvedRadius),
+      fieldHeight: resolvedHeight,
+      margin: resolvedMargin,
+      cursorWidth: cursorWidth ?? 2.0,
+      keyboardType: keyboardType ?? TextInputType.text,
+      textInputAction: textInputAction ?? TextInputAction.search,
+      textAlign: textAlign,
+      autofocus: autofocus,
+      dividerHeight: resolvedDividerHeight,
+      totalHeight: resolvedHeight +
+          resolvedMargin.top +
+          resolvedMargin.bottom +
+          resolvedDividerHeight,
+      textStyle: textStyle,
+      cursorColor: cursorColor,
+      cursorHeight: cursorHeight,
+      cursorRadius: cursorRadius,
+      padding: padding,
+      divider: divider,
+    );
+  }
+
+  InputDecoration _defaultDecoration(
+    DropdownAmbientColors ambient,
+    BorderRadius radius,
+  ) {
+    Color edge(BoxBorder? candidate, Color fallback) =>
+        candidate is Border ? candidate.top.color : fallback;
+
+    return InputDecoration(
+      hintText: 'Search...',
+      prefixIcon: const Icon(Icons.search, size: 20),
+      prefixIconConstraints: const BoxConstraints(minWidth: 36, minHeight: 0),
+      contentPadding: contentPadding ??
+          const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      isDense: true,
+      border: OutlineInputBorder(
+        borderRadius: radius,
+        borderSide: BorderSide(color: ambient.divider),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: radius,
+        borderSide: BorderSide(color: edge(border, ambient.divider)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: radius,
+        borderSide: BorderSide(color: edge(focusedBorder, ambient.primary)),
+      ),
+      filled: backgroundColor != null,
+      fillColor: backgroundColor,
     );
   }
 

--- a/test/search_divider_height_test.dart
+++ b/test/search_divider_height_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget host(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+Widget dropdown({Widget? divider}) {
+  return FlutterDropdownButton<String>.text(
+    width: 200,
+    items: const ['Apple', 'Banana', 'Cherry'],
+    hint: 'Pick a fruit',
+    searchable: true,
+    theme: DropdownStyleTheme(search: SearchFieldTheme(divider: divider)),
+    onChanged: (_) {},
+  );
+}
+
+Future<void> openMenu(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterDropdownButton<String>));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a one-pixel divider is accounted for', (tester) async {
+    await tester.pumpWidget(host(dropdown(divider: const Divider(height: 1))));
+    await openMenu(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(ListView), findsNothing,
+        reason: 'three items still fit in the 200px budget');
+  });
+
+  testWidgets('a divider taller than one pixel is accounted for too',
+      (tester) async {
+    // `Divider()` is 16px tall by default — the height most callers get when
+    // they reach for one. The overlay must reserve the space it actually
+    // occupies, not a hardcoded 1.0.
+    await tester.pumpWidget(host(dropdown(divider: const Divider())));
+    await openMenu(tester);
+
+    expect(tester.takeException(), isNull,
+        reason: 'the item list must not overflow the overlay');
+  });
+}

--- a/test/theme/search_scroll_resolve_test.dart
+++ b/test/theme/search_scroll_resolve_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// No widget tree, no `pumpWidget`, no `BuildContext`.
+
+const ambient = DropdownAmbientColors(
+  card: Color(0xFFFFFFFF),
+  divider: Color(0xFFBDBDBD),
+  splash: Color(0xFFE0E0E0),
+  highlight: Color(0xFFEEEEEE),
+  hover: Color(0xFFF5F5F5),
+  primary: Color(0xFF2196F3),
+  disabled: Color(0xFF9E9E9E),
+);
+
+const red = Color(0xFFE53935);
+
+void main() {
+  group('search field', () {
+    test('totalHeight is the field, its margin, and nothing else', () {
+      // 36 + 8 + 4, with no divider.
+      expect(const SearchFieldTheme().resolve(ambient).totalHeight, 48);
+    });
+
+    test('a divider adds exactly the height reserved for it', () {
+      const theme = SearchFieldTheme(divider: Divider(), dividerHeight: 16);
+
+      final style = theme.resolve(ambient);
+      expect(style.dividerHeight, 16);
+      expect(style.totalHeight, 64, reason: '36 + 8 + 4 + 16');
+    });
+
+    test('dividerHeight is ignored when there is no divider', () {
+      const theme = SearchFieldTheme(dividerHeight: 16);
+
+      final style = theme.resolve(ambient);
+      expect(style.dividerHeight, 0);
+      expect(style.totalHeight, 48);
+    });
+
+    test('borders fall back to the ambient palette', () {
+      final decoration = const SearchFieldTheme().resolve(ambient).decoration;
+
+      final enabled = decoration.enabledBorder! as OutlineInputBorder;
+      final focused = decoration.focusedBorder! as OutlineInputBorder;
+
+      expect(enabled.borderSide.color, ambient.divider);
+      expect(focused.borderSide.color, ambient.primary,
+          reason: 'the focused edge picks up the accent');
+    });
+
+    test('a themed border wins over the ambient one', () {
+      final theme = SearchFieldTheme(border: Border.all(color: red));
+
+      final enabled = theme.resolve(ambient).decoration.enabledBorder!
+          as OutlineInputBorder;
+      expect(enabled.borderSide.color, red);
+    });
+
+    test('a full decoration override replaces the built one', () {
+      const override = InputDecoration(hintText: 'Find a country');
+
+      expect(
+        const SearchFieldTheme(decoration: override)
+            .resolve(ambient)
+            .decoration,
+        override,
+      );
+    });
+
+    test('the field is only filled when a background is given', () {
+      expect(
+          const SearchFieldTheme().resolve(ambient).decoration.filled, false);
+      expect(
+        const SearchFieldTheme(backgroundColor: red)
+            .resolve(ambient)
+            .decoration
+            .filled,
+        true,
+      );
+    });
+
+    test('keyboard defaults suit a search box', () {
+      final style = const SearchFieldTheme().resolve(ambient);
+
+      expect(style.keyboardType, TextInputType.text);
+      expect(style.textInputAction, TextInputAction.search);
+      expect(style.cursorWidth, 2.0);
+      expect(style.autofocus, isTrue);
+    });
+  });
+
+  group('scrollbar', () {
+    test('thumb and track fall back to thickness, then to 8', () {
+      expect(const DropdownScrollTheme().resolve().thumbWidth, 8);
+      expect(const DropdownScrollTheme(thickness: 4).resolve().trackWidth, 4);
+      expect(
+        const DropdownScrollTheme(thickness: 4, trackWidth: 12)
+            .resolve()
+            .trackWidth,
+        12,
+      );
+    });
+
+    test('custom widths are flagged, because Scrollbar cannot honour them', () {
+      expect(const DropdownScrollTheme().resolve().hasCustomWidths, isFalse);
+      expect(
+        const DropdownScrollTheme(thickness: 4).resolve().hasCustomWidths,
+        isFalse,
+        reason: 'thickness alone is something Scrollbar understands',
+      );
+      expect(
+        const DropdownScrollTheme(thumbWidth: 6).resolve().hasCustomWidths,
+        isTrue,
+      );
+    });
+
+    test('RawScrollbar\'s non-null slots are all filled', () {
+      final style = const DropdownScrollTheme().resolve();
+
+      expect(style.thumbVisibility, isFalse);
+      expect(style.trackVisibility, isFalse);
+      expect(style.interactive, isTrue);
+      expect(style.crossAxisMargin, 0);
+      expect(style.mainAxisMargin, 0);
+      expect(style.minThumbLength, 18);
+      expect(style.gradientHeight, 24);
+    });
+  });
+}


### PR DESCRIPTION
Closes #26. Finishes what #5 started.

## The bug the chains were hiding

`_searchFieldHeight` reserved space for the divider like this:

```dart
final dividerHeight = searchTheme.divider != null ? 1.0 : 0.0;
```

But `SearchFieldTheme.divider` is an arbitrary `Widget`, and **Flutter's `Divider` is 16px tall by default.** Reach for the obvious thing —

```dart
SearchFieldTheme(divider: Divider())
```

— and the overlay reserves one pixel for something that draws sixteen. A three-item searchable menu then overflows:

```
A RenderFlex overflowed by 15 pixels on the bottom.
```

Exactly the same shape as the defect fixed in 2.3.2, where the search field's own height was left out of the overlay's budget. Both are the overlay mismeasuring the things inside it that are not items.

## The fix: make disagreement impossible

Adding a `dividerHeight` field is not enough on its own — a caller could still set 16 and pass a 20px widget. So the reserved height is also **enforced**: the divider is laid out inside a `SizedBox(height: dividerHeight)`.

What the overlay sets aside and what gets drawn are now the same number, by construction. Pass `Divider()` without touching `dividerHeight` and you get a 1px divider, not a 15px overflow.

`dividerHeight` defaults to `1.0`, so existing themes render identically.

## The refactor

`SearchFieldTheme.resolve(ambient)` and `DropdownScrollTheme.resolve()` return styles with every slot filled. Neither takes a `BuildContext`.

Measured on `lib/src/flutter_dropdown_button.dart`:

| | Before #5 | After #5 | After this |
| --- | --- | --- | --- |
| `Theme.of(context)` | 18 | 4 | **0** |
| `theme.<field> ??` chains | 13 + 12 | 12 | **0** |

`ResolvedSearchFieldStyle` owns `totalHeight` — the chrome the placement module reserves — so the number that overflowed the menu is now computed in the module that knows what the search field is made of, and is unit-tested directly.

`ResolvedScrollStyle` fills in the six non-null slots `RawScrollbar` demands. Moving four of them and leaving two behind would have made "the decision lives in one place" a lie.

## Verification

90 tests, up from 77.

Two widget tests on the divider, one of which fails on the unfixed code with the overflow above. The other guards the 1px case that already worked.

Eleven unit tests on the two `resolve()` methods — **no widget tree, no `pumpWidget`, no `BuildContext`.** They pin down the arithmetic that caused the bug (`totalHeight` with and without a divider), the border fallbacks, the decoration override, and every `RawScrollbar` default.

The 77 existing tests pass unchanged.

`flutter analyze` clean, package and example · `dart format` no changes.

## Public API

Additive. `SearchFieldTheme.dividerHeight`, `SearchFieldTheme.resolve()`, `DropdownScrollTheme.resolve()`, `ResolvedSearchFieldStyle`, `ResolvedScrollStyle`, and `DropdownAmbientColors.hint`. Nothing removed, nothing changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)