### PR TITLE
100% line coverage, and raise the CI floor to match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       # under a threshold. Raise it when the number rises; never lower it to
       # make a red build green.
       - name: Coverage floor
-        run: dart run tool/check_coverage.dart --min 93.3 --report
+        run: dart run tool/check_coverage.dart --min 100 --report
 
       - name: Analyze the example
         working-directory: example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ Beware the dartdoc link. `See [trackWidth].` inside another member's doc comment
 CI(`.github/workflows/ci.yml`)가 매 PR 에서 돈다. **로컬 게이트는 CI 를 대신하지 않는다.**
 
 ```
-minimum (Flutter 3.32.0)   pub get / analyze / test --coverage / check_coverage / example analyze
+minimum (Flutter 3.32.0)   pub get / analyze / test --coverage / check_coverage --min 100 / example analyze
 stable  (Flutter stable)   같음
 package                    dart format --set-exit-if-changed  /  pub publish --dry-run
 ```
@@ -185,7 +185,8 @@ package                    dart format --set-exit-if-changed  /  pub publish --d
 - **`minimum` 잡이 핵심이다.** `stable` 만 돌리면 pubspec 이 `>=3.10` 을 약속하고 3.32 API 를 쓰는 상태가 **영원히 초록**이다. 실증(#47): 이 잡이 첫 실행에서 서로 다른 두 사실을 잡았다 — `Tooltip.constraints` 가 3.27/3.29 에 없음, 그리고 **analyzer 규칙이 버전마다 다름**(3.32 는 dartdoc 링크를 deprecated 사용으로 셈). *"로컬에서 analyze 클린"* 은 *"선언한 바닥에서 클린"* 을 전혀 보장하지 않는다.
 - **`flutter analyze` 는 `info` 하나에도 exit 1 이다.**
 - **`pub publish --dry-run` 은 컴파일하지 않는다.** 파일 크기·라이선스·문서·git 청결도만 본다. 이 세션의 PR 47 개 내내 경고 0 이었고, 그동안 pubspec 은 거짓말을 하고 있었다.
-- **커버리지 바닥은 현재 수치에 여유 없이 붙인다**(`--min 93.3`). 여유를 두면 딱 그 여유만큼의 회귀를 허용하고, 실제 회귀는 임계값 바로 아래에 앉는다. 숫자가 오르면 바닥을 올린다. 빨간 빌드를 초록으로 만들려고 내리지 않는다.
+- **커버리지 바닥은 100 이다.** 여유를 두면 딱 그 여유만큼의 회귀를 허용하고, 실제 회귀는 임계값 바로 아래에 앉는다. 실증: `test/selection_test.dart` 를 통째로 지우면 **99.57%** — 바닥이 99 였다면 통과했을 것이다. 빨간 빌드를 초록으로 만들려고 바닥을 내리지 않는다.
+- **덮을 수 없는 줄은 `// coverage:ignore-start` / `ignore-end` 로 감싼다.** 그 줄들은 미커버로 세는 게 아니라 **분모에서 빠진다**(프로브로 확인: `LF` 가 1 줄었고 `DA:` 목록에서 사라졌다). 예외가 조용한 침식이 아니라 diff 에 남는 명시적 편집이 된다. 유일한 적용처는 `TextItemPresentation.labelOf` 의 `throw` 로, 생성자 assert 가 debug 에서 먼저 터지므로 **release 전용 가드**임을 증명한 뒤 감쌌다.
 - **커버리지는 "무엇을 안 봤는지" 를 알려주지, "본 것이 옳은지" 는 말해주지 않는다.** 실증: 커버리지를 처음 켜자 `lib/` 80.6% 였고, 미커버의 대부분이 여섯 개 `copyWith` 였다. 그리고 **테스트 155 개 중 메뉴 항목을 탭하는 것이 하나도 없었다** — 이 위젯의 존재 이유인 상호작용이다. 배치·테마·오버레이·검색은 겹겹이 덮여 있었다.
 - **아카이브 내용을 ASCII 로 확인한다.** `pub publish --dry-run` 의 트리는 `├──` 를 쓴다. `|--` 로 grep 하면 무엇을 넣든 빈 결과가 나온다 — 어느 쪽이든 빈 결과가 나오는 검사는 검사가 아니다. 실증: `coverage/` 를 `.gitignore` 에 넣기 전 `lcov.info` 가 아카이브에 실려 있었고, `tool/` 도 그랬다. **둘 다 `dry-run` 경고 0 인 상태였다.** `tool/.pubignore` 와 `docs/.pubignore` 가 각각 막는다.
 - **`dart format` 은 패키지의 language version 을 따른다.** 실증: SDK 바닥을 Dart 3.8 로 올리자 3.7 의 tall style 이 켜지며 35 개 파일이 재포맷됐다. 제약 변경의 필연적 결과다.
@@ -196,9 +197,9 @@ package                    dart format --set-exit-if-changed  /  pub publish --d
 
 ```bash
 flutter pub get                                    # install dependencies
-flutter test                                       # 160 tests
+flutter test                                       # 207 tests
 flutter test --coverage                            # writes coverage/lcov.info
-dart run tool/check_coverage.dart --min 93.3 --report
+dart run tool/check_coverage.dart --min 100 --report
 flutter analyze                                    # exits 1 on a single `info`
 dart format --output=none --set-exit-if-changed .  # exits 1 if anything would change
 flutter pub publish --dry-run                      # metadata only; does not compile
@@ -211,7 +212,7 @@ cd example && flutter run                          # the playground app
 
 ## Testing
 
-160 tests, 93.35% line coverage. 96 of them run without mounting a widget at all.
+207 tests, **100% line coverage**. 98 of them run without mounting a widget at all.
 
 | Suite | What it covers |
 | --- | --- |
@@ -234,6 +235,12 @@ cd example && flutter run                          # the playground app
 | `test/disabled_state_test.dart` | The disabled state, including single-item auto-disable |
 | `test/selection_test.dart` | Tapping an item — the reason this widget exists |
 | `test/theme/copy_with_test.dart` | Every `copyWith`, preserving and replacing |
+| `test/leading_widget_test.dart` | `leading` / `selectedLeading`, sized to the icon |
+| `test/layout_and_empty_state_test.dart` | Width constraints, `expand`, "No results found" |
+| `test/scroll_to_selected_test.dart` | Jumping to the chosen row, or gliding to it |
+| `test/remaining_behaviours_test.dart` | Tooltip modes, runtime `searchable`, `isTextMode` |
+| `test/overlay_controller_widget_test.dart` | The controller driven bare, with its own chrome |
+| `test/last_four_lines_test.dart` | Unwrapped overflow; the gradient's controller swap |
 
 **Conventions that matter here:**
 

--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -96,11 +96,19 @@ class TextItemPresentation<T> implements DropdownItemPresentation<T> {
   /// The text [item] displays.
   ///
   /// Uses [label] when given. Without it, `T` must be [String].
+  ///
+  /// The throw below is a **release-mode guard**, and is unreachable in debug.
+  /// It fires when `label == null && item is! String`, which is exactly the
+  /// condition this class's constructor asserts against — and asserts are
+  /// compiled out of release builds. Coverage for it is therefore always zero,
+  /// and that is not a reason to delete it: without it a release build would
+  /// carry on with no label and fail somewhere less legible.
   String labelOf(T item) {
     final extract = label;
     if (extract != null) return extract(item);
     if (item is String) return item;
 
+    // coverage:ignore-start
     throw FlutterError(
       'FlutterDropdownButton<$T>.text() needs a `label` callback.\n'
       'Text mode renders items as text, so it must know how to turn a $T '
@@ -111,6 +119,7 @@ class TextItemPresentation<T> implements DropdownItemPresentation<T> {
       '  )\n\n'
       '`label` may only be omitted when T is String.',
     );
+    // coverage:ignore-end
   }
 
   @override

--- a/test/disabled_state_test.dart
+++ b/test/disabled_state_test.dart
@@ -19,7 +19,83 @@ Widget host(Widget child) => MaterialApp(
 Color? arrowColour(WidgetTester tester) =>
     tester.widget<Icon>(find.byType(Icon)).color;
 
+/// The style the button's face is drawn with.
+TextStyle? faceStyle(WidgetTester tester, String text) =>
+    tester.widget<Text>(find.text(text)).style;
+
 void main() {
+  group('disabledTextStyle merges over the base style', () {
+    // `merge` keeps what the disabled style does not name. Replacing instead
+    // would silently drop the caller's font size the moment they disabled the
+    // button — the kind of change nobody writes a bug report for.
+    const base = TextStyle(fontSize: 20, fontWeight: FontWeight.bold);
+    const disabled = TextStyle(color: disabledIcon);
+
+    Widget dropdown({required bool enabled, String? value}) =>
+        FlutterDropdownButton<String>.text(
+          width: 200,
+          items: const ['Apple', 'Banana'],
+          value: value,
+          hint: 'Pick a fruit',
+          enabled: enabled,
+          config: const TextDropdownConfig(
+            textStyle: base,
+            hintStyle: base,
+            disabledTextStyle: disabled,
+          ),
+          onChanged: (_) {},
+        );
+
+    testWidgets('an enabled button keeps the base style untouched', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(dropdown(enabled: true, value: 'Apple')));
+
+      final style = faceStyle(tester, 'Apple')!;
+      expect(style.color, isNull, reason: 'the disabled colour never applied');
+      expect(style.fontSize, 20);
+    });
+
+    testWidgets('a disabled value takes the colour and keeps its size', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(dropdown(enabled: false, value: 'Apple')));
+
+      final style = faceStyle(tester, 'Apple')!;
+      expect(style.color, disabledIcon);
+      expect(style.fontSize, 20, reason: 'merged, not replaced');
+      expect(style.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('a disabled hint merges over hintStyle', (tester) async {
+      await tester.pumpWidget(host(dropdown(enabled: false)));
+
+      final style = faceStyle(tester, 'Pick a fruit')!;
+      expect(style.color, disabledIcon);
+      expect(style.fontSize, 20);
+    });
+
+    testWidgets('with no base style, the disabled style stands alone', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            width: 200,
+            items: const ['Apple'],
+            value: 'Apple',
+            enabled: false,
+            disableWhenSingleItem: false,
+            config: const TextDropdownConfig(disabledTextStyle: disabled),
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(faceStyle(tester, 'Apple')!.color, disabledIcon);
+    });
+  });
+
   group('the arrow icon agrees with the rest of the button', () {
     testWidgets('enabled dropdown draws the enabled icon colour', (
       tester,

--- a/test/last_four_lines_test.dart
+++ b/test/last_four_lines_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+// `ScrollGradientOverlay` is internal. The dropdown never swaps its
+// `ScrollController`, so `didUpdateWidget`'s swap branch cannot be reached
+// through the public API — but it is a real guard, and it is tested here
+// rather than deleted or ignored.
+import 'package:flutter_dropdown_button/src/widgets/scroll_gradient_overlay.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The last two behaviours #56 left uncovered.
+///
+/// Neither is unreachable. The issue guessed one of them was a `catch` that
+/// only fires in production; reading the source rather than trusting the line
+/// number showed it is the unwrapped-overflow branch instead.
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  group('overflow detection without maxLines', () {
+    // `maxLines: null` means `didExceedMaxLines` can never be true, so the
+    // widget measures the unconstrained width instead. `softWrap: false` is
+    // what makes that measurement meaningful: wrapped text never overruns.
+    const unwrapped = TextDropdownConfig(
+      maxLines: null,
+      softWrap: false,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    Widget dropdown(String label, {double width = 120}) =>
+        FlutterDropdownButton<String>.text(
+          width: width,
+          items: [label],
+          value: label,
+          disableWhenSingleItem: false,
+          config: unwrapped,
+          onChanged: (_) {},
+        );
+
+    testWidgets('text wider than the button gets a tooltip', (tester) async {
+      await tester.pumpWidget(
+        host(dropdown('A preposterously long label that will not fit')),
+      );
+
+      expect(find.byType(Tooltip), findsWidgets);
+    });
+
+    testWidgets('text that fits gets none', (tester) async {
+      await tester.pumpWidget(host(dropdown('Ok', width: 300)));
+
+      expect(find.byType(Tooltip), findsNothing);
+    });
+  });
+
+  testWidgets('the scroll gradient follows a new ScrollController', (
+    tester,
+  ) async {
+    final first = ScrollController();
+    final second = ScrollController();
+    addTearDown(first.dispose);
+    addTearDown(second.dispose);
+
+    Widget overlay(ScrollController controller) => host(
+      SizedBox(
+        height: 100,
+        width: 200,
+        child: ScrollGradientOverlay(
+          controller: controller,
+          fadeInto: const Color(0xFFFFFFFF),
+          height: 20,
+          borderRadius: 8,
+          child: ListView(
+            controller: controller,
+            children: List.generate(
+              20,
+              (i) => SizedBox(height: 40, child: Text('row$i')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(overlay(first));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(overlay(second));
+    await tester.pumpAndSettle();
+
+    // The overlay must now listen to `second`. Scrolling it has to light the
+    // top fade; were the listener still on `first`, nothing would change.
+    second.jumpTo(50);
+    await tester.pumpAndSettle();
+
+    final opacities = tester
+        .widgetList<AnimatedOpacity>(find.byType(AnimatedOpacity))
+        .map((o) => o.opacity)
+        .toList();
+
+    expect(opacities.first, 1.0, reason: 'content is hidden above');
+  });
+}

--- a/test/layout_and_empty_state_test.dart
+++ b/test/layout_and_empty_state_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Width constraints, `expand`, the overlay's padding, and the empty-search
+/// widget the package draws when the caller supplies no `emptyBuilder`.
+///
+/// All reachable from the public API; none of them covered until #56.
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+double buttonWidth(WidgetTester tester) =>
+    tester.getSize(find.byType(FlutterDropdownButton<String>)).width;
+
+void main() {
+  group('width', () {
+    testWidgets('a fixed width wins outright', (tester) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            width: 180,
+            minWidth: 10,
+            maxWidth: 20,
+            items: const ['Apple'],
+            hint: 'Pick a fruit',
+            disableWhenSingleItem: false,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(
+        buttonWidth(tester),
+        180,
+        reason: 'min/max only apply when width is null',
+      );
+    });
+
+    testWidgets('minWidth floors a narrow button', (tester) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            minWidth: 300,
+            items: const ['a'],
+            hint: 'x',
+            disableWhenSingleItem: false,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(buttonWidth(tester), 300);
+    });
+
+    testWidgets('maxWidth caps a button whose content overruns it', (
+      tester,
+    ) async {
+      const long = 'A preposterously long label indeed';
+
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            maxWidth: 120,
+            items: const [long],
+            value: long,
+            hint: 'x',
+            disableWhenSingleItem: false,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(buttonWidth(tester), 120);
+    });
+
+    testWidgets('maxWidth is a ceiling, not a width', (tester) async {
+      // The label must be *on the button* to push against the ceiling, so the
+      // value is what matters, not the item list. A short face stays short.
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            maxWidth: 400,
+            items: const ['x'],
+            value: 'x',
+            hint: 'x',
+            disableWhenSingleItem: false,
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      expect(buttonWidth(tester), lessThan(400));
+    });
+
+    testWidgets('expand fills the row it sits in', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              child: Row(
+                children: [
+                  FlutterDropdownButton<String>.text(
+                    expand: true,
+                    items: const ['Apple'],
+                    hint: 'Pick a fruit',
+                    disableWhenSingleItem: false,
+                    onChanged: (_) {},
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(buttonWidth(tester), 400);
+    });
+  });
+
+  group('the empty search state', () {
+    Widget searchable({Widget Function(String)? emptyBuilder}) =>
+        FlutterDropdownButton<String>.text(
+          width: 200,
+          items: const ['Apple', 'Banana'],
+          hint: 'Pick a fruit',
+          searchable: true,
+          emptyBuilder: emptyBuilder,
+          onChanged: (_) {},
+        );
+
+    Future<void> searchFor(WidgetTester tester, String query) async {
+      await tester.tap(find.byType(FlutterDropdownButton<String>));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), query);
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('with no emptyBuilder, the package says so itself', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(searchable()));
+
+      await searchFor(tester, 'zzz');
+
+      expect(find.text('No results found'), findsOneWidget);
+      expect(find.text('Apple'), findsNothing);
+    });
+
+    testWidgets('a query that matches again hides the empty state', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(searchable()));
+
+      await searchFor(tester, 'zzz');
+      expect(find.text('No results found'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'app');
+      await tester.pumpAndSettle();
+
+      expect(find.text('No results found'), findsNothing);
+      expect(find.text('Apple'), findsOneWidget);
+    });
+  });
+
+  testWidgets('overlayPadding wraps the menu content', (tester) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>.text(
+          width: 200,
+          items: const ['Apple', 'Banana'],
+          hint: 'Pick a fruit',
+          theme: const DropdownStyleTheme(
+            dropdown: DropdownTheme(overlayPadding: EdgeInsets.all(12)),
+          ),
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+
+    final padding = tester.widgetList<Padding>(
+      find.descendant(of: find.byType(Overlay), matching: find.byType(Padding)),
+    );
+
+    expect(
+      padding.any((p) => p.padding == const EdgeInsets.all(12)),
+      isTrue,
+      reason: 'the menu content sits inside the themed padding',
+    );
+  });
+
+  group('constructor asserts', () {
+    test('minMenuWidth may not exceed maxMenuWidth in text mode', () {
+      expect(
+        () => FlutterDropdownButton<String>.text(
+          items: const ['a'],
+          minMenuWidth: 300,
+          maxMenuWidth: 200,
+          onChanged: (_) {},
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('minMenuWidth may not exceed maxMenuWidth in custom mode', () {
+      expect(
+        () => FlutterDropdownButton<String>(
+          items: const ['a'],
+          itemBuilder: (item, isSelected) => Text(item),
+          minMenuWidth: 300,
+          maxMenuWidth: 200,
+          onChanged: (_) {},
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+}

--- a/test/leading_widget_test.dart
+++ b/test/leading_widget_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// `leading` and `selectedLeading` are reachable from the public API and were
+/// covered by nothing. #50 changed where their height comes from — a fully
+/// resolved `ResolvedButtonStyle` became `DropdownTheme.resolvedIconSize` —
+/// with no test watching.
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+/// The `SizedBox` the leading widget is centred in.
+SizedBox boxAround(WidgetTester tester, Finder leading) =>
+    tester.widget<SizedBox>(
+      find.ancestor(of: leading, matching: find.byType(SizedBox)).first,
+    );
+
+/// The `Padding` that separates the leading widget from the text.
+Padding padAround(WidgetTester tester, Finder leading) =>
+    tester.widget<Padding>(
+      find.ancestor(of: leading, matching: find.byType(Padding)).first,
+    );
+
+Widget dropdown({
+  Widget? leading,
+  Widget? selectedLeading,
+  EdgeInsets? leadingPadding,
+  String? value,
+  double? iconSize,
+}) {
+  return FlutterDropdownButton<String>.text(
+    width: 240,
+    items: const ['Apple', 'Banana'],
+    value: value,
+    hint: 'Pick a fruit',
+    leading: leading,
+    selectedLeading: selectedLeading,
+    leadingPadding: leadingPadding,
+    theme: DropdownStyleTheme(dropdown: DropdownTheme(iconSize: iconSize)),
+    onChanged: (_) {},
+  );
+}
+
+void main() {
+  testWidgets("a leading widget is sized to the theme's icon size", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(dropdown(leading: const Icon(Icons.eco), value: 'Apple')),
+    );
+
+    expect(
+      boxAround(tester, find.byIcon(Icons.eco)).height,
+      DropdownTheme.defaultIconSize,
+    );
+  });
+
+  testWidgets('a custom icon size resizes the leading widget too', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        dropdown(leading: const Icon(Icons.eco), value: 'Apple', iconSize: 40),
+      ),
+    );
+
+    expect(boxAround(tester, find.byIcon(Icons.eco)).height, 40);
+  });
+
+  testWidgets('every item row gets the leading widget', (tester) async {
+    await tester.pumpWidget(host(dropdown(leading: const Icon(Icons.eco))));
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.eco), findsNWidgets(2), reason: 'Apple, Banana');
+  });
+
+  testWidgets('the hint never takes a leading widget', (tester) async {
+    await tester.pumpWidget(host(dropdown(leading: const Icon(Icons.eco))));
+
+    expect(
+      find.byIcon(Icons.eco),
+      findsNothing,
+      reason: 'nothing is selected, so the button shows only its hint',
+    );
+  });
+
+  testWidgets('selectedLeading wins on the button face', (tester) async {
+    await tester.pumpWidget(
+      host(
+        dropdown(
+          leading: const Icon(Icons.eco),
+          selectedLeading: const Icon(Icons.star),
+          value: 'Apple',
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.star), findsOneWidget);
+    expect(find.byIcon(Icons.eco), findsNothing);
+  });
+
+  testWidgets('selectedLeading does not reach the item rows', (tester) async {
+    await tester.pumpWidget(
+      host(
+        dropdown(
+          leading: const Icon(Icons.eco),
+          selectedLeading: const Icon(Icons.star),
+          value: 'Apple',
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.star), findsOneWidget, reason: 'the button only');
+    expect(find.byIcon(Icons.eco), findsNWidgets(2), reason: 'both rows');
+  });
+
+  testWidgets('leadingPadding defaults to eight pixels on the right', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(dropdown(leading: const Icon(Icons.eco), value: 'Apple')),
+    );
+
+    expect(
+      padAround(tester, find.byIcon(Icons.eco)).padding,
+      const EdgeInsets.only(right: 8.0),
+    );
+  });
+
+  testWidgets('a themed leadingPadding replaces the default', (tester) async {
+    await tester.pumpWidget(
+      host(
+        dropdown(
+          leading: const Icon(Icons.eco),
+          leadingPadding: const EdgeInsets.all(4),
+          value: 'Apple',
+        ),
+      ),
+    );
+
+    expect(
+      padAround(tester, find.byIcon(Icons.eco)).padding,
+      const EdgeInsets.all(4),
+    );
+  });
+}

--- a/test/overlay_controller_widget_test.dart
+++ b/test/overlay_controller_widget_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// `DropdownOverlayController` driven the way a third party drives it — held by
+/// a `State`, with no `FlutterDropdownButton` anywhere.
+///
+/// `toggle()` and the controller's own default menu chrome are unreachable
+/// through the widget, which always supplies a decoration of its own.
+
+class BareDropdown extends StatefulWidget {
+  const BareDropdown({super.key, this.decoration});
+
+  /// Null lets the controller draw its own chrome from the ambient theme.
+  final BoxDecoration? decoration;
+
+  @override
+  State<BareDropdown> createState() => _BareDropdownState();
+}
+
+class _BareDropdownState extends State<BareDropdown>
+    with SingleTickerProviderStateMixin {
+  late final DropdownOverlayController menu = DropdownOverlayController(
+    vsync: this,
+    spec: () => const DropdownOverlaySpec(
+      itemCount: 2,
+      actualItemHeight: 40,
+      maxDropdownHeight: 200,
+    ),
+    contentBuilder: (height) => const Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [Text('one'), Text('two')],
+    ),
+    decorationBuilder: () => widget.decoration,
+    onOpenStateChanged: (_) => setState(() {}),
+  );
+
+  @override
+  void dispose() {
+    menu.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      key: menu.buttonKey,
+      onTap: () => menu.toggle(context),
+      child: const SizedBox(width: 120, height: 40, child: Text('open me')),
+    );
+  }
+}
+
+Widget host(Widget child) => MaterialApp(
+  theme: ThemeData(cardColor: const Color(0xFF102030)),
+  home: Scaffold(body: Center(child: child)),
+);
+
+/// The menu's own box — the one the controller gives a border radius.
+BoxDecoration menuDecoration(WidgetTester tester) {
+  final containers = tester.widgetList<Container>(
+    find.descendant(of: find.byType(Overlay), matching: find.byType(Container)),
+  );
+
+  return containers
+      .map((c) => c.decoration)
+      .whereType<BoxDecoration>()
+      .firstWhere((d) => d.borderRadius != null);
+}
+
+void main() {
+  testWidgets('toggle opens a closed menu and closes an open one', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(const BareDropdown()));
+
+    expect(find.text('one'), findsNothing);
+
+    await tester.tap(find.text('open me'));
+    await tester.pumpAndSettle();
+    expect(find.text('one'), findsOneWidget);
+
+    await tester.tap(find.text('open me'));
+    await tester.pumpAndSettle();
+    expect(find.text('one'), findsNothing);
+  });
+
+  testWidgets('a null decoration falls back to the ambient theme', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(const BareDropdown()));
+
+    await tester.tap(find.text('open me'));
+    await tester.pumpAndSettle();
+
+    final decoration = menuDecoration(tester);
+    expect(
+      decoration.color,
+      const Color(0xFF102030),
+      reason: "the ThemeData's cardColor",
+    );
+    expect(decoration.border, isNotNull, reason: 'and its dividerColor');
+  });
+
+  testWidgets('a supplied decoration is used as-is', (tester) async {
+    await tester.pumpWidget(
+      host(
+        const BareDropdown(
+          decoration: BoxDecoration(
+            color: Color(0xFFAABBCC),
+            borderRadius: BorderRadius.all(Radius.circular(4)),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open me'));
+    await tester.pumpAndSettle();
+
+    expect(menuDecoration(tester).color, const Color(0xFFAABBCC));
+  });
+}

--- a/test/presentation/item_presentation_test.dart
+++ b/test/presentation/item_presentation_test.dart
@@ -39,7 +39,8 @@ CustomItemPresentation<T> custom<T>({
   Widget? hintWidget,
 }) {
   return CustomItemPresentation<T>(
-    itemBuilder: (item, isSelected) => Text('$item'),
+    // The flag is in the text so a caller can see which one it was handed.
+    itemBuilder: (item, isSelected) => Text('$item/$isSelected'),
     items: items,
     value: value,
     selectedBuilder: selectedBuilder,
@@ -131,6 +132,23 @@ void main() {
       );
 
       expect((presentation.buildSelected() as Text).data, 'face:a');
+    });
+
+    test('without selectedBuilder, itemBuilder draws the face as selected', () {
+      final presentation = custom<String>(items: const ['a'], value: 'a');
+
+      expect(
+        (presentation.buildSelected() as Text).data,
+        'a/true',
+        reason: 'the button face is the item, and the item is the chosen one',
+      );
+    });
+
+    test('an item row is drawn unselected unless it is the value', () {
+      final presentation = custom<String>(items: const ['a', 'b'], value: 'a');
+
+      expect((presentation.buildItem('a', true) as Text).data, 'a/true');
+      expect((presentation.buildItem('b', false) as Text).data, 'b/false');
     });
   });
 }

--- a/test/remaining_behaviours_test.dart
+++ b/test/remaining_behaviours_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The last few behaviours #56 found uncovered: the tooltip's three modes,
+/// the scroll position resetting as a query narrows the list, `searchable`
+/// flipping at runtime, and `isTextMode`'s public promise.
+
+const long = 'A label far too long for a narrow button';
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+Widget textDropdown({
+  DropdownTooltipTheme? tooltip,
+  bool searchable = false,
+  List<String> items = const ['Apple', 'Banana'],
+  String? value,
+}) {
+  return FlutterDropdownButton<String>.text(
+    width: 140,
+    items: items,
+    value: value,
+    hint: 'Pick a fruit',
+    searchable: searchable,
+    disableWhenSingleItem: false,
+    theme: DropdownStyleTheme(tooltip: tooltip ?? const DropdownTooltipTheme()),
+    onChanged: (_) {},
+  );
+}
+
+void main() {
+  group('isTextMode', () {
+    test('the text constructor says so', () {
+      final button = FlutterDropdownButton<String>.text(
+        items: const ['a'],
+        onChanged: (_) {},
+      );
+
+      expect(button.isTextMode, isTrue);
+    });
+
+    test('the default constructor does not', () {
+      final button = FlutterDropdownButton<String>(
+        items: const ['a'],
+        itemBuilder: (item, isSelected) => Text(item),
+        onChanged: (_) {},
+      );
+
+      expect(button.isTextMode, isFalse);
+    });
+  });
+
+  group('tooltip modes', () {
+    testWidgets('disabled draws no tooltip, however long the text', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          textDropdown(
+            items: const [long],
+            value: long,
+            tooltip: const DropdownTooltipTheme(mode: TooltipMode.disabled),
+          ),
+        ),
+      );
+
+      expect(find.byType(Tooltip), findsNothing);
+    });
+
+    testWidgets('enabled: false draws no tooltip either', (tester) async {
+      await tester.pumpWidget(
+        host(
+          textDropdown(
+            items: const [long],
+            value: long,
+            tooltip: const DropdownTooltipTheme(enabled: false),
+          ),
+        ),
+      );
+
+      expect(find.byType(Tooltip), findsNothing);
+    });
+
+    testWidgets('always draws a tooltip even when the text fits', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          textDropdown(
+            items: const ['Ok'],
+            value: 'Ok',
+            tooltip: const DropdownTooltipTheme(mode: TooltipMode.always),
+          ),
+        ),
+      );
+
+      expect(find.byType(Tooltip), findsWidgets);
+    });
+
+    testWidgets('textColor becomes the tooltip text style', (tester) async {
+      await tester.pumpWidget(
+        host(
+          textDropdown(
+            items: const [long],
+            value: long,
+            tooltip: const DropdownTooltipTheme(textColor: Colors.amber),
+          ),
+        ),
+      );
+
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip).first);
+      expect(tooltip.textStyle!.color, Colors.amber);
+    });
+
+    testWidgets('an explicit textStyle wins over textColor', (tester) async {
+      await tester.pumpWidget(
+        host(
+          textDropdown(
+            items: const [long],
+            value: long,
+            tooltip: const DropdownTooltipTheme(
+              textColor: Colors.amber,
+              textStyle: TextStyle(color: Colors.green),
+            ),
+          ),
+        ),
+      );
+
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip).first);
+      expect(tooltip.textStyle!.color, Colors.green);
+    });
+  });
+
+  testWidgets('narrowing a query scrolls the list back to the top', (
+    tester,
+  ) async {
+    final many = List.generate(20, (i) => 'item$i');
+
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>.text(
+          width: 200,
+          height: 150,
+          items: many,
+          hint: 'Pick one',
+          searchable: true,
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+
+    final controller = tester
+        .widget<ListView>(find.byType(ListView))
+        .controller!;
+    controller.jumpTo(100);
+    await tester.pump();
+    expect(controller.offset, 100);
+
+    await tester.enterText(find.byType(TextField), 'item1');
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<ListView>(find.byType(ListView)).controller!.offset,
+      0,
+      reason: 'the old offset means nothing once the list changes',
+    );
+  });
+
+  testWidgets('searchable can be turned on after the first build', (
+    tester,
+  ) async {
+    var searchable = false;
+    late StateSetter setOuterState;
+
+    await tester.pumpWidget(
+      host(
+        StatefulBuilder(
+          builder: (context, setState) {
+            setOuterState = setState;
+            return textDropdown(searchable: searchable);
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsNothing);
+
+    await tester.tapAt(const Offset(10, 10)); // dismiss
+    await tester.pumpAndSettle();
+
+    setOuterState(() => searchable = true);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsOneWidget);
+  });
+
+  testWidgets('searchable can be turned off again', (tester) async {
+    var searchable = true;
+    late StateSetter setOuterState;
+
+    await tester.pumpWidget(
+      host(
+        StatefulBuilder(
+          builder: (context, setState) {
+            setOuterState = setState;
+            return textDropdown(searchable: searchable);
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsOneWidget);
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    setOuterState(() => searchable = false);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsNothing);
+  });
+}

--- a/test/scroll_to_selected_test.dart
+++ b/test/scroll_to_selected_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Opening a long menu with a value already chosen scrolls that value into
+/// view. `scrollToSelectedDuration` decides whether it jumps or glides.
+
+const items = [
+  'i0',
+  'i1',
+  'i2',
+  'i3',
+  'i4',
+  'i5',
+  'i6',
+  'i7',
+  'i8',
+  'i9',
+  'i10',
+  'i11',
+];
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+Widget dropdown({
+  String? value,
+  bool scrollToSelectedItem = true,
+  Duration? duration,
+}) {
+  return FlutterDropdownButton<String>.text(
+    width: 200,
+    height: 150,
+    items: items,
+    value: value,
+    hint: 'Pick one',
+    scrollToSelectedItem: scrollToSelectedItem,
+    scrollToSelectedDuration: duration,
+    onChanged: (_) {},
+  );
+}
+
+ScrollController menuController(WidgetTester tester) =>
+    tester.widget<ListView>(find.byType(ListView)).controller!;
+
+Future<void> open(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterDropdownButton<String>).first);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a menu opened with no value stays at the top', (tester) async {
+    await tester.pumpWidget(host(dropdown()));
+    await open(tester);
+
+    expect(menuController(tester).offset, 0);
+  });
+
+  testWidgets('the chosen item is scrolled into view', (tester) async {
+    await tester.pumpWidget(host(dropdown(value: 'i10')));
+    await open(tester);
+
+    expect(
+      menuController(tester).offset,
+      greaterThan(0),
+      reason: 'the tenth row is far below the fold',
+    );
+  });
+
+  testWidgets('scrollToSelectedItem: false leaves the menu at the top', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(dropdown(value: 'i10', scrollToSelectedItem: false)),
+    );
+    await open(tester);
+
+    expect(menuController(tester).offset, 0);
+  });
+
+  testWidgets('a value absent from items scrolls nowhere', (tester) async {
+    await tester.pumpWidget(host(dropdown(value: 'not in the list')));
+    await open(tester);
+
+    expect(menuController(tester).offset, 0);
+  });
+
+  testWidgets('the offset is clamped to the end of the list', (tester) async {
+    await tester.pumpWidget(host(dropdown(value: 'i11')));
+    await open(tester);
+
+    final controller = menuController(tester);
+    expect(
+      controller.offset,
+      controller.position.maxScrollExtent,
+      reason: 'the last row cannot scroll past the bottom',
+    );
+  });
+
+  /// Opens the menu and stops fifty milliseconds in — before a one-second
+  /// scroll animation could have finished, but long after a jump would have.
+  Future<double> offsetShortlyAfterOpening(
+    WidgetTester tester,
+    Duration? duration,
+  ) async {
+    await tester.pumpWidget(host(dropdown(value: 'i11', duration: duration)));
+
+    await tester.tap(find.byType(FlutterDropdownButton<String>).first);
+    await tester.pump(); // insert the overlay
+    await tester.pump(); // run the post-frame callback
+    await tester.pump(const Duration(milliseconds: 50));
+
+    return menuController(tester).offset;
+  }
+
+  testWidgets('with no duration the menu is already where it belongs', (
+    tester,
+  ) async {
+    final offset = await offsetShortlyAfterOpening(tester, null);
+
+    expect(offset, greaterThan(0), reason: 'jumpTo lands in one frame');
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a duration makes it glide, so it is not there yet', (
+    tester,
+  ) async {
+    final partway = await offsetShortlyAfterOpening(
+      tester,
+      const Duration(seconds: 1),
+    );
+
+    await tester.pumpAndSettle();
+    final settled = menuController(tester).offset;
+
+    expect(settled, greaterThan(0));
+    expect(
+      partway,
+      lessThan(settled),
+      reason: 'fifty milliseconds into a one-second glide',
+    );
+  });
+}


### PR DESCRIPTION
Closes #56.

`main` was at **93.35%**. It is now **100.00% (931/931)**, and `.github/workflows/ci.yml` says `--min 100`.

207 tests, up from 160.

## Two tests went red, and neither was a bug in `lib/`

**`maxWidth caps a wide button`** expected 120 and got 80.25. `maxWidth` is a *ceiling*, not a width, and the button had nothing wide on its face — the long label was in the item list, not the value. My expectation was wrong. The test now sets a value, and a second test pins the ceiling's other half: a short face stays short.

**`a duration animates rather than jumps`** passed for the wrong reason. My second `pumpWidget` reused the first's `State`, so the menu was already open and already scrolled. Rewritten to open once and stop fifty milliseconds in, which is what separates a jump (arrives in one frame) from a glide (does not).

Both are #40's lesson again: a red that fires for the wrong reason is not a red, and a green that passes for the wrong reason is worse.

## The issue was wrong about the last two lines

#56 said `smart_tooltip_text.dart:252-253` were `_calculatePreferBelow`'s `catch`, possibly unreachable, and warned against deleting them on coverage alone.

Reading the source rather than trusting the line numbers showed they are the `maxLines == null && softWrap == false` branch of `_checkTextOverflow` — plainly reachable, and now covered. Had the issue been believed, a working branch would have been wrapped in `// coverage:ignore`.

## One line genuinely cannot be covered

`TextItemPresentation.labelOf`'s `throw` fires when `label == null && item is! String` — exactly the condition the constructor asserts against. Asserts are compiled out of release builds, so the throw is unreachable in debug and is the only guard in release.

It is wrapped in `// coverage:ignore-start` with that proof written above it. Verified first that the toolchain honours the pragma: a probe showed the ignored line vanish from `DA:` and `LF` drop by one. **Ignored lines leave the denominator rather than counting as misses**, so the exception lives in this diff instead of in a sagging threshold.

## What the gaps turned out to be

| | |
| --- | --- |
| `leading` / `selectedLeading` | **No test supplied either.** #50 changed where their height comes from with nothing watching. |
| `disabledTextStyle` | Merges over the base style. A test now pins that `fontSize` survives; replacing instead of merging would have dropped it silently. |
| `scrollToSelectedItem` | Entirely untested — jump, glide, clamp-to-end, absent value. |
| `expand`, `minWidth`, `maxWidth` | Untested. |
| "No results found" | The empty state drawn when no `emptyBuilder` is given. |
| Tooltip modes | `disabled`, `always`, `enabled: false`, `textColor` vs `textStyle`. |
| `DropdownOverlayController.toggle()` and its default chrome | Unreachable through `FlutterDropdownButton`, which always passes a decoration. Covered by driving the controller bare, as `example/lib/pages/domain_type_page.dart` does. |
| `ScrollGradientOverlay.didUpdateWidget` | The dropdown never swaps its `ScrollController`, so the swap branch is unreachable through the public API. Tested by importing `src/` directly rather than deleting a real guard. |

## The floor fails when it should

Deleting `test/selection_test.dart` drops coverage to **99.57%** and the gate exits 1.

Had the floor been 99, that deletion would have passed. That is the argument for 100, in one number.

CI: `stable`, `minimum (3.32.0)`, coverage at `--min 100`, format and `publish --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)