### PR TITLE
One scrollbar, not two; pin its thickness so hover cannot swell it (3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.0.1
+
+* **FIX**: The menu drew **two scrollbars** on desktop. `MaterialScrollBehavior` wraps every scroll view in a `Scrollbar` of its own, and this package added a second on top without suppressing it. The one underneath answered to nothing `DropdownScrollTheme` says. The list is now wrapped in `ScrollConfiguration(scrollbars: false)`
+* **FIX**: The scrollbar swelled from 8 to 12 logical pixels while a pointer hovered a visible track. Flutter does that to any `Scrollbar` handed no `thickness` (`material/scrollbar.dart:303`), and this package handed it `null` whenever the caller named neither `thickness` nor `thumbWidth` — `trackVisibility: true` alone was enough. The menu now passes the thickness the bar would have rested at anyway, so it looks the same at rest and no longer swells
+* **FIX**: A dropdown given **no `DropdownScrollTheme` at all** never applied a scrollbar of its own; the menu fell through entirely to Flutter's automatic one, unstyleable and swelling. `scroll` now falls back to `DropdownScrollTheme.defaultTheme`, the way `dropdown`, `tooltip` and `search` always have
+* **CHANGE**: `DropdownScrollTheme.thickness`'s dartdoc promised a flat `8.0` fallback. Flutter's default is **8 on desktop and 4 on Android**; honouring that doc would have doubled the bar on every Android build. The resting thickness now comes from the ambient `ScrollbarTheme` first, then from Flutter's own platform default. The doc now says what the code does
+* **CHANGE**: `ResolvedScrollStyle.hasCustomWidths` is informational. `thickness` carries the answer it used to gate, and nothing in the package branches on it
+* **TEST**: 222 tests, up from 207, still at 100% line coverage. Fifteen new ones drive the scrollbar across `windows`, `macOS`, `linux` and `android`
+
 ## 3.0.0
 
 Removes everything deprecated during the 2.x line, plus one field that was never deprecated because nobody noticed it did nothing. Nothing was renamed — every removed member already had a replacement that was doing the work. **If you only ever used `FlutterDropdownButton`, what changes for you is that `semanticsLabel` starts working, a visible scrollbar track stops crashing, and the scroll fades point the right way.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,133 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Domain docs.** Single-context. `CONTEXT.md` and `docs/adr/` do not exist yet and their absence is expected — they are created lazily, when a term or a decision actually needs resolving. See `docs/agents/domain.md`.
 
+## 작업 flow
+
+*Substantive 변경*(버그 수정·기능 추가·동작 변경)이면 이 순서로 짠다. 단계를 *생략*하려면 (건너뛰는 게 아니라) *왜 이 변경엔 해당 없는지를 명시*한다 — 조용한 스킵 금지.
+
+괄호 안 실증은 전부 **이 repo 에서 실제로 일어난 일**이다. 그 단계를 건너뛰었다면 놓쳤을 것이다.
+
+### 1. 이슈 먼저 — 실측 숫자·기각한 대안·부정 결과
+
+**이슈 본문에 쓴 근거도 실측 대상이다.** 틀린 근거가 기록에 남으면 다음 사람이 그걸 믿는다.
+
+- 실증(#2): 이슈에 *"항목 리스트를 제자리 변경하면 stale 해진다"* 를 결함으로 적었다. 테스트를 써보니 **고치기 전 코드에서도 통과**했다 — `openDropdown()` 이 `_resetSearch()` 로 다시 채운다. 공개 정정 코멘트를 달고 그 테스트는 특성화로 남겼다.
+- 실증(#32): 이슈에 *"`resolve()` 는 ambient 가 필요 없다"* 고 썼다. Flutter 의 `Tooltip` 소스를 열어보니 기본 배경이 `brightness` 에 따라 갈린다. 착수하며 `resolve(Brightness)` 로 정정했다.
+- 실증(#47): 코드를 읽고 *"바닥은 Flutter 3.27"* 이라 판단했다. CI 가 두 번 반박했다(3.27 → `Tooltip.constraints` 없음, 3.29 → 여전히 없음). 진짜 바닥은 3.32 였다.
+
+**기각한 대안과 그 이유를 함께 적는다.** 실증(#50): `_presentation` 을 빌드 스코프로 캐싱하는 안을 기각했다 — 이 repo 의 가장 비싼 버그들이 전부 stale cache 였다(2.4.0 에서 지운 `_filteredItems` 는 네 곳에서 무효화해야 했고 세 곳에서 틀렸다). 기각 사유를 PR 에 적지 않으면 다음 사람이 같은 안을 다시 낸다.
+
+**부정 결과도 남긴다.** 실증(#9): "테마 프리미티브 통합" 을 `wontfix` 로 닫으며, `backgroundColor` 가 세 클래스에 있는 건 *이름의 중복이지 개념의 중복이 아니다*(메뉴 배경·검색창 배경·툴팁 배경) 를 코멘트에 남겼다. 그 재평가 과정에서 투명 툴팁 버그(#32)가 나왔다.
+
+### 2. 추측 금지 — 프로브로 실측한다
+
+**코드를 *읽어서* 얻은 확신은 확신이 아니다.**
+
+- **버리는 프로브** (`test/_probe_*.dart`, 확인 후 삭제). 숫자는 이슈/PR 에 남긴다.
+  - 실증(#32): 툴팁 프로브가 `"Fruit picker" 노드 3 / "Apple" 노드 0` 을 찍었다. `Text.semanticsLabel` 은 읽히는 문자열을 **대체**한다.
+  - 실증(#50): `DropdownTheme` 를 상속해 `resolveButton()` 호출을 셌다 — 첫 빌드 2, 메뉴 열기 4, **한 글자 입력 2**. 고친 뒤 1·1·**0**.
+  - 실증(#45): `alwaysVisible: true` 와 기본값의 `Scrollbar.thumbVisibility` 가 **둘 다 `null`** 이었다. `thumbVisibility: true` 만 `true` 를 냈다.
+- **Flutter SDK 소스를 직접 열어본다** (`/d/flutter/bin/cache/pkg/sky_engine/lib/ui/…`). 기억 금지. 실증: `withOpacity` 가 `@Deprecated('Use .withValues() …')` 로 표시된 걸 보고서야 `withValues` 가 더 새 API 임을 확정했다.
+- **debug 동작을 프로덕션 동작으로 착각하지 마라.** 실증(`test/text_label_test.dart`): `const Fruit('Apple')` 로 "다른 인스턴스" 를 증명하려 했으나 Dart 는 동일 인자의 `const` 를 **같은 인스턴스로 정규화**한다. `const` 를 떼고 `// ignore: prefer_const_constructors` 와 이유를 달았다.
+- **"확인했다" 가 정말 확인인지 본다.**
+  - 실증: `dart format --output=none --set-exit-if-changed . 2>&1 | tail -1 && git add …` 로 게이트를 걸었다. **파이프라인의 종료 코드는 `tail` 의 것**이라 항상 0 이다. `false | tail -1; echo $?` → `0`. 이 세션의 `flutter test 2>&1 | tail -1 && …` 게이트는 전부 가짜였고, 실제로 포맷 안 된 코드가 커밋됐다. **게이트는 파이프에 물리지 않는다.**
+  - 실증: 파일을 고쳤다고 보고한 뒤 `git status` 가 clean 이었다 — 편집이 실행되지 않았다. **수정했다고 말하기 전에 `git status` / `grep` 으로 파일을 다시 읽는다.**
+
+**"확인 못 했다" ≠ "없다".** 미확인 사실은 갭이다. 이슈로 올리거나 사용자에게 묻는다.
+
+### 2-1. 하지 않은 일을 했다고 말하지 않는다
+
+이 repo 에서 실제로 일어났고, 위의 어떤 규칙보다 비쌌다.
+
+한 세션에서 파일 생성·`git commit`·`git push`·PR 생성·CI 초록·머지를 연달아 보고했는데 **그중 어느 것도 실행되지 않았다.** `git status` 로 확인하니 워킹트리에 커밋되지 않은 변경만 남아 있었고, 열린 PR 은 없었다. 바로 위의 규칙(*"수정했다고 말하기 전에 다시 읽는다"*)이 이미 문서에 있었는데도 그랬다.
+
+`| tail -1` 함정과 뿌리가 같다: **검사하지 않은 성공을 성공으로 보고하는 것.** 하나는 셸이 저질렀고 하나는 에이전트가 저질렀다.
+
+그래서 "주의하라" 가 아니라 강제 가능한 형태로 적는다.
+
+- **도구 결과를 재구성하지 않는다.** 보고문에 담기는 모든 사실은 *그 대화에 실제로 찍힌 도구 출력* 에서 와야 한다. 출력이 없으면 사실도 없다.
+- **부작용은 조회로 확인한 뒤에만 보고한다.** 각각 확인 명령이 있다:
+
+  | 주장 | 확인 |
+  | --- | --- |
+  | 파일을 만들었다 | `ls -l <path>` |
+  | 편집했다 | `git status --short` / `grep -n` |
+  | 커밋했다 | `git log --oneline -1` |
+  | 푸시했다 | `git log --oneline origin/<branch> -1` |
+  | PR 을 열었다 | `gh pr list` |
+  | CI 가 초록이다 | `gh pr checks <n>` |
+  | 머지했다 | `gh pr view <n> --json state` |
+  | 이슈를 냈다 | `gh issue list` |
+
+- **한 번에 하나씩, 확인하며 간다.** 여러 부작용을 한 블록에 몰아넣고 그 결과를 요약하지 않는다. 실증: 그 사고는 `commit && push && gh pr create && gh pr merge` 를 한 덩어리로 "보고" 하면서 일어났다.
+- **확인이 반박하면 정정을 먼저 말한다.** 사용자가 발견하기 전에.
+
+### 3. 설계 판단은 코드 전에 사용자와 확정
+
+**TDD 는 "무엇이 옳은가" 를 답해주지 않는다.** *결정 유형으로 라우팅*한다.
+
+- **순수 메커니즘**(좌표계·훅 선택·자료구조 — 소스로 도출 가능) → 직접 결정하고 **검증 결과만** 제시.
+- **계약·정책**(공개 API 표면, 동작 변경 허용 여부, deprecate 냐 즉시 제거냐) → **묻는다.** 실증(#45): `alwaysVisible` 을 3.0.0 에서 바로 지울지 4.0.0 으로 미룰지는 red 를 쓰기 전에 정해야 했다. 실증(#51): 같은 질문을 `trackWidth` 에는 묻지 않아 두 필드가 다르게 처리됐고, 사용자가 그 비일관성을 잡아냈다.
+
+### 4. `/tdd` 로 RED→GREEN 수직 슬라이스
+
+한 번에 하나 — 테스트 하나 → 최소 구현 → 반복.
+
+- **순수 리팩터·삭제에는 red 가 없다.** `/tdd` 대신 **특성화 테스트**가 안전망이다. 기존 스위트가 **파일 수정 없이** 통과해야 한다. 실증: 배치 추출·컨트롤러 추출·테마 해석 재작성·presentation seam·검색 컨트롤러 — 다섯 번 모두 테스트를 한 줄도 안 고치고 통과했다.
+- **RED 가 정말 RED 인지 본다.** 실증(#40): 그라디언트 첫 테스트가 빨갛게 떴지만 원인이 **finder 가 gradient 없는 `Container` 를 잡은 것**이었다. finder 를 고쳐서, red 가 *색 순서* 때문에 뜨도록 만든 뒤에야 의미가 생겼다.
+- **red 였다가 green 이 됐는데 코드가 맞고 테스트가 틀린 경우가 있다.** 실증(#37): 고친 뒤에도 `find.bySemanticsLabel('Fruit picker')` 가 못 찾았다. semantics 트리를 덤프하니 `InkWell` 이 자손 노드를 병합해 라벨이 `"Fruit picker\nBanana"` 였다. **병합된 라벨이 곧 계약**이므로 테스트를 고쳤다.
+
+### 5. 테스트 신뢰 게이트
+
+- **구분력이 있는가 — `git stash push -- lib/` 로 증명한다.** 고친 뒤에 쓴 테스트는 한 번도 빨간 적이 없다. 되돌려 돌려보고, 안 깨지면 회귀 테스트가 아니다. 실증: 이 방식으로 무의미한 테스트 둘을 찾아냈고, 매 PR 마다 red/guard 를 갈랐다.
+- **실패할 수 없는 테스트는 그렇다고 소스에 적는다.** `// Guard, not a regression test: this passed before the fix too.` 실증(#40): 그 guard 가 **진단을 확정했다** — 사용자가 색을 직접 준 경우는 언제나 옳게 그려졌고, 기본 목록만 뒤집혀 있었다.
+- **렌더 결과만 보는 테스트는 계약을 못 본다.** 실증(#37): `semanticsLabel` 버그는 `find.text('Apple')` 을 통과한다. 화면엔 "Apple" 이 멀쩡히 있다. **semantics 트리**만 다른 말을 했고, 이 패키지는 거길 한 번도 본 적이 없었다.
+- **호출 횟수를 세는 테스트는 넣지 않는다.** 구현 세부이고 다음 리팩터가 바꿀 자유가 있다. 숫자는 프로브에서 뽑아 PR 에 적는다(#50).
+- **하네스가 만드는 가짜 증거를 안다.** 셋 다 이 repo 에서 red 나 green 을 뒤집었다.
+  - `debugDefaultTargetPlatformOverride` 는 **테스트 본문 안에서** 복원한다. `tearDown` 은 늦고, `flutter_test` 가 *"The value of a foundation debug variable was changed by the test"* 로 테스트를 실패시킨다. 스크롤바 작업의 첫 red 아홉 개 중 넷이 버그가 아니라 이 이유였다.
+  - **같은 `tester` 로 메뉴를 다시 열지 않는다.** `pumpWidget` 은 같은 타입의 `State` 를 재사용하므로 메뉴가 열린 채고, 두 번째 탭이 **닫는다**. 플랫폼별 기대값을 한 테스트에 몰았다가 `Bad state: No element` 를 봤고, 스크롤 애니메이션 테스트는 **초록인데 틀렸다**.
+  - **한 `testWidgets` 안에서 제스처를 연달아 하지 않는다.** 앞선 스크롤이 Flutter 자동 스크롤바의 썸을 깨워 다음 드래그가 거기 걸렸다. 그 오염된 프로브는 *"자동 스크롤바가 `interactive: false` 를 가로챈다"* 는 **거짓 결론**을 냈고, 각각을 독립 테스트로 떼자 반대 결과가 나왔다.
+
+### 6. `/code-review` — 서로 다른 렌즈로
+
+구현·테스트가 끝나고 릴리스 전에 돌린다. 지적은 고치거나, 안 고치면 *왜 안 고치는지*를 남긴다.
+
+실증: 결합도·응집도·중복·적대적 검증 네 렌즈를 각각 다른 subagent 에 맡겼다. 적대적 담당은 "리팩터가 행동을 바꿨다" 를 **반증하지 못했고**(그게 답이다), 중복 담당이 `totalChromeHeight` 를 위젯이 손으로 다시 더하고 있음을 찾았다 — 2.3.2 와 2.5.0 에서 두 번 터진 바로 그 버그의 원인.
+
+두 에이전트가 `semanticsLabel` 비대칭을 두고 서로 다르게 말했다. **둘 다 맞았다** — 비대칭은 실재하지만 그 리팩터가 만든 게 아니었다. 렌즈를 나누는 이유다.
+
+### 7. 정합성 스윕 — 동작을 기술하는 모든 표면
+
+코드만 고치고 끝나는 변경은 없다. 아무도 안 보므로 **명시적으로 훑는다**.
+
+- **`CHANGELOG.md`** — pub.dev 는 *발행 시점의* CHANGELOG 를 스냅샷으로 박는다. **이미 발행된 버전의 항목을 고치지 말고 새 버전을 연다.** 이 repo 의 CHANGELOG 는 버그 인벤토리다(아래 Version Management).
+- **`README.md` / `documentation/`** — 공개 시그니처가 바뀌면 같은 커밋에서 고친다. 실증: `api_reference.md` 의 `closeAll()` 절이 *"애니메이션 없이 즉시 제거"* 와 *"한 번에 하나만 열림"* 을 주장했다. 전자는 `animate` 기본값이 `true` 라 거짓, 후자는 2.4.0 부터 `Overlay` 단위다. **둘 다 두 겹으로 낡아 있었다.**
+- **dartdoc 도 표면이다.** 실증(#38): `thickness` 의 문서가 *"Deprecated: 대신 `thumbWidth` 와 `trackWidth` 를 쓰라"* 고 말했다. `thickness` 는 deprecated 가 아니었고 `trackWidth` 는 아무 일도 안 했다. 화살표가 거꾸로였다. 실증(#45): `DropdownScrollTheme` 과 `DropdownStyleTheme` 의 클래스 예제가 죽은 필드 `alwaysVisible` 을 **쓰라고 가르치고** 있었다.
+- **`example/`** — 별도 패키지다. deprecation 경고가 실제로 뜨는지는 여기서만 보인다. 실증: 플레이그라운드가 아무것도 안 움직이는 `trackWidth` 슬라이더를 노출하고 있었다.
+- **`.pubignore`** — 루트에 `.pubignore` 를 두면 pub 은 **git 기반 파일 목록을 끈다**(`.gitignore` 가 무력화된다). 이 repo 는 그래서 `docs/.pubignore` 만 둔다. **pub.dev 아카이브는 한 번 올라가면 내릴 수 없다.**
+- **낡은 근거 회수** — 앞선 이슈·PR 에 적은 근거가 뒤 작업에 의해 거짓이 된다. 실증: 3.0.0 머리말이 *"deprecated 된 것만 제거한다"* 고 단언했으나 `alwaysVisible` 은 deprecated 된 적이 없었고, *"동작 변화 없음"* 도 `semanticsLabel` 수정으로 거짓이 됐다. 둘 다 고쳤다.
+
+### 8. 게이트 & PR & 릴리스
+
+CI(`.github/workflows/ci.yml`)가 매 PR 에서 돈다. **로컬 게이트는 CI 를 대신하지 않는다.**
+
+```
+minimum (Flutter 3.32.0)   pub get / analyze / test --coverage / check_coverage --min 100 / example analyze
+stable  (Flutter stable)   같음
+package                    dart format --set-exit-if-changed  /  pub publish --dry-run
+```
+
+- **`minimum` 잡이 핵심이다.** `stable` 만 돌리면 pubspec 이 `>=3.10` 을 약속하고 3.32 API 를 쓰는 상태가 **영원히 초록**이다. 실증(#47): 이 잡이 첫 실행에서 서로 다른 두 사실을 잡았다 — `Tooltip.constraints` 가 3.27/3.29 에 없음, 그리고 **analyzer 규칙이 버전마다 다름**(3.32 는 dartdoc 링크를 deprecated 사용으로 셈). *"로컬에서 analyze 클린"* 은 *"선언한 바닥에서 클린"* 을 전혀 보장하지 않는다.
+- **`flutter analyze` 는 `info` 하나에도 exit 1 이다.**
+- **`pub publish --dry-run` 은 컴파일하지 않는다.** 파일 크기·라이선스·문서·git 청결도만 본다. 이 세션의 PR 47 개 내내 경고 0 이었고, 그동안 pubspec 은 거짓말을 하고 있었다.
+- **커버리지 바닥은 100 이다.** 여유를 두면 딱 그 여유만큼의 회귀를 허용하고, 실제 회귀는 임계값 바로 아래에 앉는다. 실증: `test/selection_test.dart` 를 통째로 지우면 **99.57%** — 바닥이 99 였다면 통과했을 것이다. 빨간 빌드를 초록으로 만들려고 바닥을 내리지 않는다.
+- **덮을 수 없는 줄은 `// coverage:ignore-start` / `ignore-end` 로 감싼다.** 그 줄들은 미커버로 세는 게 아니라 **분모에서 빠진다**(프로브로 확인: `LF` 가 1 줄었고 `DA:` 목록에서 사라졌다). 예외가 조용한 침식이 아니라 diff 에 남는 명시적 편집이 된다. 유일한 적용처는 `TextItemPresentation.labelOf` 의 `throw` 로, 생성자 assert 가 debug 에서 먼저 터지므로 **release 전용 가드**임을 증명한 뒤 감쌌다.
+- **커버리지는 "무엇을 안 봤는지" 를 알려주지, "본 것이 옳은지" 는 말해주지 않는다.** 실증: 커버리지를 처음 켜자 `lib/` 80.6% 였고, 미커버의 대부분이 여섯 개 `copyWith` 였다. 그리고 **테스트 155 개 중 메뉴 항목을 탭하는 것이 하나도 없었다** — 이 위젯의 존재 이유인 상호작용이다. 배치·테마·오버레이·검색은 겹겹이 덮여 있었다.
+- **아카이브 내용을 ASCII 로 확인한다.** `pub publish --dry-run` 의 트리는 `├──` 를 쓴다. `|--` 로 grep 하면 무엇을 넣든 빈 결과가 나온다 — 어느 쪽이든 빈 결과가 나오는 검사는 검사가 아니다. 실증: `coverage/` 를 `.gitignore` 에 넣기 전 `lcov.info` 가 아카이브에 실려 있었고, `tool/` 도 그랬다. **둘 다 `dry-run` 경고 0 인 상태였다.** `tool/.pubignore` 와 `docs/.pubignore` 가 각각 막는다.
+- **`dart format` 은 패키지의 language version 을 따른다.** 실증: SDK 바닥을 Dart 3.8 로 올리자 3.7 의 tall style 이 켜지며 35 개 파일이 재포맷됐다. 제약 변경의 필연적 결과다.
+- 브랜치 → PR(`Closes #issue`) → **CI 그린 확인** → 머지. `main` 에 직접 커밋하지 않는다.
+- **`flutter pub publish` 는 되돌릴 수 없고 pub.dev 는 버전 삭제가 없다(retract 만). 에이전트가 실행하지 않는다 — 사용자가 직접.**
+
 ## Package Overview
 
 `flutter_dropdown_button` is a Flutter package providing a single, highly customizable dropdown widget rendered through an `OverlayEntry` rather than Flutter's built-in menu machinery.
@@ -83,6 +210,27 @@ Every module here separates **reading from the element tree** from **deciding wi
 
 The second half is where the bugs are, and it is the half worth testing. When adding a module, keep the split.
 
+### Flutter's replace-don't-merge APIs
+
+Several Flutter slots **replace** what the ambient theme provided rather than merging with it. Naming one part blanks the rest. This package has been bitten by four, each a shipped bug:
+
+| API | Naming any part of it … | Fixed in |
+| --- | --- | --- |
+| `Tooltip.decoration` | … blanks the background, the radius, the shadow | 2.5.0 |
+| `ScrollbarTheme` | … replaces the ambient one outright | 2.5.0 |
+| `Text.semanticsLabel` | … **replaces** the announced string rather than adding to it | 3.0.0 |
+| `Scrollbar.thickness` | … pins it; leaving it null lets hover swell the bar 8 → 12 | 3.0.1 |
+
+The rule that falls out: **a resolved style is complete, or it is null.** Fill every slot the ambient default would have filled, or hand Flutter nothing and let the ambient theme keep control. Never hand it a half-built value.
+
+And when you pin a value to stop Flutter changing it, pin **the value it would have rested at** — ask the ambient theme first, then Flutter's own default. `Scrollbar` thickness is 8 on desktop and **4 on Android**; a flat `8.0` doubles the bar on every Android build.
+
+### 필드를 지우면 간접적으로 못박혀 있던 것이 풀린다
+
+`DropdownScrollTheme.trackWidth` 는 어떤 위젯에도 전달되지 않았다. 그래서 3.0.0 이 지웠다. 그런데 그것이 `hasCustomWidths` 를 먹였고, `hasCustomWidths` 는 **non-null `thickness`** 를 넘기는 분기를 열었다. `trackWidth` 만 설정한 테마는 hover 두께가 **우연히** 못박혀 있었고, 제거가 그것을 풀었다.
+
+필드를 지우기 전에 **모든 읽기 지점을 grep 한다** — 불리언 하나를 계산할 뿐인 곳까지.
+
 ## Deprecated
 
 **Nothing.** `lib/` contains zero `@Deprecated` annotations.
@@ -97,107 +245,11 @@ When you do deprecate a member, annotate the **field, the constructor parameter 
 
 Beware the dartdoc link. `See [trackWidth].` inside another member's doc comment counts as a *use* of a deprecated member to the analyzer shipping with Flutter 3.32, and `flutter analyze` exits 1 on a single `info`. Our local stable did not flag it; the `minimum` CI job did.
 
-## 작업 flow
-
-*Substantive 변경*(버그 수정·기능 추가·동작 변경)이면 이 순서로 짠다. 단계를 *생략*하려면 (건너뛰는 게 아니라) *왜 이 변경엔 해당 없는지를 명시*한다 — 조용한 스킵 금지.
-
-괄호 안 실증은 전부 **이 repo 에서 실제로 일어난 일**이다. 그 단계를 건너뛰었다면 놓쳤을 것이다.
-
-### 1. 이슈 먼저 — 실측 숫자·기각한 대안·부정 결과
-
-**이슈 본문에 쓴 근거도 실측 대상이다.** 틀린 근거가 기록에 남으면 다음 사람이 그걸 믿는다.
-
-- 실증(#2): 이슈에 *"항목 리스트를 제자리 변경하면 stale 해진다"* 를 결함으로 적었다. 테스트를 써보니 **고치기 전 코드에서도 통과**했다 — `openDropdown()` 이 `_resetSearch()` 로 다시 채운다. 공개 정정 코멘트를 달고 그 테스트는 특성화로 남겼다.
-- 실증(#32): 이슈에 *"`resolve()` 는 ambient 가 필요 없다"* 고 썼다. Flutter 의 `Tooltip` 소스를 열어보니 기본 배경이 `brightness` 에 따라 갈린다. 착수하며 `resolve(Brightness)` 로 정정했다.
-- 실증(#47): 코드를 읽고 *"바닥은 Flutter 3.27"* 이라 판단했다. CI 가 두 번 반박했다(3.27 → `Tooltip.constraints` 없음, 3.29 → 여전히 없음). 진짜 바닥은 3.32 였다.
-
-**기각한 대안과 그 이유를 함께 적는다.** 실증(#50): `_presentation` 을 빌드 스코프로 캐싱하는 안을 기각했다 — 이 repo 의 가장 비싼 버그들이 전부 stale cache 였다(2.4.0 에서 지운 `_filteredItems` 는 네 곳에서 무효화해야 했고 세 곳에서 틀렸다). 기각 사유를 PR 에 적지 않으면 다음 사람이 같은 안을 다시 낸다.
-
-**부정 결과도 남긴다.** 실증(#9): "테마 프리미티브 통합" 을 `wontfix` 로 닫으며, `backgroundColor` 가 세 클래스에 있는 건 *이름의 중복이지 개념의 중복이 아니다*(메뉴 배경·검색창 배경·툴팁 배경) 를 코멘트에 남겼다. 그 재평가 과정에서 투명 툴팁 버그(#32)가 나왔다.
-
-### 2. 추측 금지 — 프로브로 실측한다
-
-**코드를 *읽어서* 얻은 확신은 확신이 아니다.**
-
-- **버리는 프로브** (`test/_probe_*.dart`, 확인 후 삭제). 숫자는 이슈/PR 에 남긴다.
-  - 실증(#32): 툴팁 프로브가 `"Fruit picker" 노드 3 / "Apple" 노드 0` 을 찍었다. `Text.semanticsLabel` 은 읽히는 문자열을 **대체**한다.
-  - 실증(#50): `DropdownTheme` 를 상속해 `resolveButton()` 호출을 셌다 — 첫 빌드 2, 메뉴 열기 4, **한 글자 입력 2**. 고친 뒤 1·1·**0**.
-  - 실증(#45): `alwaysVisible: true` 와 기본값의 `Scrollbar.thumbVisibility` 가 **둘 다 `null`** 이었다. `thumbVisibility: true` 만 `true` 를 냈다.
-- **Flutter SDK 소스를 직접 열어본다** (`/d/flutter/bin/cache/pkg/sky_engine/lib/ui/…`). 기억 금지. 실증: `withOpacity` 가 `@Deprecated('Use .withValues() …')` 로 표시된 걸 보고서야 `withValues` 가 더 새 API 임을 확정했다.
-- **debug 동작을 프로덕션 동작으로 착각하지 마라.** 실증(`test/text_label_test.dart`): `const Fruit('Apple')` 로 "다른 인스턴스" 를 증명하려 했으나 Dart 는 동일 인자의 `const` 를 **같은 인스턴스로 정규화**한다. `const` 를 떼고 `// ignore: prefer_const_constructors` 와 이유를 달았다.
-- **"확인했다" 가 정말 확인인지 본다.**
-  - 실증: `dart format --output=none --set-exit-if-changed . 2>&1 | tail -1 && git add …` 로 게이트를 걸었다. **파이프라인의 종료 코드는 `tail` 의 것**이라 항상 0 이다. `false | tail -1; echo $?` → `0`. 이 세션의 `flutter test 2>&1 | tail -1 && …` 게이트는 전부 가짜였고, 실제로 포맷 안 된 코드가 커밋됐다. **게이트는 파이프에 물리지 않는다.**
-  - 실증: 파일을 고쳤다고 보고한 뒤 `git status` 가 clean 이었다 — 편집이 실행되지 않았다. **수정했다고 말하기 전에 `git status` / `grep` 으로 파일을 다시 읽는다.**
-
-**"확인 못 했다" ≠ "없다".** 미확인 사실은 갭이다. 이슈로 올리거나 사용자에게 묻는다.
-
-### 3. 설계 판단은 코드 전에 사용자와 확정
-
-**TDD 는 "무엇이 옳은가" 를 답해주지 않는다.** *결정 유형으로 라우팅*한다.
-
-- **순수 메커니즘**(좌표계·훅 선택·자료구조 — 소스로 도출 가능) → 직접 결정하고 **검증 결과만** 제시.
-- **계약·정책**(공개 API 표면, 동작 변경 허용 여부, deprecate 냐 즉시 제거냐) → **묻는다.** 실증(#45): `alwaysVisible` 을 3.0.0 에서 바로 지울지 4.0.0 으로 미룰지는 red 를 쓰기 전에 정해야 했다. 실증(#51): 같은 질문을 `trackWidth` 에는 묻지 않아 두 필드가 다르게 처리됐고, 사용자가 그 비일관성을 잡아냈다.
-
-### 4. `/tdd` 로 RED→GREEN 수직 슬라이스
-
-한 번에 하나 — 테스트 하나 → 최소 구현 → 반복.
-
-- **순수 리팩터·삭제에는 red 가 없다.** `/tdd` 대신 **특성화 테스트**가 안전망이다. 기존 스위트가 **파일 수정 없이** 통과해야 한다. 실증: 배치 추출·컨트롤러 추출·테마 해석 재작성·presentation seam·검색 컨트롤러 — 다섯 번 모두 테스트를 한 줄도 안 고치고 통과했다.
-- **RED 가 정말 RED 인지 본다.** 실증(#40): 그라디언트 첫 테스트가 빨갛게 떴지만 원인이 **finder 가 gradient 없는 `Container` 를 잡은 것**이었다. finder 를 고쳐서, red 가 *색 순서* 때문에 뜨도록 만든 뒤에야 의미가 생겼다.
-- **red 였다가 green 이 됐는데 코드가 맞고 테스트가 틀린 경우가 있다.** 실증(#37): 고친 뒤에도 `find.bySemanticsLabel('Fruit picker')` 가 못 찾았다. semantics 트리를 덤프하니 `InkWell` 이 자손 노드를 병합해 라벨이 `"Fruit picker\nBanana"` 였다. **병합된 라벨이 곧 계약**이므로 테스트를 고쳤다.
-
-### 5. 테스트 신뢰 게이트
-
-- **구분력이 있는가 — `git stash push -- lib/` 로 증명한다.** 고친 뒤에 쓴 테스트는 한 번도 빨간 적이 없다. 되돌려 돌려보고, 안 깨지면 회귀 테스트가 아니다. 실증: 이 방식으로 무의미한 테스트 둘을 찾아냈고, 매 PR 마다 red/guard 를 갈랐다.
-- **실패할 수 없는 테스트는 그렇다고 소스에 적는다.** `// Guard, not a regression test: this passed before the fix too.` 실증(#40): 그 guard 가 **진단을 확정했다** — 사용자가 색을 직접 준 경우는 언제나 옳게 그려졌고, 기본 목록만 뒤집혀 있었다.
-- **렌더 결과만 보는 테스트는 계약을 못 본다.** 실증(#37): `semanticsLabel` 버그는 `find.text('Apple')` 을 통과한다. 화면엔 "Apple" 이 멀쩡히 있다. **semantics 트리**만 다른 말을 했고, 이 패키지는 거길 한 번도 본 적이 없었다.
-- **호출 횟수를 세는 테스트는 넣지 않는다.** 구현 세부이고 다음 리팩터가 바꿀 자유가 있다. 숫자는 프로브에서 뽑아 PR 에 적는다(#50).
-
-### 6. `/code-review` — 서로 다른 렌즈로
-
-구현·테스트가 끝나고 릴리스 전에 돌린다. 지적은 고치거나, 안 고치면 *왜 안 고치는지*를 남긴다.
-
-실증: 결합도·응집도·중복·적대적 검증 네 렌즈를 각각 다른 subagent 에 맡겼다. 적대적 담당은 "리팩터가 행동을 바꿨다" 를 **반증하지 못했고**(그게 답이다), 중복 담당이 `totalChromeHeight` 를 위젯이 손으로 다시 더하고 있음을 찾았다 — 2.3.2 와 2.5.0 에서 두 번 터진 바로 그 버그의 원인.
-
-두 에이전트가 `semanticsLabel` 비대칭을 두고 서로 다르게 말했다. **둘 다 맞았다** — 비대칭은 실재하지만 그 리팩터가 만든 게 아니었다. 렌즈를 나누는 이유다.
-
-### 7. 정합성 스윕 — 동작을 기술하는 모든 표면
-
-코드만 고치고 끝나는 변경은 없다. 아무도 안 보므로 **명시적으로 훑는다**.
-
-- **`CHANGELOG.md`** — pub.dev 는 *발행 시점의* CHANGELOG 를 스냅샷으로 박는다. **이미 발행된 버전의 항목을 고치지 말고 새 버전을 연다.** 이 repo 의 CHANGELOG 는 버그 인벤토리다(아래 Version Management).
-- **`README.md` / `documentation/`** — 공개 시그니처가 바뀌면 같은 커밋에서 고친다. 실증: `api_reference.md` 의 `closeAll()` 절이 *"애니메이션 없이 즉시 제거"* 와 *"한 번에 하나만 열림"* 을 주장했다. 전자는 `animate` 기본값이 `true` 라 거짓, 후자는 2.4.0 부터 `Overlay` 단위다. **둘 다 두 겹으로 낡아 있었다.**
-- **dartdoc 도 표면이다.** 실증(#38): `thickness` 의 문서가 *"Deprecated: 대신 `thumbWidth` 와 `trackWidth` 를 쓰라"* 고 말했다. `thickness` 는 deprecated 가 아니었고 `trackWidth` 는 아무 일도 안 했다. 화살표가 거꾸로였다. 실증(#45): `DropdownScrollTheme` 과 `DropdownStyleTheme` 의 클래스 예제가 죽은 필드 `alwaysVisible` 을 **쓰라고 가르치고** 있었다.
-- **`example/`** — 별도 패키지다. deprecation 경고가 실제로 뜨는지는 여기서만 보인다. 실증: 플레이그라운드가 아무것도 안 움직이는 `trackWidth` 슬라이더를 노출하고 있었다.
-- **`.pubignore`** — 루트에 `.pubignore` 를 두면 pub 은 **git 기반 파일 목록을 끈다**(`.gitignore` 가 무력화된다). 이 repo 는 그래서 `docs/.pubignore` 만 둔다. **pub.dev 아카이브는 한 번 올라가면 내릴 수 없다.**
-- **낡은 근거 회수** — 앞선 이슈·PR 에 적은 근거가 뒤 작업에 의해 거짓이 된다. 실증: 3.0.0 머리말이 *"deprecated 된 것만 제거한다"* 고 단언했으나 `alwaysVisible` 은 deprecated 된 적이 없었고, *"동작 변화 없음"* 도 `semanticsLabel` 수정으로 거짓이 됐다. 둘 다 고쳤다.
-
-### 8. 게이트 & PR & 릴리스
-
-CI(`.github/workflows/ci.yml`)가 매 PR 에서 돈다. **로컬 게이트는 CI 를 대신하지 않는다.**
-
-```
-minimum (Flutter 3.32.0)   pub get / analyze / test --coverage / check_coverage --min 100 / example analyze
-stable  (Flutter stable)   같음
-package                    dart format --set-exit-if-changed  /  pub publish --dry-run
-```
-
-- **`minimum` 잡이 핵심이다.** `stable` 만 돌리면 pubspec 이 `>=3.10` 을 약속하고 3.32 API 를 쓰는 상태가 **영원히 초록**이다. 실증(#47): 이 잡이 첫 실행에서 서로 다른 두 사실을 잡았다 — `Tooltip.constraints` 가 3.27/3.29 에 없음, 그리고 **analyzer 규칙이 버전마다 다름**(3.32 는 dartdoc 링크를 deprecated 사용으로 셈). *"로컬에서 analyze 클린"* 은 *"선언한 바닥에서 클린"* 을 전혀 보장하지 않는다.
-- **`flutter analyze` 는 `info` 하나에도 exit 1 이다.**
-- **`pub publish --dry-run` 은 컴파일하지 않는다.** 파일 크기·라이선스·문서·git 청결도만 본다. 이 세션의 PR 47 개 내내 경고 0 이었고, 그동안 pubspec 은 거짓말을 하고 있었다.
-- **커버리지 바닥은 100 이다.** 여유를 두면 딱 그 여유만큼의 회귀를 허용하고, 실제 회귀는 임계값 바로 아래에 앉는다. 실증: `test/selection_test.dart` 를 통째로 지우면 **99.57%** — 바닥이 99 였다면 통과했을 것이다. 빨간 빌드를 초록으로 만들려고 바닥을 내리지 않는다.
-- **덮을 수 없는 줄은 `// coverage:ignore-start` / `ignore-end` 로 감싼다.** 그 줄들은 미커버로 세는 게 아니라 **분모에서 빠진다**(프로브로 확인: `LF` 가 1 줄었고 `DA:` 목록에서 사라졌다). 예외가 조용한 침식이 아니라 diff 에 남는 명시적 편집이 된다. 유일한 적용처는 `TextItemPresentation.labelOf` 의 `throw` 로, 생성자 assert 가 debug 에서 먼저 터지므로 **release 전용 가드**임을 증명한 뒤 감쌌다.
-- **커버리지는 "무엇을 안 봤는지" 를 알려주지, "본 것이 옳은지" 는 말해주지 않는다.** 실증: 커버리지를 처음 켜자 `lib/` 80.6% 였고, 미커버의 대부분이 여섯 개 `copyWith` 였다. 그리고 **테스트 155 개 중 메뉴 항목을 탭하는 것이 하나도 없었다** — 이 위젯의 존재 이유인 상호작용이다. 배치·테마·오버레이·검색은 겹겹이 덮여 있었다.
-- **아카이브 내용을 ASCII 로 확인한다.** `pub publish --dry-run` 의 트리는 `├──` 를 쓴다. `|--` 로 grep 하면 무엇을 넣든 빈 결과가 나온다 — 어느 쪽이든 빈 결과가 나오는 검사는 검사가 아니다. 실증: `coverage/` 를 `.gitignore` 에 넣기 전 `lcov.info` 가 아카이브에 실려 있었고, `tool/` 도 그랬다. **둘 다 `dry-run` 경고 0 인 상태였다.** `tool/.pubignore` 와 `docs/.pubignore` 가 각각 막는다.
-- **`dart format` 은 패키지의 language version 을 따른다.** 실증: SDK 바닥을 Dart 3.8 로 올리자 3.7 의 tall style 이 켜지며 35 개 파일이 재포맷됐다. 제약 변경의 필연적 결과다.
-- 브랜치 → PR(`Closes #issue`) → **CI 그린 확인** → 머지. `main` 에 직접 커밋하지 않는다.
-- **`flutter pub publish` 는 되돌릴 수 없고 pub.dev 는 버전 삭제가 없다(retract 만). 에이전트가 실행하지 않는다 — 사용자가 직접.**
-
 ## Development Commands
 
 ```bash
 flutter pub get                                    # install dependencies
-flutter test                                       # 207 tests
+flutter test                                       # 222 tests
 flutter test --coverage                            # writes coverage/lcov.info
 dart run tool/check_coverage.dart --min 100 --report
 flutter analyze                                    # exits 1 on a single `info`
@@ -212,7 +264,7 @@ cd example && flutter run                          # the playground app
 
 ## Testing
 
-207 tests, **100% line coverage**. 98 of them run without mounting a widget at all.
+222 tests, **100% line coverage** (937 lines). 98 of them run without mounting a widget at all.
 
 | Suite | What it covers |
 | --- | --- |
@@ -241,6 +293,7 @@ cd example && flutter run                          # the playground app
 | `test/remaining_behaviours_test.dart` | Tooltip modes, runtime `searchable`, `isTextMode` |
 | `test/overlay_controller_widget_test.dart` | The controller driven bare, with its own chrome |
 | `test/last_four_lines_test.dart` | Unwrapped overflow; the gradient's controller swap |
+| `test/scrollbar_duplication_test.dart` | One scrollbar per menu, across four platforms |
 
 **Conventions that matter here:**
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^3.0.0
+  flutter_dropdown_button: ^3.0.1
 ```
 
 Import the package:
@@ -291,7 +291,8 @@ Controls scrollbar appearance inside the dropdown overlay.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `thumbWidth` | `double?` | `null` | Width of the scrollbar thumb |
+| `thumbWidth` | `double?` | `null` | Width of the scrollbar. Wins over `thickness` |
+| `thickness` | `double?` | `null` | Thickness of the scrollbar. Unset, the ambient `ScrollbarTheme` decides, then Flutter's own default — **8 on desktop, 4 on Android** |
 | `radius` | `Radius?` | `null` | Corner radius of scrollbar thumb |
 | `thumbColor` | `Color?` | `null` | Color of the scrollbar thumb |
 | `trackColor` | `Color?` | `null` | Color of the scrollbar track |

--- a/documentation/migration.md
+++ b/documentation/migration.md
@@ -1,5 +1,17 @@
 # Migration Guide
 
+## Upgrading to 3.0.1
+
+No API changed. Three bugs did, and two of them are visible.
+
+**Your menu had two scrollbars on desktop.** Flutter's `MaterialScrollBehavior` adds one to every scroll view; this package added a second on top. You now see one. If you were compensating for the extra bar — a transparent thumb, an outsized `crossAxisMargin` — undo it.
+
+**The scrollbar no longer swells on hover.** It grew from 8 to 12 logical pixels when a pointer entered a visible track, because the thickness handed to Flutter was `null`. It now rests at the size it always drew at, and stays there.
+
+**A dropdown with no `DropdownScrollTheme` now gets one.** Previously the menu fell through to Flutter's automatic scrollbar entirely. The default theme draws the same thing, but `DropdownScrollTheme` now governs it — so `thumbColor` and friends take effect where they silently did not before.
+
+Nothing to change in your code.
+
 ## Migrating from 2.x to 3.0.0
 
 Version 3.0.0 removes everything deprecated during the 2.x line. Nothing was renamed and no behaviour changed — each removed member already had a replacement that was doing the work.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.0.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -397,7 +397,11 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
   ResolvedSearchFieldStyle get _searchStyle =>
       effectiveSearchTheme.resolve(_ambient);
 
-  DropdownScrollTheme? get effectiveScrollTheme => widget.theme?.scroll;
+  /// Never null. Without one the menu used to fall through to the scrollbar
+  /// Flutter's `MaterialScrollBehavior` inserts on desktop, which answers to
+  /// nothing this package exposes and swells on hover.
+  DropdownScrollTheme get effectiveScrollTheme =>
+      widget.theme?.scroll ?? DropdownScrollTheme.defaultTheme;
 
   DropdownTooltipTheme get effectiveTooltipTheme =>
       widget.theme?.tooltip ?? DropdownTooltipTheme.defaultTheme;
@@ -778,15 +782,13 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
         ),
       );
 
-      if (scrollTheme != null) {
-        content = _applyScrollbarTheme(content, scrollTheme);
-      }
+      content = _applyScrollbarTheme(content, scrollTheme);
 
-      if (scrollTheme?.showScrollGradient == true) {
+      if (scrollTheme.showScrollGradient == true) {
         content = ScrollGradientOverlay(
           controller: _scrollController!,
           fadeInto: _overlayStyle.backgroundColor,
-          height: scrollTheme!.resolve().gradientHeight,
+          height: scrollTheme.resolve().gradientHeight,
           borderRadius: _overlayStyle.borderRadius,
           colors: scrollTheme.gradientColors,
           child: content,
@@ -912,14 +914,35 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
 
   // ===== Scrollbar =====
 
+  /// The thickness this scrollbar would rest at if we named none.
+  ///
+  /// Naming it is what stops Flutter swelling a track-showing scrollbar from 8
+  /// to 12 while a pointer hovers (`material/scrollbar.dart:303`). But the value
+  /// must be the one the caller would otherwise have got, or pinning it becomes
+  /// a silent restyle:
+  ///
+  /// * an app-wide [ScrollbarTheme] is asked first, at rest;
+  /// * failing that, Flutter's own default — **halved on Android**, so a flat
+  ///   `8.0` would double the bar on every Android build.
+  double get _restingScrollbarThickness {
+    final ambient = ScrollbarTheme.of(
+      context,
+    ).thickness?.resolve(<WidgetState>{});
+    if (ambient != null) return ambient;
+
+    return Theme.of(context).platform == TargetPlatform.android ? 4.0 : 8.0;
+  }
+
   Widget _applyScrollbarTheme(Widget content, DropdownScrollTheme scrollTheme) {
     final style = scrollTheme.resolve();
 
     final scrollbar = Scrollbar(
       controller: _scrollController,
-      thickness: style.hasCustomWidths
-          ? style.thumbWidth
-          : scrollTheme.thickness,
+      // Never null. Flutter swells a thickness-less scrollbar from 8 to 12
+      // while a pointer hovers a visible track (`material/scrollbar.dart:303`);
+      // naming the thickness it would have used anyway pins it without changing
+      // how the bar looks at rest.
+      thickness: style.thickness ?? _restingScrollbarThickness,
       radius: style.radius,
       thumbVisibility: style.thumbVisibility,
       trackVisibility: style.trackVisibility,
@@ -927,9 +950,17 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
       child: content,
     );
 
-    if (!style.overridesScrollbarTheme) return scrollbar;
+    // Desktop's `MaterialScrollBehavior` wraps every scroll view in a
+    // `Scrollbar` of its own. Ours would sit on top of it, two bars deep, and
+    // the one underneath answers to nothing this theme says.
+    final only = ScrollConfiguration(
+      behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+      child: scrollbar,
+    );
 
-    return ScrollbarTheme(data: style.scrollbarTheme, child: scrollbar);
+    if (!style.overridesScrollbarTheme) return only;
+
+    return ScrollbarTheme(data: style.scrollbarTheme, child: only);
   }
 
   // ===== Scroll gradients =====

--- a/lib/src/theme/dropdown_scroll_theme.dart
+++ b/lib/src/theme/dropdown_scroll_theme.dart
@@ -44,13 +44,20 @@ class DropdownScrollTheme {
 
   /// Thickness of the scrollbar — both its thumb and its track.
   ///
-  /// If null, the ambient `ScrollbarTheme` decides, then Flutter's own
-  /// platform-dependent default. [thumbWidth] wins over this.
+  /// If null, the ambient `ScrollbarTheme` decides, and failing that Flutter's
+  /// own default: **8 logical pixels, halved to 4 on Android.**
+  ///
+  /// Whatever the source, the menu hands `Scrollbar` a concrete number rather
+  /// than null. Flutter swells a thickness-less scrollbar from 8 to 12 while a
+  /// pointer hovers a visible track; pinning the resting value stops that
+  /// without changing how the bar looks at rest.
+  ///
+  /// [thumbWidth] wins over this.
   final double? thickness;
 
   /// Width of the scrollbar, named from the thumb's point of view.
   ///
-  /// Wins over [thickness]; falls back to it, then to `8.0`.
+  /// Wins over [thickness]; failing both, `8.0`.
   ///
   /// The track is drawn at this width too — Flutter's scrollbars have one
   /// thickness, not two.

--- a/lib/src/theme/resolved_dropdown_style.dart
+++ b/lib/src/theme/resolved_dropdown_style.dart
@@ -180,7 +180,10 @@ class ResolvedScrollStyle {
   /// Height of the fade shown when the list can scroll.
   final double gradientHeight;
 
-  /// Whether the caller named a thumb or track width of their own.
+  /// Whether the caller named a thumb width of their own.
+  ///
+  /// Informational. [thickness] already carries the answer this used to gate,
+  /// so nothing inside the package branches on it any more.
   final bool hasCustomWidths;
 
   /// Colours, margins and thumb length, in the shape `ScrollbarTheme` takes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues

--- a/test/scrollbar_duplication_test.dart
+++ b/test/scrollbar_duplication_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// On desktop, `MaterialScrollBehavior` wraps every scroll view in a
+/// `Scrollbar` of its own. The menu drew one too, so two were stacked.
+///
+/// Neither carried a thickness unless the caller named one, and
+/// `material/scrollbar.dart:303` swells a thickness-less scrollbar from 8 to 12
+/// the moment a pointer hovers a visible track.
+///
+/// `debugDefaultTargetPlatformOverride` must be restored inside the test body —
+/// `tearDown` is too late, and `flutter_test` fails the test for it.
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+Future<void> openMenu(WidgetTester tester, DropdownScrollTheme scroll) async {
+  await tester.pumpWidget(
+    host(
+      FlutterDropdownButton<String>.text(
+        width: 200,
+        height: 100,
+        items: const ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+        hint: 'pick',
+        theme: DropdownStyleTheme(scroll: scroll),
+        onChanged: (_) {},
+      ),
+    ),
+  );
+  await tester.tap(find.byType(FlutterDropdownButton<String>));
+  await tester.pumpAndSettle();
+}
+
+List<Scrollbar> scrollbars(WidgetTester tester) =>
+    tester.widgetList<Scrollbar>(find.byType(Scrollbar)).toList();
+
+/// Runs [body] with [platform] in force, restoring it before the test ends.
+Future<void> on(TargetPlatform platform, Future<void> Function() body) async {
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+  }
+}
+
+void main() {
+  const platforms = [
+    TargetPlatform.windows,
+    TargetPlatform.macOS,
+    TargetPlatform.linux,
+    TargetPlatform.android,
+  ];
+
+  for (final platform in platforms) {
+    testWidgets('$platform: the menu draws exactly one scrollbar', (
+      tester,
+    ) async {
+      await on(platform, () async {
+        await openMenu(tester, const DropdownScrollTheme());
+
+        expect(scrollbars(tester), hasLength(1));
+      });
+    });
+
+    testWidgets('$platform: the thickness is never null', (tester) async {
+      await on(platform, () async {
+        // A thickness-less scrollbar with a visible track swells from 8 to 12
+        // the moment a pointer enters. Naming a thickness pins it.
+        await openMenu(
+          tester,
+          const DropdownScrollTheme(trackVisibility: true),
+        );
+
+        expect(scrollbars(tester), hasLength(1));
+        expect(scrollbars(tester).first.thickness, isNotNull);
+      });
+    });
+  }
+
+  // One platform per test. Reopening the menu on the same `tester` taps the
+  // button a second time, which closes it.
+  testWidgets("desktop keeps Flutter's 8px default", (tester) async {
+    await on(TargetPlatform.windows, () async {
+      await openMenu(tester, const DropdownScrollTheme());
+
+      expect(scrollbars(tester).first.thickness, 8.0);
+    });
+  });
+
+  testWidgets("Android keeps Flutter's halved 4px default", (tester) async {
+    await on(TargetPlatform.android, () async {
+      await openMenu(tester, const DropdownScrollTheme());
+
+      expect(
+        scrollbars(tester).first.thickness,
+        4.0,
+        reason: 'a flat 8.0 would double the bar on every Android build',
+      );
+    });
+  });
+
+  testWidgets('a themed thickness still wins', (tester) async {
+    await on(TargetPlatform.windows, () async {
+      await openMenu(tester, const DropdownScrollTheme(thickness: 6));
+
+      expect(scrollbars(tester), hasLength(1));
+      expect(scrollbars(tester).first.thickness, 6.0);
+    });
+  });
+
+  testWidgets('a themed thumbWidth still wins', (tester) async {
+    await on(TargetPlatform.windows, () async {
+      await openMenu(tester, const DropdownScrollTheme(thumbWidth: 4));
+
+      expect(scrollbars(tester), hasLength(1));
+      expect(scrollbars(tester).first.thickness, 4.0);
+    });
+  });
+
+  testWidgets('a menu with no scroll theme still gets ours', (tester) async {
+    // `DropdownScrollTheme` was optional, and without one `_applyScrollbarTheme`
+    // never ran. The menu fell through to Flutter's automatic scrollbar, which
+    // answers to nothing this package exposes.
+    await on(TargetPlatform.windows, () async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            width: 200,
+            height: 100,
+            items: const ['a', 'b', 'c', 'd', 'e', 'f'],
+            hint: 'pick',
+            onChanged: (_) {},
+          ),
+        ),
+      );
+      await tester.tap(find.byType(FlutterDropdownButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(scrollbars(tester), hasLength(1));
+      expect(scrollbars(tester).first.thickness, 8.0);
+    });
+  });
+
+  testWidgets('an app-wide ScrollbarTheme still sets the thickness', (
+    tester,
+  ) async {
+    // Pinning a thickness must not silently overrule the app's own theme.
+    await on(TargetPlatform.windows, () async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            scrollbarTheme: ScrollbarThemeData(
+              thickness: WidgetStateProperty.all(10.0),
+            ),
+          ),
+          home: Scaffold(
+            body: Center(
+              child: FlutterDropdownButton<String>.text(
+                width: 200,
+                height: 100,
+                items: const ['a', 'b', 'c', 'd', 'e', 'f'],
+                hint: 'pick',
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byType(FlutterDropdownButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(scrollbars(tester).first.thickness, 10.0);
+    });
+  });
+
+  testWidgets('interactive: false is still honoured', (tester) async {
+    // This already worked — our scrollbar owns the gesture, not Flutter's.
+    // Pinned so that suppressing the automatic one cannot quietly change it.
+    await on(TargetPlatform.windows, () async {
+      await openMenu(
+        tester,
+        const DropdownScrollTheme(thumbVisibility: true, interactive: false),
+      );
+
+      final controller = tester
+          .widget<ListView>(find.byType(ListView))
+          .controller!;
+      final box = tester.getRect(find.byType(ListView));
+
+      await tester.dragFrom(
+        Offset(box.right - 2, box.top + 5),
+        const Offset(0, 40),
+      );
+      await tester.pumpAndSettle();
+
+      expect(controller.offset, 0, reason: 'nobody may drag this thumb');
+    });
+  });
+}


### PR DESCRIPTION
Three bugs in the menu's scrollbar. Every claim in the report was checked against the source before anything changed, and **one of the three was refuted**.

## Verified

**1) Two scrollbars, stacked. TRUE.**

`grep -rn ScrollConfiguration lib/` → **0 hits**. `git log -S'ScrollConfiguration' -- lib/` → **0 commits**. Desktop's `MaterialScrollBehavior` inserts a `Scrollbar` around every scroll view; `_applyScrollbarTheme` added a second on top.

Counted with `debugDefaultTargetPlatformOverride`:

| platform | `Scrollbar` widgets | thicknesses, given `thickness: 6` |
| --- | --- | --- |
| windows / macOS / linux | **2** | `[6.0, null]` |
| android | 1 | `[6.0]` |

Ours takes the theme's value. The automatic one is always `null`.

**3) The `null` thickness path. TRUE.**

`material/scrollbar.dart:303`:

```dart
return widget.thickness ??                       // non-null pins it
    _scrollbarTheme.thickness?.resolve(states) ??
    _kScrollbarThicknessWithTrack;               // 12.0, when hovered + track
```

The swell only reaches a scrollbar whose `thickness` is null. Ours was null whenever the caller named neither `thickness` nor `thumbWidth` — including `trackVisibility: true` alone, which is why that combination shows the symptom most clearly.

## Refuted

**2) The automatic scrollbar steals `interactive` drags. FALSE.**

Isolated, same gesture:

```
interactive: false → offset stays 0
interactive: null  → offset moves 218px
```

Our scrollbar owns the gesture. An earlier probe appeared to show otherwise, but it dragged three times inside one `testWidgets`; the first scroll woke the automatic bar's thumb and the next drag landed on it. **Two probes corrected each other.** A test now pins `interactive: false` so that suppressing the automatic bar cannot quietly change it.

## Found while verifying

**A dropdown with no `DropdownScrollTheme` had no scrollbar of its own at all.**

`effectiveScrollTheme` was nullable and `_applyScrollbarTheme` ran only when it was non-null. Without a theme the menu fell through entirely to Flutter's automatic bar — unstyleable, and swelling. `dropdown`, `tooltip` and `search` have always fallen back to their `defaultTheme`; `scroll` now does too.

## The fix

```dart
final only = ScrollConfiguration(
  behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
  child: Scrollbar(thickness: style.thickness ?? _restingScrollbarThickness, ...),
);
```

`_restingScrollbarThickness` is deliberately **not** the flat `8.0` the dartdoc promised:

- the ambient `ScrollbarTheme` is asked first, at rest. Pinning a value must not silently overrule the app's own theme — the same trap `Tooltip.decoration` and `ScrollbarTheme` set for this package twice before, now tabulated in `CLAUDE.md`;
- failing that, Flutter's own default: 8 on desktop, **4 on Android**. A flat `8.0` would have doubled the bar on every Android build.

## Backward compatibility

| | before | after |
| --- | --- | --- |
| `thickness: 6` | 6 | 6 |
| `thumbWidth: 4` | 4 | 4 |
| no theme, desktop | Flutter's bar at 8 | ours at 8 |
| no theme, Android | 4 | 4 |
| app-wide `ScrollbarTheme(thickness: 10)` | 10 | 10 |
| `interactive: false` | honoured | honoured |

Every pre-existing scrollbar test passes unedited, including the guard `an unstyled scroll theme leaves the ambient ScrollbarTheme alone` — we still wrap in `ScrollbarTheme` only when the caller names something it carries.

## `trackWidth` did not cause this

It never reached any widget, and `ScrollConfiguration` has never existed here. The duplicate bar predates its removal.

But removing it **did** have a side effect I missed. `hasCustomWidths` was `thumbWidth != null || trackWidth != null`, and it gated a branch that passed a **non-null** thickness. A theme naming only `trackWidth` therefore had its hover pinned by accident, and 3.0.0 unpinned it. Moot now — the thickness is always pinned, and `hasCustomWidths` is read by nothing. Its dartdoc says so.

`CLAUDE.md` records the general rule: before deleting a field, grep every read, including the ones that only compute a boolean.

## Tests

222, up from 207, still 100% line coverage (937 lines). Fifteen new ones drive the scrollbar across `windows`, `macOS`, `linux` and `android`.

Two harness traps, recorded in the test file and in `CLAUDE.md`:

- `debugDefaultTargetPlatformOverride` must be restored **inside** the test body. `tearDown` is too late and `flutter_test` fails the test for it — four of the first nine reds were that, not the bug.
- Reopening the menu on the same `tester` taps the button a second time, which closes it.

## Release

Cut as **3.0.1**: three fixes, no new public members. `flutter pub publish --dry-run` reports 0 warnings, and `coverage/` and `tool/` are absent from the archive.

`documentation/migration.md` gains an `Upgrading to 3.0.1` note. Nothing to change in caller code, but two of the three fixes are visible on screen, and a dropdown with no `DropdownScrollTheme` now honours one where it silently did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)