### PR TITLE
semanticsLabel labels the dropdown, not every item in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.0
 
-Removes everything deprecated during the 2.x line. Nothing was renamed and no behaviour changed — every removed member already had a replacement that was doing the work. **If you only ever used `FlutterDropdownButton`, nothing here affects you.**
+Removes everything deprecated during the 2.x line. Nothing was renamed — every removed member already had a replacement that was doing the work. **If you only ever used `FlutterDropdownButton`, the only thing that changes for you is that `semanticsLabel` starts working.**
 
 The deprecations landed across 2.3.2, 2.4.0, 2.4.1 and 2.5.0. Upgrading straight from an earlier 2.x skips the versions that warned, so the list below is the warning.
 
@@ -11,13 +11,14 @@ The deprecations landed across 2.3.2, 2.4.0, 2.4.1 and 2.5.0. Upgrading straight
 * **BREAKING**: Removed `DropdownPositionResult` and `DropdownMixin.calculateDropdownPosition()`. Use `DropdownOverlayController.measurePlacement()`, which returns a `DropdownPlacementResult`
 * **BREAKING**: Removed `DropdownTheme.animationDuration`. Nothing ever read it; setting it did nothing. Pass `animationDuration` to `FlutterDropdownButton`. If you were setting it on the theme your menus animated at 200ms and still do — move the value across only if you actually wanted the slower animation. Deprecated in 2.4.1
 * **BREAKING**: Removed `DropdownTooltipTheme.borderColor` and `DropdownTooltipTheme.borderWidth`. Use `border`, which takes any `BoxBorder`: `DropdownTooltipTheme(border: Border.all(color: Colors.red, width: 2))`. Deprecated in 2.5.0
+* **FIX**: `TextDropdownConfig.semanticsLabel` now labels the dropdown, as it always claimed to. It was applied to **every menu item** and to nothing else — and `Text`'s semantics label *replaces* the announced string, so a screen reader read `"Fruit picker"` for the Apple row, the Banana row and the Cherry row alike, suppressing every item's name and leaving the menu unnavigable by voice. It now sits on the button, announced alongside the selected value (`"Fruit picker, Banana"`), and items announce their own text
 * **CHANGE**: `lib/src/buttons/dropdown_mixin.dart` is gone, and with it the last `@Deprecated` annotation in the package
 * **FEAT**: Added `DropdownItemPresentation<T>`, with `TextItemPresentation` and `CustomItemPresentation` behind it. Anyone building a dropdown on `DropdownOverlayController` can reuse `TextItemPresentation` and get overflow handling, the tooltip and the default search filter for free, rather than reimplementing them
 * **REFACTOR**: The widget no longer branches on `isTextMode`. Rendering is chosen once, in one factory; eight consult sites became zero, and four private render methods left `flutter_dropdown_button.dart` (1291 → 1166 lines). A third rendering mode is now a third implementation and a third branch in that factory, not another conditional at every render site
 * **REFACTOR**: The overlay's content area is now sized by `DropdownOverlaySpec.totalChromeHeight` rather than by re-adding the border, padding and search-field heights by hand. `DropdownPlacement` grows the menu by that same getter, so the grow and the shrink can no longer disagree — which is what they did in 2.3.2 and again in 2.5.0
 * **CHANGE**: `isTextMode` remains public but is informational — nothing inside the widget reads it
 * **CHANGE**: The `label`-or-`String` invariant is now asserted by `TextItemPresentation` rather than in `initState`, so it fires on the first build. Still before anything paints, still an `AssertionError` in debug builds
-* **TEST**: 113 tests, up from 107. Four guarded members that no longer exist and were deleted; ten new ones exercise the presentation seam with no widget tree. One deletion is worth naming: "a tooltip `borderWidth` with no `borderColor` draws nothing" is now unrepresentable rather than untested, because a `BoxBorder` cannot carry a width without a colour
+* **TEST**: 116 tests, up from 107. Four guarded members that no longer exist and were deleted; ten new ones exercise the presentation seam with no widget tree. One deletion is worth naming: "a tooltip `borderWidth` with no `borderColor` draws nothing" is now unrepresentable rather than untested, because a `BoxBorder` cannot carry a width without a colour
 * **DOCS**: `documentation/migration.md` gains a 2.x → 3.0.0 section. `api_reference.md` no longer documents `DropdownMixin`, and its `closeAll()` section no longer claims the call is unanimated or that only one menu can be open process-wide — both stopped being true in 2.4.0
 
 ## 2.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ When you deprecate a member, annotate the **field, the constructor parameter and
 
 ```bash
 flutter pub get              # install dependencies
-flutter test                 # run the suite (113 tests)
+flutter test                 # run the suite (116 tests)
 flutter analyze              # static analysis; must be clean
 dart format .                # formatting; must produce no changes
 flutter pub publish --dry-run   # validate the package before release
@@ -85,7 +85,7 @@ cd example && flutter run    # run the playground app
 
 ## Testing
 
-113 tests. 66 of them run without mounting a widget at all.
+116 tests. 66 of them run without mounting a widget at all.
 
 | Suite | What it covers |
 | --- | --- |
@@ -101,6 +101,7 @@ cd example && flutter run    # run the playground app
 | `test/text_label_test.dart` | `label` with a non-`String` `T` |
 | `test/theme_resolution_test.dart` | Resolution rules, observed at the rendered widget |
 | `test/tooltip_decoration_test.dart` | A partial tooltip theme keeping the box it did not name |
+| `test/semantics_label_test.dart` | What a screen reader hears, at the semantics tree |
 | `test/disabled_state_test.dart` | The disabled state, including single-item auto-disable |
 
 **Conventions that matter here:**

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -341,7 +341,7 @@ TextDropdownConfig({
 | `textDirection` | `TextDirection?` | null | Text direction |
 | `locale` | `Locale?` | null | Locale for text rendering |
 | `textScaler` | `TextScaler?` | null | Text scaler for accessibility |
-| `semanticsLabel` | `String?` | null | Semantic label for accessibility |
+| `semanticsLabel` | `String?` | null | Accessibility label for the **button**, announced alongside the selected value. Items announce their own text |
 
 ### Predefined Configurations
 

--- a/documentation/text_configuration.md
+++ b/documentation/text_configuration.md
@@ -279,6 +279,10 @@ TextDropdownConfig(
 )
 ```
 
+`semanticsLabel` describes the **button**. A screen reader announces it alongside
+the selected value — `"Fruit selection dropdown, Banana"` — not in place of it.
+Menu items are unaffected: each announces its own text.
+
 ### Locale-specific Rendering
 
 ```dart

--- a/lib/src/config/text_dropdown_config.dart
+++ b/lib/src/config/text_dropdown_config.dart
@@ -129,8 +129,11 @@ class TextDropdownConfig {
 
   /// A semantic description of the dropdown for accessibility.
   ///
-  /// Used by screen readers and other assistive technologies.
-  /// If null, no semantic label is provided.
+  /// Applied to the **button**, alongside the selected value rather than in
+  /// place of it: a screen reader announces `"Fruit picker, Banana"`.
+  ///
+  /// It does **not** label the items — each of those announces its own text.
+  /// If null, the button announces only its value.
   final String? semanticsLabel;
 
   /// Creates a copy of this config with the given fields replaced.

--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -136,9 +136,12 @@ class TextItemPresentation<T> implements DropdownItemPresentation<T> {
       textDirection: config.textDirection,
       locale: config.locale,
       textScaler: config.textScaler,
-      semanticsLabel: config.semanticsLabel,
     );
 
+    // `config.semanticsLabel` deliberately does not reach here. `Text`'s
+    // semantics label *replaces* the announced string, so applying one label to
+    // every row made a screen reader read the same phrase for all of them.
+    // It describes the dropdown, and it is applied in [buildSelected].
     return _withLeading(text, leading);
   }
 
@@ -169,10 +172,16 @@ class TextItemPresentation<T> implements DropdownItemPresentation<T> {
     );
 
     // The hint never takes a leading widget; only a chosen item does.
-    return _withLeading(
+    final face = _withLeading(
       text,
       selectedText != null ? (selectedLeading ?? leading) : null,
     );
+
+    // The label describes the control, so it goes on the control. Wrapping
+    // rather than passing it to `Text` keeps the selected value announced too.
+    final describe = config.semanticsLabel;
+    if (describe == null) return face;
+    return Semantics(label: describe, child: face);
   }
 
   Widget _withLeading(Widget text, Widget? leadingWidget) {

--- a/test/semantics_label_test.dart
+++ b/test/semantics_label_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Observed at the seam that matters for this field: the semantics tree, which
+/// is what a screen reader actually reads. Not the widget tree.
+
+class Fruit {
+  const Fruit(this.name);
+  final String name;
+}
+
+const apple = Fruit('Apple');
+const banana = Fruit('Banana');
+const cherry = Fruit('Cherry');
+
+Future<void> pumpDropdown(WidgetTester tester, {Fruit? value}) async {
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: Center(
+        child: FlutterDropdownButton<Fruit>.text(
+          width: 200,
+          items: const [apple, banana, cherry],
+          value: value,
+          label: (fruit) => fruit.name,
+          hint: 'Pick a fruit',
+          config: const TextDropdownConfig(semanticsLabel: 'Fruit picker'),
+          onChanged: (_) {},
+        ),
+      ),
+    ),
+  ));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('each item announces its own name, not the dropdown\'s label',
+      (tester) async {
+    final semantics = tester.ensureSemantics();
+    await pumpDropdown(tester);
+
+    await tester.tap(find.byType(FlutterDropdownButton<Fruit>));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Apple'), findsOneWidget);
+    expect(find.bySemanticsLabel('Banana'), findsOneWidget);
+    expect(find.bySemanticsLabel('Cherry'), findsOneWidget);
+
+    semantics.dispose();
+  });
+
+  testWidgets('the button announces the dropdown\'s purpose and its value',
+      (tester) async {
+    final semantics = tester.ensureSemantics();
+    await pumpDropdown(tester, value: banana);
+
+    // The button's descendants merge into one node, so a screen reader reads
+    // "Fruit picker, Banana" — what the control is for, then what it holds.
+    expect(find.bySemanticsLabel(RegExp('Fruit picker')), findsOneWidget);
+    expect(find.bySemanticsLabel(RegExp('Banana')), findsOneWidget,
+        reason: 'the label must not replace the selected value');
+
+    semantics.dispose();
+  });
+
+  testWidgets('an unlabelled dropdown announces only its value',
+      (tester) async {
+    // Guard, not a regression test: this passed before the fix too. It pins the
+    // other half of the fix — wrapping in `Semantics` only when asked to.
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: FlutterDropdownButton<Fruit>.text(
+            width: 200,
+            items: const [apple, banana],
+            value: banana,
+            label: (fruit) => fruit.name,
+            onChanged: (_) {},
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Banana'), findsOneWidget,
+        reason: 'exactly "Banana" — no stray Semantics node is added');
+
+    semantics.dispose();
+  });
+}


### PR DESCRIPTION
Closes #37.

## The bug

`TextDropdownConfig.semanticsLabel` documented itself as "a semantic description of the dropdown". It was applied to neither the dropdown nor anything else useful — it was passed to **every menu item's** `Text`.

`Text.semanticsLabel` *replaces* the announced string rather than adding to it. Measured on `main`, with `semanticsLabel: 'Fruit picker'` and three items:

```
"Fruit picker" nodes: 3
"Apple" nodes:        0
```

A screen reader announced `"Fruit picker"` for the Apple row, the Banana row and the Cherry row alike. Every item's name was suppressed and the menu could not be navigated by voice. Meanwhile the button — the control the label was written for — announced nothing beyond its visible text.

Both ends were backwards. It has been this way since the field was introduced.

## Why nobody noticed

The bug is invisible to every test that looks at what is *rendered*. `find.text('Apple')` passes: the word is on screen. Only the semantics tree disagrees, and nothing in this package had ever looked at it.

## The fix

`TextItemPresentation` stops passing `semanticsLabel` to item rows, and wraps the button's face in `Semantics(label: ...)` instead — wrapping rather than replacing, so the selected value is still announced:

```
"Fruit picker, Banana"
```

which is what the control is for, then what it holds.

## Tests

Three, at the semantics tree — the seam that matters for this field. Two were confirmed **red** against the unfixed `lib/`. The third is labelled in the source as a guard: it pins that no `Semantics` node is added when the caller asks for no label, which was already true.

Along the way the second test taught me something and I corrected it rather than the code: `find.bySemanticsLabel('Fruit picker')` found nothing even after the fix, because `InkWell` merges the button's descendants into one node whose label is `"Fruit picker\nBanana"`. The merged label *is* the contract, so the test now asserts that both strings are in it.

116 tests, up from 113.

## Behaviour change

Anyone who set `semanticsLabel` gets different screen-reader output. Recorded as a `FIX`, and the 3.0.0 preamble no longer claims the release changes no behaviour. The set of people relying on the old behaviour is empty by construction — it destroyed menu navigation.

Docs corrected in `text_configuration.md` and `api_reference.md`; the dartdoc now says where the label lands and that items are unaffected.

`flutter analyze` clean, `dart format` clean, `flutter pub publish --dry-run` reports 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)