### PR TITLE
Choose the rendering mode once, behind a DropdownItemPresentation seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Removes everything deprecated during the 2.x line. Nothing was renamed and no behaviour changed — every removed member already had a replacement that was doing the work. **If you only ever used `FlutterDropdownButton`, nothing here affects you.**
 
-The deprecations landed across 2.3.2, 2.4.0, 2.4.1 and 2.5.0. Upgrading straight from an earlier 2.x skips the versions that warned, so the table below is the warning.
+The deprecations landed across 2.3.2, 2.4.0, 2.4.1 and 2.5.0. Upgrading straight from an earlier 2.x skips the versions that warned, so the list below is the warning.
 
 * **BREAKING**: Removed `DropdownMixin<T>`. Hold a `DropdownOverlayController` instead of mixing one in — the twenty-three members the mixin asked you to override collapse into one `DropdownOverlaySpec`. Deprecated in 2.4.0
 * **BREAKING**: Removed `DropdownMixin.calculateMenuWidth()` and `DropdownMixin.calculateMenuLeftPosition()`. Use `DropdownPlacement.resolve()`, which returns the menu's full geometry in one call. Deprecated in 2.3.2
@@ -12,7 +12,11 @@ The deprecations landed across 2.3.2, 2.4.0, 2.4.1 and 2.5.0. Upgrading straight
 * **BREAKING**: Removed `DropdownTheme.animationDuration`. Nothing ever read it; setting it did nothing. Pass `animationDuration` to `FlutterDropdownButton`. If you were setting it on the theme your menus animated at 200ms and still do — move the value across only if you actually wanted the slower animation. Deprecated in 2.4.1
 * **BREAKING**: Removed `DropdownTooltipTheme.borderColor` and `DropdownTooltipTheme.borderWidth`. Use `border`, which takes any `BoxBorder`: `DropdownTooltipTheme(border: Border.all(color: Colors.red, width: 2))`. Deprecated in 2.5.0
 * **CHANGE**: `lib/src/buttons/dropdown_mixin.dart` is gone, and with it the last `@Deprecated` annotation in the package
-* **TEST**: 103 tests, down from 107. Four guarded members that no longer exist. One of them — "a tooltip `borderWidth` with no `borderColor` draws nothing" — is now unrepresentable rather than untested: a `BoxBorder` cannot carry a width without a colour
+* **FEAT**: Added `DropdownItemPresentation<T>`, with `TextItemPresentation` and `CustomItemPresentation` behind it. Anyone building a dropdown on `DropdownOverlayController` can reuse `TextItemPresentation` and get overflow handling, the tooltip and the default search filter for free, rather than reimplementing them
+* **REFACTOR**: The widget no longer branches on `isTextMode`. Rendering is chosen once, in one factory; eight consult sites became zero, and four private render methods left `flutter_dropdown_button.dart` (1291 → 1166 lines). A third rendering mode is now a third implementation and a third branch in that factory, not another conditional at every render site
+* **CHANGE**: `isTextMode` remains public but is informational — nothing inside the widget reads it
+* **CHANGE**: The `label`-or-`String` invariant is now asserted by `TextItemPresentation` rather than in `initState`, so it fires on the first build. Still before anything paints, still an `AssertionError` in debug builds
+* **TEST**: 113 tests, up from 107. Four guarded members that no longer exist and were deleted; ten new ones exercise the presentation seam with no widget tree. One deletion is worth naming: "a tooltip `borderWidth` with no `borderColor` draws nothing" is now unrepresentable rather than untested, because a `BoxBorder` cannot carry a width without a colour
 * **DOCS**: `documentation/migration.md` gains a 2.x → 3.0.0 section. `api_reference.md` no longer documents `DropdownMixin`, and its `closeAll()` section no longer claims the call is unanimated or that only one menu can be open process-wide — both stopped being true in 2.4.0
 
 ## 2.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The two are distinguished internally by `isTextMode`, which is `itemBuilder == n
 
 ## Core Architecture
 
-The widget is a thin shell over three modules, each of which takes plain values and can be tested without mounting a widget.
+The widget is a thin shell over four modules, each of which takes plain values rather than a `BuildContext`.
 
 ### `DropdownPlacement` — `lib/src/placement/`
 
@@ -34,6 +34,16 @@ Owns the overlay's lifetime, the open/close animation, the widget tree the menu 
 It takes a `DropdownOverlaySpec` **callback**, not a value — the item count, the theme and the search field's height change while the menu is open, and `measurePlacement()` re-reads them on every overlay build. That is why an open menu re-sizes when its items change, and flips above the button when the taller menu no longer fits below.
 
 Single-open coordination lives in a registry keyed by `Overlay`, not in a process-wide static.
+
+### `DropdownItemPresentation` — `lib/src/presentation/`
+
+How items and the button's face are drawn. `TextItemPresentation` renders through a `label` and gains overflow handling, the tooltip and a default search filter; `CustomItemPresentation` calls `itemBuilder`.
+
+The widget decides the mode **once**, in the `_presentation` getter, and every render site asks the result what to draw. It does not ask itself which constructor was used. `isTextMode` survives as a public informational getter that nothing branches on.
+
+A presentation takes plain values and no `BuildContext` — the resolved icon size, not a `ResolvedButtonStyle`; a `DropdownTooltipTheme`, not a `Theme.of`. It holds the invariants of its own mode: `TextItemPresentation` asserts that `label` is present unless `T` is `String`, which is a promise `.text()` makes and the default constructor knows nothing about.
+
+A third mode — grouped items, sections, multi-select — is a third implementation and a third branch in that one getter.
 
 ### Theme resolution — `lib/src/theme/`
 
@@ -65,7 +75,7 @@ When you deprecate a member, annotate the **field, the constructor parameter and
 
 ```bash
 flutter pub get              # install dependencies
-flutter test                 # run the suite (103 tests)
+flutter test                 # run the suite (113 tests)
 flutter analyze              # static analysis; must be clean
 dart format .                # formatting; must produce no changes
 flutter pub publish --dry-run   # validate the package before release
@@ -75,13 +85,14 @@ cd example && flutter run    # run the playground app
 
 ## Testing
 
-103 tests. 56 of them run without mounting a widget at all.
+113 tests. 66 of them run without mounting a widget at all.
 
 | Suite | What it covers |
 | --- | --- |
 | `test/placement/` | The geometry module, exhaustively. No widgets. |
 | `test/theme/` | Every `resolve()`. No widgets. |
 | `test/overlay/` | The controller's lifecycle. No widgets. |
+| `test/presentation/` | Alignment, the default filter, label extraction. No widgets. |
 | `test/overlay_bounds_test.dart` | Menus near screen edges, and inside a nested `Overlay` |
 | `test/overlay_resize_test.dart` | An open menu growing, shrinking, and flipping |
 | `test/overlay_lifecycle_test.dart` | Single-open, `closeAll`, dispose |
@@ -108,6 +119,8 @@ lib/
     ├── placement/dropdown_placement.dart # pure geometry
     ├── overlay/
     │   └── dropdown_overlay_controller.dart  # overlay lifetime, animation, spec
+    ├── presentation/
+    │   └── item_presentation.dart         # text vs custom rendering, behind one interface
     ├── theme/
     │   ├── dropdown_style_theme.dart     # composes the four below
     │   ├── dropdown_theme.dart           # + resolveButton/Overlay/Item

--- a/lib/flutter_dropdown_button.dart
+++ b/lib/flutter_dropdown_button.dart
@@ -3,6 +3,7 @@ library;
 export 'src/flutter_dropdown_button.dart';
 export 'src/buttons/menu_alignment.dart';
 export 'src/overlay/dropdown_overlay_controller.dart';
+export 'src/presentation/item_presentation.dart';
 export 'src/config/text_dropdown_config.dart';
 export 'src/theme/dropdown_scroll_theme.dart';
 export 'src/theme/dropdown_style_theme.dart';

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -4,6 +4,7 @@ import 'package:flutter/scheduler.dart';
 import 'buttons/menu_alignment.dart';
 import 'config/text_dropdown_config.dart';
 import 'overlay/dropdown_overlay_controller.dart';
+import 'presentation/item_presentation.dart';
 import 'theme/dropdown_scroll_theme.dart';
 import 'theme/dropdown_style_theme.dart';
 import 'theme/dropdown_theme.dart';
@@ -324,7 +325,12 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   /// ```
   final Widget Function(String query)? emptyBuilder;
 
-  /// Whether this dropdown uses text mode rendering.
+  /// Whether this dropdown was built by [FlutterDropdownButton.text].
+  ///
+  /// Informational. Nothing inside the widget branches on this: rendering is
+  /// chosen once, by building a `DropdownItemPresentation`, and every render
+  /// site asks that what to draw. Adding a third mode therefore does not add a
+  /// third answer here.
   bool get isTextMode => itemBuilder == null;
 
   /// Closes all currently open dropdown overlays.
@@ -400,24 +406,35 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   TextDropdownConfig get _textConfig =>
       widget.config ?? TextDropdownConfig.defaultConfig;
 
-  /// The text to display for [item] in text mode.
+  /// How this dropdown draws its items and its button face.
   ///
-  /// Uses [FlutterDropdownButton.label] when given. Without it, `T` must be
-  /// [String] — a string is its own label.
-  String _labelOf(T item) {
-    final label = widget.label;
-    if (label != null) return label(item);
-    if (item is String) return item;
+  /// **The one place the rendering mode is decided.** Everything downstream
+  /// asks the presentation what to draw rather than asking which constructor
+  /// was used. A third mode is a third implementation and a third branch here,
+  /// not another conditional at every render site.
+  DropdownItemPresentation<T> get _presentation {
+    final itemBuilder = widget.itemBuilder;
+    if (itemBuilder != null) {
+      return CustomItemPresentation<T>(
+        itemBuilder: itemBuilder,
+        items: widget.items,
+        value: widget.value,
+        selectedBuilder: widget.selectedBuilder,
+        hintWidget: widget.hintWidget,
+      );
+    }
 
-    throw FlutterError(
-      'FlutterDropdownButton<$T>.text() needs a `label` callback.\n'
-      'Text mode renders items as text, so it must know how to turn a $T '
-      'into a String. Supply one:\n\n'
-      '  FlutterDropdownButton<$T>.text(\n'
-      '    items: items,\n'
-      '    label: (item) => item.someTextProperty,\n'
-      '  )\n\n'
-      '`label` may only be omitted when T is String.',
+    return TextItemPresentation<T>(
+      label: widget.label,
+      value: widget.value,
+      hintText: widget.hintText,
+      config: _textConfig,
+      tooltipTheme: effectiveTooltipTheme,
+      enabled: isEnabled,
+      leadingHeight: _buttonStyle.iconSize,
+      leading: widget.leading,
+      selectedLeading: widget.selectedLeading,
+      leadingPadding: widget.leadingPadding,
     );
   }
 
@@ -483,16 +500,11 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
 
   /// Case-insensitive `contains` over the item's label. The default in text
   /// mode, whatever `T` is.
-  bool _defaultTextFilter(T item, String query) {
-    return _labelOf(item).toLowerCase().contains(query.toLowerCase());
-  }
-
   /// The items [query] leaves visible. A pure function of its arguments.
   List<T> _applyFilter(List<T> items, String query) {
     if (query.isEmpty) return List<T>.from(items);
 
-    final filter =
-        widget.searchFilter ?? (widget.isTextMode ? _defaultTextFilter : null);
+    final filter = widget.searchFilter ?? _presentation.defaultSearchFilter;
     if (filter == null) return List<T>.from(items);
 
     return items.where((item) => filter(item, query)).toList();
@@ -519,13 +531,8 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   @override
   void initState() {
     super.initState();
-    assert(
-      !widget.isTextMode || widget.label != null || T == String,
-      'FlutterDropdownButton<$T>.text() needs a `label` callback.\n'
-      'Text mode renders items as text, so it must know how to turn a $T '
-      'into a String. Supply `label: (item) => item.someTextProperty`, or '
-      'use the default constructor with `itemBuilder` instead.',
-    );
+    // The `label`-or-String invariant is asserted by TextItemPresentation,
+    // which is built during the first build — still before anything paints.
     _autoSelectSingleItem();
     if (widget.searchable) {
       _searchController = TextEditingController();
@@ -645,6 +652,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     final rowHeight = effectiveContentHeight > effectiveIconSize
         ? effectiveContentHeight
         : effectiveIconSize;
+    final presentation = _presentation;
 
     return SizedBox(
       height: rowHeight,
@@ -662,17 +670,13 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
               height: effectiveContentHeight,
               child: widget.width != null || widget.expand
                   ? Container(
-                      alignment: widget.isTextMode
-                          ? _alignmentFromTextAlign(_textConfig.textAlign)
-                          : Alignment.centerLeft,
-                      child: _buildSelectedWidget(),
+                      alignment: presentation.contentAlignment,
+                      child: presentation.buildSelected(),
                     )
                   : Align(
-                      alignment: widget.isTextMode
-                          ? _alignmentFromTextAlign(_textConfig.textAlign)
-                          : Alignment.centerLeft,
+                      alignment: presentation.contentAlignment,
                       widthFactor: 1.0,
-                      child: _buildSelectedWidget(),
+                      child: presentation.buildSelected(),
                     ),
             ),
           ),
@@ -718,115 +722,6 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     return child;
   }
 
-  // ===== Selected widget rendering =====
-
-  Widget _buildSelectedWidget() {
-    if (widget.isTextMode) {
-      return _buildTextSelectedWidget();
-    }
-    return _buildCustomSelectedWidget();
-  }
-
-  Widget _buildCustomSelectedWidget() {
-    final value = widget.value;
-    if (value != null && widget.items.contains(value)) {
-      if (widget.selectedBuilder != null) {
-        return widget.selectedBuilder!(value);
-      }
-      return widget.itemBuilder!(value, true);
-    }
-    return widget.hintWidget ?? const SizedBox.shrink();
-  }
-
-  Widget _buildTextSelectedWidget() {
-    final selected = widget.value;
-    final selectedText = selected == null ? null : _labelOf(selected);
-    final displayText = selectedText ?? widget.hintText ?? '';
-    final isHint = selectedText == null;
-
-    final baseStyle = isHint ? _textConfig.hintStyle : _textConfig.textStyle;
-    final resolvedStyle = !isEnabled && _textConfig.disabledTextStyle != null
-        ? (baseStyle?.merge(_textConfig.disabledTextStyle) ??
-            _textConfig.disabledTextStyle)
-        : baseStyle;
-
-    final textWidget = SmartTooltipText(
-      text: displayText,
-      tooltipTheme: effectiveTooltipTheme,
-      style: resolvedStyle,
-      textAlign: _textConfig.textAlign,
-      maxLines: _textConfig.maxLines,
-      overflow: _textConfig.overflow,
-      softWrap: _textConfig.softWrap,
-      textDirection: _textConfig.textDirection,
-      locale: _textConfig.locale,
-      textScaler: _textConfig.textScaler,
-    );
-
-    final leadingWidget = selectedText != null
-        ? (widget.selectedLeading ?? widget.leading)
-        : null;
-
-    if (leadingWidget == null) return textWidget;
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Padding(
-          padding: widget.leadingPadding ?? const EdgeInsets.only(right: 8.0),
-          child: SizedBox(
-            height: _buttonStyle.iconSize,
-            child: Center(child: leadingWidget),
-          ),
-        ),
-        Flexible(child: textWidget),
-      ],
-    );
-  }
-
-  // ===== Item widget rendering =====
-
-  Widget _buildItemWidget(T item, bool isSelected) {
-    if (widget.isTextMode) {
-      return _buildTextItemWidget(item, isSelected);
-    }
-    return widget.itemBuilder!(item, isSelected);
-  }
-
-  Widget _buildTextItemWidget(T item, bool isSelected) {
-    final textWidget = SmartTooltipText(
-      text: _labelOf(item),
-      tooltipTheme: effectiveTooltipTheme,
-      style: isSelected
-          ? _textConfig.selectedTextStyle ?? _textConfig.textStyle
-          : _textConfig.textStyle,
-      textAlign: _textConfig.textAlign,
-      maxLines: _textConfig.maxLines,
-      overflow: _textConfig.overflow,
-      softWrap: _textConfig.softWrap,
-      textDirection: _textConfig.textDirection,
-      locale: _textConfig.locale,
-      textScaler: _textConfig.textScaler,
-      semanticsLabel: _textConfig.semanticsLabel,
-    );
-
-    if (widget.leading == null) return textWidget;
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Padding(
-          padding: widget.leadingPadding ?? const EdgeInsets.only(right: 8.0),
-          child: SizedBox(
-            height: _buttonStyle.iconSize,
-            child: Center(child: widget.leading!),
-          ),
-        ),
-        Flexible(child: textWidget),
-      ],
-    );
-  }
-
   // ===== Overlay content =====
 
   Widget _buildOverlayContent(double height) {
@@ -841,9 +736,8 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
             .clamp(0.0, double.infinity);
     final totalItemsHeight = items.length * actualItemHeight;
     final needsScroll = totalItemsHeight > availableContentHeight;
-    final itemAlignment = widget.isTextMode
-        ? _alignmentFromTextAlign(_textConfig.textAlign)
-        : Alignment.centerLeft;
+    final presentation = _presentation;
+    final itemAlignment = presentation.contentAlignment;
 
     Widget content;
 
@@ -892,7 +786,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
               isFirst: index == 0,
               isLast: index == items.length - 1,
               alignment: itemAlignment,
-              child: _buildItemWidget(item, isSelected),
+              child: presentation.buildItem(item, isSelected),
             );
           },
         ),
@@ -917,7 +811,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
             isFirst: index == 0,
             isLast: index == items.length - 1,
             alignment: itemAlignment,
-            child: _buildItemWidget(item, isSelected),
+            child: presentation.buildItem(item, isSelected),
           ),
         );
       }
@@ -983,20 +877,6 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     }
 
     return field;
-  }
-
-  Alignment _alignmentFromTextAlign(TextAlign textAlign) {
-    switch (textAlign) {
-      case TextAlign.center:
-        return Alignment.center;
-      case TextAlign.right:
-      case TextAlign.end:
-        return Alignment.centerRight;
-      case TextAlign.left:
-      case TextAlign.start:
-      case TextAlign.justify:
-        return Alignment.centerLeft;
-    }
   }
 
   Widget _buildItemWrapper({

--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+
+import '../config/text_dropdown_config.dart';
+import '../theme/tooltip_theme.dart';
+import '../widgets/smart_tooltip_text.dart';
+
+/// Decides whether [item] survives a search for [query].
+typedef DropdownSearchFilter<T> = bool Function(T item, String query);
+
+/// How a dropdown draws its items and the face of its button.
+///
+/// One implementation per rendering mode. The widget asks a presentation what
+/// to draw rather than asking itself what mode it is in, so a new mode is a new
+/// implementation rather than another branch at every render site.
+///
+/// A presentation is built fresh on each build and holds only plain values —
+/// no `State`, no `BuildContext`. Whatever it needs from the element tree, the
+/// widget reads first and hands over.
+abstract interface class DropdownItemPresentation<T> {
+  /// Where the button's face and each item row sit horizontally.
+  Alignment get contentAlignment;
+
+  /// The filter to use when the caller supplies no `searchFilter`.
+  ///
+  /// Null means this mode has no sensible default: it cannot know how to match
+  /// an arbitrary widget against a query.
+  DropdownSearchFilter<T>? get defaultSearchFilter;
+
+  /// One row of the open menu.
+  Widget buildItem(T item, bool isSelected);
+
+  /// The button's face: the selected item, or the hint when nothing is chosen.
+  Widget buildSelected();
+}
+
+/// Renders items as text, through a [label] extractor.
+///
+/// Text gains overflow handling, an automatic tooltip on overflow, and a
+/// default search filter — the three things [CustomItemPresentation] cannot
+/// offer, because it does not know what an item *says*.
+class TextItemPresentation<T> implements DropdownItemPresentation<T> {
+  /// Creates the text presentation.
+  ///
+  /// Asserts that [label] is present unless `T` is [String]; a string is its
+  /// own label. This is the invariant `.text()` promises and the default
+  /// constructor knows nothing about.
+  TextItemPresentation({
+    required this.label,
+    required this.value,
+    required this.hintText,
+    required this.config,
+    required this.tooltipTheme,
+    required this.enabled,
+    required this.leadingHeight,
+    this.leading,
+    this.selectedLeading,
+    this.leadingPadding,
+  }) : assert(
+          label != null || T == String,
+          'FlutterDropdownButton<$T>.text() needs a `label` callback.\n'
+          'Text mode renders items as text, so it must know how to turn a $T '
+          'into a String. Supply `label: (item) => item.someTextProperty`, or '
+          'use the default constructor with `itemBuilder` instead.',
+        );
+
+  /// Turns an item into the string that represents it.
+  final String Function(T item)? label;
+
+  /// The chosen item, if any.
+  final T? value;
+
+  /// Shown on the button when [value] is null.
+  final String? hintText;
+
+  /// Text rendering rules: overflow, alignment, styles.
+  final TextDropdownConfig config;
+
+  /// Styling and behaviour of the overflow tooltip.
+  final DropdownTooltipTheme tooltipTheme;
+
+  /// Whether the button is interactive, which selects the disabled text style.
+  final bool enabled;
+
+  /// The height a [leading] widget is centred within.
+  final double leadingHeight;
+
+  /// Drawn before the text of every item.
+  final Widget? leading;
+
+  /// Drawn before the text on the button face. Falls back to [leading].
+  final Widget? selectedLeading;
+
+  /// Space between a leading widget and the text.
+  final EdgeInsets? leadingPadding;
+
+  /// The text [item] displays.
+  ///
+  /// Uses [label] when given. Without it, `T` must be [String].
+  String labelOf(T item) {
+    final extract = label;
+    if (extract != null) return extract(item);
+    if (item is String) return item;
+
+    throw FlutterError(
+      'FlutterDropdownButton<$T>.text() needs a `label` callback.\n'
+      'Text mode renders items as text, so it must know how to turn a $T '
+      'into a String. Supply one:\n\n'
+      '  FlutterDropdownButton<$T>.text(\n'
+      '    items: items,\n'
+      '    label: (item) => item.someTextProperty,\n'
+      '  )\n\n'
+      '`label` may only be omitted when T is String.',
+    );
+  }
+
+  @override
+  Alignment get contentAlignment => _alignmentOf(config.textAlign);
+
+  @override
+  DropdownSearchFilter<T>? get defaultSearchFilter => (item, query) =>
+      labelOf(item).toLowerCase().contains(query.toLowerCase());
+
+  @override
+  Widget buildItem(T item, bool isSelected) {
+    final text = SmartTooltipText(
+      text: labelOf(item),
+      tooltipTheme: tooltipTheme,
+      style: isSelected
+          ? config.selectedTextStyle ?? config.textStyle
+          : config.textStyle,
+      textAlign: config.textAlign,
+      maxLines: config.maxLines,
+      overflow: config.overflow,
+      softWrap: config.softWrap,
+      textDirection: config.textDirection,
+      locale: config.locale,
+      textScaler: config.textScaler,
+      semanticsLabel: config.semanticsLabel,
+    );
+
+    return _withLeading(text, leading);
+  }
+
+  @override
+  Widget buildSelected() {
+    final selected = value;
+    final selectedText = selected == null ? null : labelOf(selected);
+    final displayText = selectedText ?? hintText ?? '';
+    final isHint = selectedText == null;
+
+    final baseStyle = isHint ? config.hintStyle : config.textStyle;
+    final resolvedStyle = !enabled && config.disabledTextStyle != null
+        ? (baseStyle?.merge(config.disabledTextStyle) ??
+            config.disabledTextStyle)
+        : baseStyle;
+
+    final text = SmartTooltipText(
+      text: displayText,
+      tooltipTheme: tooltipTheme,
+      style: resolvedStyle,
+      textAlign: config.textAlign,
+      maxLines: config.maxLines,
+      overflow: config.overflow,
+      softWrap: config.softWrap,
+      textDirection: config.textDirection,
+      locale: config.locale,
+      textScaler: config.textScaler,
+    );
+
+    // The hint never takes a leading widget; only a chosen item does.
+    return _withLeading(
+      text,
+      selectedText != null ? (selectedLeading ?? leading) : null,
+    );
+  }
+
+  Widget _withLeading(Widget text, Widget? leadingWidget) {
+    if (leadingWidget == null) return text;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: leadingPadding ?? const EdgeInsets.only(right: 8.0),
+          child: SizedBox(
+            height: leadingHeight,
+            child: Center(child: leadingWidget),
+          ),
+        ),
+        Flexible(child: text),
+      ],
+    );
+  }
+}
+
+/// Renders each item as whatever widget [itemBuilder] returns.
+class CustomItemPresentation<T> implements DropdownItemPresentation<T> {
+  /// Creates the custom-widget presentation.
+  const CustomItemPresentation({
+    required this.itemBuilder,
+    required this.items,
+    required this.value,
+    this.selectedBuilder,
+    this.hintWidget,
+  });
+
+  /// Builds one item row.
+  final Widget Function(T item, bool isSelected) itemBuilder;
+
+  /// The items on offer, consulted to decide whether [value] is still one.
+  final List<T> items;
+
+  /// The chosen item, if any.
+  final T? value;
+
+  /// Builds the button's face. Falls back to [itemBuilder].
+  final Widget Function(T item)? selectedBuilder;
+
+  /// Shown on the button when nothing is chosen.
+  final Widget? hintWidget;
+
+  @override
+  Alignment get contentAlignment => Alignment.centerLeft;
+
+  /// None. This mode cannot match an arbitrary widget against a query, so a
+  /// caller who wants search must supply `searchFilter` themselves.
+  @override
+  DropdownSearchFilter<T>? get defaultSearchFilter => null;
+
+  @override
+  Widget buildItem(T item, bool isSelected) => itemBuilder(item, isSelected);
+
+  @override
+  Widget buildSelected() {
+    final selected = value;
+    if (selected != null && items.contains(selected)) {
+      final build = selectedBuilder;
+      if (build != null) return build(selected);
+      return itemBuilder(selected, true);
+    }
+    return hintWidget ?? const SizedBox.shrink();
+  }
+}
+
+Alignment _alignmentOf(TextAlign textAlign) {
+  switch (textAlign) {
+    case TextAlign.center:
+      return Alignment.center;
+    case TextAlign.right:
+    case TextAlign.end:
+      return Alignment.centerRight;
+    case TextAlign.left:
+    case TextAlign.start:
+    case TextAlign.justify:
+      return Alignment.centerLeft;
+  }
+}

--- a/test/presentation/item_presentation_test.dart
+++ b/test/presentation/item_presentation_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// No widget tree, no `pumpWidget`, no `BuildContext`.
+///
+/// **Characterization, not regression.** None of these were ever red: they pin
+/// behaviour that already worked, extracted unchanged from private methods on
+/// the widget's `State`. What is new is that they are reachable at all — the
+/// alignment mapping and the default filter used to be observable only by
+/// rendering a menu and looking at it.
+
+class Fruit {
+  const Fruit(this.name);
+  final String name;
+}
+
+TextItemPresentation<T> text<T>({
+  String Function(T)? label,
+  T? value,
+  String? hintText,
+  TextDropdownConfig config = TextDropdownConfig.defaultConfig,
+}) {
+  return TextItemPresentation<T>(
+    label: label,
+    value: value,
+    hintText: hintText,
+    config: config,
+    tooltipTheme: DropdownTooltipTheme.defaultTheme,
+    enabled: true,
+    leadingHeight: 24,
+  );
+}
+
+CustomItemPresentation<T> custom<T>({
+  required List<T> items,
+  T? value,
+  Widget Function(T)? selectedBuilder,
+  Widget? hintWidget,
+}) {
+  return CustomItemPresentation<T>(
+    itemBuilder: (item, isSelected) => Text('$item'),
+    items: items,
+    value: value,
+    selectedBuilder: selectedBuilder,
+    hintWidget: hintWidget,
+  );
+}
+
+void main() {
+  group('content alignment', () {
+    Alignment alignmentFor(TextAlign textAlign) =>
+        text<String>(config: TextDropdownConfig(textAlign: textAlign))
+            .contentAlignment;
+
+    test('text mode follows the configured textAlign', () {
+      expect(alignmentFor(TextAlign.center), Alignment.center);
+      expect(alignmentFor(TextAlign.right), Alignment.centerRight);
+      expect(alignmentFor(TextAlign.end), Alignment.centerRight);
+      expect(alignmentFor(TextAlign.left), Alignment.centerLeft);
+      expect(alignmentFor(TextAlign.start), Alignment.centerLeft);
+      expect(alignmentFor(TextAlign.justify), Alignment.centerLeft);
+    });
+
+    test('custom mode is always left, whatever the text config says', () {
+      expect(custom<String>(items: const ['a']).contentAlignment,
+          Alignment.centerLeft);
+    });
+  });
+
+  group('default search filter', () {
+    test('text mode matches the label, case-insensitively', () {
+      final filter = text<Fruit>(label: (f) => f.name).defaultSearchFilter!;
+
+      expect(filter(const Fruit('Banana'), 'ban'), isTrue);
+      expect(filter(const Fruit('Banana'), 'NAN'), isTrue);
+      expect(filter(const Fruit('Apple'), 'ban'), isFalse);
+    });
+
+    test('custom mode has none — it cannot read a widget', () {
+      expect(custom<String>(items: const ['a']).defaultSearchFilter, isNull);
+    });
+  });
+
+  group('label extraction', () {
+    test('a String is its own label', () {
+      expect(text<String>().labelOf('Apple'), 'Apple');
+    });
+
+    test('any other T goes through the callback', () {
+      expect(text<Fruit>(label: (f) => f.name).labelOf(const Fruit('Kiwi')),
+          'Kiwi');
+    });
+
+    test('a non-String T without a label fails at construction', () {
+      expect(() => text<Fruit>(), throwsAssertionError,
+          reason: 'the invariant .text() promises, checked where it lives');
+    });
+  });
+
+  group('custom selected widget', () {
+    test('a value absent from items falls back to the hint', () {
+      final presentation = custom<String>(
+        items: const ['a', 'b'],
+        value: 'gone',
+        hintWidget: const Text('pick one'),
+      );
+
+      expect((presentation.buildSelected() as Text).data, 'pick one');
+    });
+
+    test('no value and no hint widget draws nothing', () {
+      expect(
+          custom<String>(items: const ['a']).buildSelected(), isA<SizedBox>());
+    });
+
+    test('selectedBuilder wins over itemBuilder for the button face', () {
+      final presentation = custom<String>(
+        items: const ['a'],
+        value: 'a',
+        selectedBuilder: (item) => Text('face:$item'),
+      );
+
+      expect((presentation.buildSelected() as Text).data, 'face:a');
+    });
+  });
+}


### PR DESCRIPTION
Closes #4.

## What changed

`isTextMode` was consulted at **eight** sites. It is now consulted at **zero**.

```dart
bool get isTextMode => itemBuilder == null;   // inferred from an empty field
```

Those eight sites made four decisions, and each is now a member of one interface:

| Old site | `DropdownItemPresentation<T>` |
|---|---|
| the default search filter | `defaultSearchFilter` |
| three alignment ternaries | `contentAlignment` |
| `_buildSelectedWidget()` | `buildSelected()` |
| `_buildItemWidget()` | `buildItem()` |

`TextItemPresentation` renders through a `label`; `CustomItemPresentation` calls `itemBuilder`. The widget picks one in a single factory and every render site asks the result what to draw.

A third mode — grouped items, sections, multi-select — is now a third implementation plus a third branch in one place, rather than another conditional at every render site plus more permanently-null fields.

`flutter_dropdown_button.dart`: 1291 → 1166 lines. The new module is 256.

## Not TDD, and how it was checked

A pure refactor has no red. The safety net was the 103 existing tests: if the seam changed behaviour, they would say so.

**All 103 pass, with zero edits to any test file.** That is the whole argument. It works because the suite asserts on what is *rendered* — the `BoxDecoration` on the button, the presence of a `ListView` — never on private methods. Those private methods are exactly what moved.

This is the third time the convention has paid: the controller extraction and the theme-resolution rewrite also landed without touching a test.

## Two things moved, not just relocated

**The `label` invariant now lives where it belongs.** It used to be an `assert` in `initState` re-checking what the constructors had already split apart:

```dart
!widget.isTextMode || widget.label != null || T == String
```

`TextItemPresentation`'s constructor asserts it instead — no `isTextMode` term, because a text presentation is the only thing that can be built without one. It fires on the first build rather than in `initState`, which is still before anything paints. `test/text_label_test.dart` passes unchanged.

**`_alignmentFromTextAlign` became testable.** It was private and, in five years, never directly tested. It is now `contentAlignment`, and `test/presentation/` pins all six `TextAlign` cases without a widget tree.

## Exported

`DropdownItemPresentation`, `TextItemPresentation` and `CustomItemPresentation` are public.

We already export `DropdownOverlayController` so third parties can build their own dropdown. Until now such a person had to reimplement overflow handling, the tooltip and the search filter from scratch. Now they hold a `TextItemPresentation` and get all three.

Folded into 3.0.0 rather than 3.1.0 — 3.0.0 has not reached pub. Its changelog entry no longer claims the release only removes things.

## Tests: 107 → 113

Ten new, all pure, all **characterization**: none of them was ever red, and the file says so. They pin behaviour extracted unchanged. What is new is that it is reachable at all.

`flutter analyze` clean (package and example), `dart format` clean, `flutter pub publish --dry-run` reports 0 warnings.

## What this does not do

`isTextMode` stays as a public getter, because removing it would be breaking and it is derived, so it cannot rot. Nothing inside the widget reads it, and its dartdoc now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)