### PR TITLE
Partial DropdownTooltipTheme styling no longer blanks the tooltip's box

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,13 @@ Single-open coordination lives in a registry keyed by `Overlay`, not in a proces
 
 `DropdownStyleTheme` composes four themes: `DropdownTheme`, `DropdownScrollTheme`, `DropdownTooltipTheme`, `SearchFieldTheme`.
 
-`DropdownTheme` **resolves itself**. `resolveButton()`, `resolveOverlay()` and `resolveItem()` return styles whose slots are all filled in; the widget reads the result rather than deciding. Resolution takes a `DropdownAmbientColors` — a plain palette lifted out of `ThemeData` — rather than a `BuildContext`, so it is a pure function.
+Each **resolves itself**. `DropdownTheme.resolveButton()`, `.resolveOverlay()` and `.resolveItem()`, `SearchFieldTheme.resolve()`, `DropdownScrollTheme.resolve()` and `DropdownTooltipTheme.resolve()` return styles whose slots are all filled in; the widget reads the result rather than deciding. There is no `??` chain and no `Theme.of(context)` left in `build()`.
 
-`SearchFieldTheme` and `DropdownScrollTheme` have **not** been converted yet; they still inline their fallbacks in `build()`. See issue #26.
+Resolution never takes a `BuildContext`. It takes whatever plain value it needs — a `DropdownAmbientColors` palette lifted out of `ThemeData`, a `Brightness`, or nothing at all — so every rule is a pure function.
+
+A resolved style is **complete**, and that is load-bearing rather than tidy. `SearchFieldTheme` reserves the height it also constrains its divider to, so the two cannot disagree. `DropdownTooltipTheme` fills the whole `BoxDecoration` once the caller names any part of it, because Flutter's `Tooltip` treats a decoration as a total replacement and would otherwise blank the slots the caller left alone. Both of those were shipped bugs.
+
+`DropdownTooltipTheme.resolve()` returns a **nullable** decoration on purpose: a theme that names no box property must leave the box to the ambient `TooltipTheme`.
 
 ### The recurring pattern
 

--- a/README.md
+++ b/README.md
@@ -315,16 +315,21 @@ Controls tooltip styling and behavior for text-based dropdowns.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `decoration` | `Decoration?` | `null` | Custom tooltip decoration |
+| `decoration` | `Decoration?` | `null` | Custom tooltip decoration; a total override |
 | `backgroundColor` | `Color?` | `null` | Tooltip background color |
 | `textColor` | `Color?` | `null` | Tooltip text color |
 | `textStyle` | `TextStyle?` | `null` | Tooltip text style (overrides `textColor`) |
 | `borderRadius` | `BorderRadius?` | `null` | Tooltip corner radius |
-| `borderColor` | `Color?` | `null` | Tooltip border color |
-| `borderWidth` | `double?` | `1.0` | Tooltip border width |
+| `border` | `BoxBorder?` | `null` | Tooltip border |
+| `borderColor` | `Color?` | `null` | **Deprecated** — use `border`. Removed in 3.0.0 |
+| `borderWidth` | `double?` | `1.0` | **Deprecated** — use `border`. Removed in 3.0.0 |
 | `shadow` | `List<BoxShadow>?` | `null` | Tooltip shadow |
 | `padding` | `EdgeInsetsGeometry?` | `null` | Padding inside tooltip |
 | `margin` | `EdgeInsetsGeometry?` | `null` | Margin around tooltip |
+
+Setting any of `backgroundColor`, `borderRadius`, `border` or `shadow` hands this
+theme the tooltip's whole box; the ones you leave unset fall back to Flutter's own
+tooltip defaults. Set none of them and an app-wide `TooltipTheme` still applies.
 
 #### Behavior
 

--- a/lib/src/theme/resolved_dropdown_style.dart
+++ b/lib/src/theme/resolved_dropdown_style.dart
@@ -64,6 +64,21 @@ class DropdownAmbientColors {
   final Color? hint;
 }
 
+/// The tooltip's appearance, with every slot the theme touches filled in.
+class ResolvedTooltipStyle {
+  /// Creates a resolved tooltip style.
+  const ResolvedTooltipStyle({this.decoration});
+
+  /// The tooltip's box, or null to leave it to Flutter.
+  ///
+  /// Null means the theme named no box property, so the ambient [TooltipTheme]
+  /// — or, failing that, [Tooltip]'s own default — keeps control. Handing
+  /// [Tooltip] a decoration *replaces* that default outright rather than
+  /// merging with it, so a partially-specified box would blank every slot it
+  /// did not restate. Non-null therefore always means complete.
+  final Decoration? decoration;
+}
+
 /// The search field's appearance, with every slot filled in.
 class ResolvedSearchFieldStyle {
   /// Creates a resolved search field style.

--- a/lib/src/theme/tooltip_theme.dart
+++ b/lib/src/theme/tooltip_theme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../config/text_dropdown_config.dart';
+import 'resolved_dropdown_style.dart';
 
 /// Theme configuration for tooltip styling and behavior in dropdown widgets.
 ///
@@ -30,6 +31,11 @@ import '../config/text_dropdown_config.dart';
 ///   showDuration: Duration(seconds: 3),
 /// )
 /// ```
+///
+/// Naming any one of [backgroundColor], [borderRadius], [border] or [shadow]
+/// hands this theme the tooltip's whole box; the ones left unset fall back to
+/// [Tooltip]'s own defaults. Naming none of them leaves the box alone, so an
+/// app-wide [TooltipTheme] still applies. See [resolve].
 class DropdownTooltipTheme {
   /// Creates a tooltip theme configuration.
   const DropdownTooltipTheme({
@@ -38,8 +44,9 @@ class DropdownTooltipTheme {
     this.textStyle,
     this.decoration,
     this.borderRadius,
-    this.borderColor,
-    this.borderWidth,
+    this.border,
+    @Deprecated('Use border instead. Removed in 3.0.0.') this.borderColor,
+    @Deprecated('Use border instead. Removed in 3.0.0.') this.borderWidth,
     this.shadow,
     this.padding,
     this.margin,
@@ -58,7 +65,8 @@ class DropdownTooltipTheme {
 
   /// The background color of the tooltip.
   ///
-  /// If null, uses Flutter's default tooltip background color (dark grey).
+  /// If null, uses Flutter's own tooltip background — dark grey on a light
+  /// theme, off-white on a dark one.
   /// This is a convenience property that creates a BoxDecoration internally.
   /// If [decoration] is provided, this property is ignored.
   final Color? backgroundColor;
@@ -79,24 +87,38 @@ class DropdownTooltipTheme {
   /// The decoration for the tooltip background.
   ///
   /// If provided, this takes precedence over [backgroundColor],
-  /// [borderRadius], [borderColor], [borderWidth], and [shadow].
+  /// [borderRadius], [border] and [shadow], and the tooltip's box is entirely
+  /// yours.
   ///
-  /// If null, a BoxDecoration is created from the individual style properties.
-  /// Customize this to match your app's design system.
+  /// If null, a [BoxDecoration] is built from the individual style properties
+  /// — but only if at least one of them is set. Naming one of them hands the
+  /// whole box to this theme, so the rest fall back to [Tooltip]'s own
+  /// defaults rather than to nothing. Naming none of them leaves the box to
+  /// the ambient [TooltipTheme].
   final Decoration? decoration;
 
   /// The border radius of the tooltip.
   ///
-  /// If null, uses Flutter's default rounded corners.
+  /// If null, uses Flutter's own tooltip corners — a 4-pixel radius.
   /// This is a convenience property that creates a BoxDecoration internally.
   /// If [decoration] is provided, this property is ignored.
   final BorderRadius? borderRadius;
+
+  /// The border of the tooltip.
+  ///
+  /// If null, no border is displayed. Takes precedence over [borderColor] and
+  /// [borderWidth]. If [decoration] is provided, this property is ignored.
+  ///
+  /// This is the same shape [DropdownTheme.border] and [SearchFieldTheme.border]
+  /// take; the older colour-and-width pair is kept only for compatibility.
+  final BoxBorder? border;
 
   /// The border color of the tooltip.
   ///
   /// If null, no border is displayed.
   /// This is a convenience property that creates a BoxDecoration internally.
   /// If [decoration] is provided, this property is ignored.
+  @Deprecated('Use border instead. Removed in 3.0.0.')
   final Color? borderColor;
 
   /// The border width of the tooltip.
@@ -105,11 +127,12 @@ class DropdownTooltipTheme {
   /// Defaults to 1.0 if [borderColor] is provided.
   /// This is a convenience property that creates a BoxDecoration internally.
   /// If [decoration] is provided, this property is ignored.
+  @Deprecated('Use border instead. Removed in 3.0.0.')
   final double? borderWidth;
 
   /// The shadow for the tooltip.
   ///
-  /// If null, uses Flutter's default tooltip shadow.
+  /// If null, the tooltip casts no shadow, as Flutter's own does not.
   /// This is a convenience property that creates a BoxDecoration internally.
   /// If [decoration] is provided, this property is ignored.
   final List<BoxShadow>? shadow;
@@ -228,8 +251,9 @@ class DropdownTooltipTheme {
     TextStyle? textStyle,
     Decoration? decoration,
     BorderRadius? borderRadius,
-    Color? borderColor,
-    double? borderWidth,
+    BoxBorder? border,
+    @Deprecated('Use border instead. Removed in 3.0.0.') Color? borderColor,
+    @Deprecated('Use border instead. Removed in 3.0.0.') double? borderWidth,
     List<BoxShadow>? shadow,
     EdgeInsetsGeometry? padding,
     EdgeInsetsGeometry? margin,
@@ -251,7 +275,10 @@ class DropdownTooltipTheme {
       textStyle: textStyle ?? this.textStyle,
       decoration: decoration ?? this.decoration,
       borderRadius: borderRadius ?? this.borderRadius,
+      border: border ?? this.border,
+      // ignore: deprecated_member_use_from_same_package
       borderColor: borderColor ?? this.borderColor,
+      // ignore: deprecated_member_use_from_same_package
       borderWidth: borderWidth ?? this.borderWidth,
       shadow: shadow ?? this.shadow,
       padding: padding ?? this.padding,
@@ -268,6 +295,57 @@ class DropdownTooltipTheme {
       enableTapToDismiss: enableTapToDismiss ?? this.enableTapToDismiss,
       triggerMode: triggerMode ?? this.triggerMode,
     );
+  }
+
+  /// The tooltip as it should be drawn.
+  ///
+  /// Pure: hand it the ambient [Brightness], not a [BuildContext]. Unlike the
+  /// other themes this one takes no [DropdownAmbientColors] — a tooltip's
+  /// defaults come from [Tooltip] itself, which switches on brightness alone
+  /// and never consults [ThemeData]'s palette.
+  ResolvedTooltipStyle resolve(Brightness brightness) {
+    return ResolvedTooltipStyle(decoration: _resolveDecoration(brightness));
+  }
+
+  /// Flutter's own tooltip corner radius.
+  static const BorderRadius _defaultRadius =
+      BorderRadius.all(Radius.circular(4));
+
+  /// Flutter's own tooltip background, which flips with the ambient brightness.
+  static Color _defaultBackground(Brightness brightness) =>
+      brightness == Brightness.dark
+          ? Colors.white.withValues(alpha: 0.9)
+          : Colors.grey.shade700.withValues(alpha: 0.9);
+
+  Decoration? _resolveDecoration(Brightness brightness) {
+    if (decoration != null) return decoration;
+
+    final resolvedBorder = _resolveBorder();
+
+    // `borderWidth` is deliberately absent: on its own it draws nothing, and
+    // synthesising a box for it would override an ambient `TooltipTheme` to
+    // no visible end.
+    final touchesTheBox = backgroundColor != null ||
+        borderRadius != null ||
+        resolvedBorder != null ||
+        shadow != null;
+    if (!touchesTheBox) return null;
+
+    return BoxDecoration(
+      color: backgroundColor ?? _defaultBackground(brightness),
+      borderRadius: borderRadius ?? _defaultRadius,
+      border: resolvedBorder,
+      boxShadow: shadow,
+    );
+  }
+
+  BoxBorder? _resolveBorder() {
+    if (border != null) return border;
+    // ignore: deprecated_member_use_from_same_package
+    final color = borderColor;
+    if (color == null) return null;
+    // ignore: deprecated_member_use_from_same_package
+    return Border.all(color: color, width: borderWidth ?? 1.0);
   }
 
   /// Default theme that works well with Material Design.

--- a/lib/src/widgets/smart_tooltip_text.dart
+++ b/lib/src/widgets/smart_tooltip_text.dart
@@ -145,25 +145,8 @@ class SmartTooltipText extends StatelessWidget {
     // Get effective theme (use provided theme or default)
     final theme = tooltipTheme ?? DropdownTooltipTheme.defaultTheme;
 
-    // Build decoration from individual properties if not explicitly provided
-    Decoration? effectiveDecoration = theme.decoration;
-    if (effectiveDecoration == null &&
-        (theme.backgroundColor != null ||
-            theme.borderRadius != null ||
-            theme.borderColor != null ||
-            theme.shadow != null)) {
-      effectiveDecoration = BoxDecoration(
-        color: theme.backgroundColor,
-        borderRadius: theme.borderRadius,
-        border: theme.borderColor != null
-            ? Border.all(
-                color: theme.borderColor!,
-                width: theme.borderWidth ?? 1.0,
-              )
-            : null,
-        boxShadow: theme.shadow,
-      );
-    }
+    // Reading the brightness needs the element tree; deciding with it does not.
+    final style = theme.resolve(Theme.of(context).brightness);
 
     // Build text style from individual properties if not explicitly provided
     TextStyle? effectiveTextStyle = theme.textStyle;
@@ -180,7 +163,7 @@ class SmartTooltipText extends StatelessWidget {
       waitDuration: theme.waitDuration,
       showDuration: theme.showDuration,
       exitDuration: theme.exitDuration,
-      decoration: effectiveDecoration,
+      decoration: style.decoration,
       textStyle: effectiveTextStyle,
       textAlign: theme.textAlign,
       padding: theme.padding,

--- a/test/theme/tooltip_resolve_test.dart
+++ b/test/theme/tooltip_resolve_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// No widget tree, no `pumpWidget`, no `BuildContext`.
+
+BoxDecoration boxOf(DropdownTooltipTheme theme,
+        [Brightness brightness = Brightness.light]) =>
+    theme.resolve(brightness).decoration! as BoxDecoration;
+
+final grey700 = Colors.grey.shade700.withValues(alpha: 0.9);
+const radius4 = BorderRadius.all(Radius.circular(4));
+
+void main() {
+  test('a theme that names no box property leaves the decoration null', () {
+    expect(const DropdownTooltipTheme().resolve(Brightness.light).decoration,
+        isNull);
+  });
+
+  test('borderWidth alone names no box, because it draws nothing alone', () {
+    expect(
+      const DropdownTooltipTheme(borderWidth: 3)
+          .resolve(Brightness.light)
+          .decoration,
+      isNull,
+      reason: 'synthesising a box here would override an ambient TooltipTheme',
+    );
+  });
+
+  test('any one box property fills all the others', () {
+    final box = boxOf(DropdownTooltipTheme(borderRadius: BorderRadius.zero));
+
+    expect(box.color, grey700);
+    expect(box.borderRadius, BorderRadius.zero);
+    expect(box.border, isNull);
+    expect(box.boxShadow, isNull);
+  });
+
+  test('a background keeps the default radius', () {
+    final box = boxOf(const DropdownTooltipTheme(backgroundColor: Colors.red));
+
+    expect(box.color, Colors.red);
+    expect(box.borderRadius, radius4);
+  });
+
+  test('the default background follows the brightness', () {
+    final theme = DropdownTooltipTheme(borderRadius: BorderRadius.circular(8));
+
+    expect(boxOf(theme, Brightness.light).color, grey700);
+    expect(boxOf(theme, Brightness.dark).color,
+        Colors.white.withValues(alpha: 0.9));
+  });
+
+  test('an explicit background overrides the brightness default', () {
+    const theme = DropdownTooltipTheme(backgroundColor: Colors.red);
+
+    expect(boxOf(theme, Brightness.dark).color, Colors.red);
+  });
+
+  test('borderWidth defaults to one, and applies once a colour is given', () {
+    final thin = boxOf(const DropdownTooltipTheme(borderColor: Colors.red))
+        .border! as Border;
+    expect(thin.top.width, 1.0);
+
+    final thick = boxOf(const DropdownTooltipTheme(
+      borderColor: Colors.red,
+      borderWidth: 3,
+    )).border! as Border;
+    expect(thick.top.width, 3.0);
+  });
+
+  test('border takes a BoxBorder, like the other themes do', () {
+    final theme = DropdownTooltipTheme(
+      border: Border.all(color: Colors.blue, width: 2),
+    );
+
+    final border = boxOf(theme).border! as Border;
+    expect(border.top.color, Colors.blue);
+    expect(border.top.width, 2.0);
+    expect(boxOf(theme).color, grey700, reason: 'and it fills the box too');
+  });
+
+  test('border wins over the deprecated borderColor pair', () {
+    final theme = DropdownTooltipTheme(
+      border: Border.all(color: Colors.blue),
+      // ignore: deprecated_member_use_from_same_package
+      borderColor: Colors.red,
+    );
+
+    expect((boxOf(theme).border! as Border).top.color, Colors.blue);
+  });
+
+  test('an explicit decoration wins over every individual property', () {
+    const override = BoxDecoration(color: Colors.green);
+    const theme = DropdownTooltipTheme(
+      decoration: override,
+      backgroundColor: Colors.red,
+      borderColor: Colors.blue,
+    );
+
+    expect(theme.resolve(Brightness.light).decoration, same(override));
+  });
+}

--- a/test/tooltip_decoration_test.dart
+++ b/test/tooltip_decoration_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Observed at the public seam: the `Tooltip` the button renders.
+///
+/// Flutter's `Tooltip` treats a non-null `decoration` as a *total* replacement
+/// for its own default. A theme that sets one visual property must therefore
+/// still hand it a complete box, or the slots it left alone go blank.
+
+const _long = 'A label far too long for a narrow button';
+
+Future<Tooltip> pumpTooltip(
+  WidgetTester tester,
+  DropdownTooltipTheme tooltip, {
+  Brightness brightness = Brightness.light,
+}) async {
+  await tester.pumpWidget(MaterialApp(
+    theme: ThemeData(brightness: brightness),
+    home: Scaffold(
+      body: Center(
+        child: FlutterDropdownButton<String>.text(
+          width: 140,
+          items: const [_long],
+          value: _long,
+          disableWhenSingleItem: false,
+          theme: DropdownStyleTheme(tooltip: tooltip),
+          onChanged: (_) {},
+        ),
+      ),
+    ),
+  ));
+  await tester.pumpAndSettle();
+  return tester.widget<Tooltip>(find.byType(Tooltip).first);
+}
+
+BoxDecoration boxOf(Tooltip tooltip) => tooltip.decoration! as BoxDecoration;
+
+void main() {
+  testWidgets('a rounded tooltip still has a background', (tester) async {
+    final tooltip = await pumpTooltip(
+      tester,
+      DropdownTooltipTheme(borderRadius: BorderRadius.circular(8)),
+    );
+
+    expect(boxOf(tooltip).borderRadius, BorderRadius.circular(8));
+    expect(
+      boxOf(tooltip).color,
+      isNotNull,
+      reason: 'setting the radius must not erase the default background',
+    );
+  });
+
+  testWidgets('a recoloured tooltip keeps its rounded corners', (tester) async {
+    final tooltip = await pumpTooltip(
+      tester,
+      const DropdownTooltipTheme(backgroundColor: Colors.black87),
+    );
+
+    expect(boxOf(tooltip).color, Colors.black87);
+    expect(
+      boxOf(tooltip).borderRadius,
+      const BorderRadius.all(Radius.circular(4)),
+      reason: "the corners Flutter's own tooltip has",
+    );
+  });
+
+  testWidgets('a shadow does not blank the box', (tester) async {
+    const shadow = [BoxShadow(color: Colors.black26, blurRadius: 8)];
+    final tooltip =
+        await pumpTooltip(tester, const DropdownTooltipTheme(shadow: shadow));
+
+    expect(boxOf(tooltip).boxShadow, shadow);
+    expect(boxOf(tooltip).color, isNotNull);
+    expect(boxOf(tooltip).borderRadius, isNotNull);
+  });
+
+  testWidgets('a border does not blank the box', (tester) async {
+    final tooltip = await pumpTooltip(
+      tester,
+      const DropdownTooltipTheme(borderColor: Colors.red, borderWidth: 3),
+    );
+
+    final border = boxOf(tooltip).border! as Border;
+    expect(border.top.color, Colors.red);
+    expect(border.top.width, 3);
+    expect(boxOf(tooltip).color, isNotNull);
+  });
+
+  testWidgets('the default background flips with the ambient brightness',
+      (tester) async {
+    final light = await pumpTooltip(
+      tester,
+      DropdownTooltipTheme(borderRadius: BorderRadius.circular(8)),
+    );
+    final dark = await pumpTooltip(
+      tester,
+      DropdownTooltipTheme(borderRadius: BorderRadius.circular(8)),
+      brightness: Brightness.dark,
+    );
+
+    expect(boxOf(light).color, isNot(boxOf(dark).color));
+    expect(boxOf(dark).color, Colors.white.withValues(alpha: 0.9));
+  });
+
+  testWidgets('an unstyled tooltip leaves the box to Flutter', (tester) async {
+    // Guard, not a regression test: this passed before the fix too. It pins
+    // the reason `resolve()` returns a nullable decoration — an app-wide
+    // `TooltipTheme` must still win when this theme names no box property.
+    final tooltip = await pumpTooltip(tester, const DropdownTooltipTheme());
+
+    expect(tooltip.decoration, isNull);
+  });
+
+  testWidgets('an explicit decoration is a total override', (tester) async {
+    // Guard: `decoration` has always bypassed the individual properties, and
+    // must keep doing so even though they now carry defaults.
+    const override = BoxDecoration(color: Colors.green);
+    final tooltip = await pumpTooltip(
+      tester,
+      DropdownTooltipTheme(
+        decoration: override,
+        backgroundColor: Colors.black87,
+        borderRadius: BorderRadius.circular(8),
+      ),
+    );
+
+    expect(tooltip.decoration, same(override));
+  });
+}


### PR DESCRIPTION
Closes #32.

## The bug

`SmartTooltipText` synthesised a `BoxDecoration` as soon as one of `backgroundColor`, `borderRadius`, `borderColor` or `shadow` was set, and handed it to Flutter's `Tooltip`. But `Tooltip` treats a non-null `decoration` as a **total replacement** for its default, not a merge — so every slot the caller did not restate came out blank.

```dart
DropdownTooltipTheme(borderRadius: BorderRadius.circular(8))
// → BoxDecoration(color: null, ...) → a transparent tooltip. White text on nothing.
```

Same for `shadow` alone and `borderColor` alone. Even the happy path in this class's own dartdoc — `backgroundColor: Colors.black87` — silently squared off the corners Flutter rounds to 4px.

## The fix

`DropdownTooltipTheme` now resolves itself, like the other three themes after #5 and #26.

- `DropdownTooltipTheme.resolve(Brightness)` → `ResolvedTooltipStyle`.
- Naming **any** box property hands the theme the whole box; the rest fall back to `Tooltip`'s own defaults.
- Naming **none** returns a null decoration, so an app-wide `TooltipTheme` still wins. That nullability is deliberate and now pinned by a test.
- `SmartTooltipText` reads the resolved style; the inline `if` blocks are gone.

`resolve()` takes a `Brightness` rather than a `DropdownAmbientColors`, which is the one place the issue was wrong: a tooltip's defaults come from `Tooltip` itself, which switches on brightness alone and never consults `ThemeData`'s palette.

### Border modelling, additively

`DropdownTooltipTheme` was the only theme to model its border as `borderColor` + `borderWidth` rather than a `BoxBorder` — the one duplication #9 correctly identified before it was closed.

- Added `border: BoxBorder?`, which wins over the pair.
- Deprecated `borderColor` and `borderWidth`, removed in 3.0.0 alongside #7.

Annotated on the field, the constructor parameter **and** the `copyWith` parameter — `@Deprecated` does not propagate from a field to its initializing formal. Verified from `example/`, a separate package: all four call sites warn, `border:` is silent.

## Tests

107, up from 90.

- `test/theme/tooltip_resolve_test.dart` — 10 tests, no widget tree.
- `test/tooltip_decoration_test.dart` — 7 tests at the rendered `Tooltip`.

Five of the seven widget tests were confirmed **red** against the unfixed `lib/` before being trusted. The two that were not are labelled in the source as guards rather than regression tests: `decoration` has always been a total override, and an unstyled theme has always passed `null`.

Before this PR, no test in the suite constructed a `DropdownTooltipTheme` at all. That is why this survived.

## Scope

Non-breaking. Additive (`resolve()`, `ResolvedTooltipStyle`, `border`), two deprecations, one bug fix. `flutter analyze` clean, `dart format` clean, `flutter pub publish --dry-run` reports 0 warnings.

Also corrected three dartdoc claims that were false: Flutter's default tooltip has no shadow, and its background follows the ambient brightness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)