### PR TITLE
docs: DropdownScrollTheme's null semantics, as Flutter actually resolves them

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,19 +293,23 @@ Controls scrollbar appearance inside the dropdown overlay.
 |-----------|------|---------|-------------|
 | `thumbWidth` | `double?` | `null` | Width of the scrollbar. Wins over `thickness` |
 | `thickness` | `double?` | `null` | Thickness of the scrollbar. Unset, the ambient `ScrollbarTheme` decides, then Flutter's own default — **8 on desktop, 4 on Android** |
-| `radius` | `Radius?` | `null` | Corner radius of scrollbar thumb |
+| `radius` | `Radius?` | `null` | Corner radius of scrollbar thumb. Unset, `Radius.circular(8)` on desktop and square on Android |
 | `thumbColor` | `Color?` | `null` | Color of the scrollbar thumb |
-| `trackColor` | `Color?` | `null` | Color of the scrollbar track |
-| `trackBorderColor` | `Color?` | `null` | Border color of the scrollbar track |
-| `thumbVisibility` | `bool?` | `null` | Show/hide scrollbar thumb |
-| `trackVisibility` | `bool?` | `null` | Show/hide scrollbar track |
-| `interactive` | `bool?` | `null` | Allow dragging the scrollbar thumb |
+| `trackColor` | `Color?` | `null` | Color of the scrollbar track. **Paints nothing unless `trackVisibility` is `true`** |
+| `trackBorderColor` | `Color?` | `null` | Border color of the scrollbar track, on the same terms as `trackColor` |
+| `thumbVisibility` | `bool?` | `null` | `true` pins the thumb on screen. `false` and `null` behave alike: it fades in while scrolling and fades out |
+| `trackVisibility` | `bool?` | `null` | `true` draws the track and pins the thumb with it. Unset, there is **no track** |
+| `interactive` | `bool?` | `null` | `false` makes the thumb undraggable. Unset, Flutter decides — **draggable on desktop**, not on Android |
 | `crossAxisMargin` | `double?` | `null` | Margin from edge of scroll view |
 | `mainAxisMargin` | `double?` | `null` | Margin at top/bottom of scrollbar |
 | `minThumbLength` | `double?` | `null` | Minimum length of scrollbar thumb |
 | `showScrollGradient` | `bool?` | `false` | Show fade gradient when scrollable |
 | `gradientHeight` | `double?` | `24.0` | Height of gradient effect |
 | `gradientColors` | `List<Color>?` | `null` | Custom gradient colors (auto-detects from background if `null`) |
+
+> A colour is not a request. `trackColor` describes the track; `trackVisibility`
+> is what draws it. A `null` `bool?` means *let the ambient `ScrollbarTheme`
+> decide* — not *off*.
 
 ### DropdownTooltipTheme
 

--- a/example/lib/pages/playground_page.dart
+++ b/example/lib/pages/playground_page.dart
@@ -160,7 +160,10 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
   Color? _dstTrackBorderColor;
   bool _dstThumbVisibility = false;
   bool _dstTrackVisibility = false;
-  bool _dstInteractive = false;
+
+  // Matches what a null `interactive` resolves to on desktop. Starting at
+  // `false` shipped a demo whose scrollbar could not be dragged.
+  bool _dstInteractive = true;
   bool _dstShowScrollGradient = false;
   double _dstGradientHeight = 24.0;
 

--- a/lib/src/theme/dropdown_scroll_theme.dart
+++ b/lib/src/theme/dropdown_scroll_theme.dart
@@ -13,10 +13,20 @@ import 'resolved_dropdown_style.dart';
 ///   thickness: 8.0,
 ///   radius: Radius.circular(4.0),
 ///   thumbColor: Colors.grey,
-///   trackColor: Colors.grey.withOpacity(0.2),
+///   trackColor: Colors.grey.withValues(alpha: 0.2),
 ///   thumbVisibility: true,
+///   trackVisibility: true,
 /// )
 /// ```
+///
+/// **A colour is not a request.** [trackColor] and [trackBorderColor] say what
+/// the track looks like once it is drawn; [trackVisibility] is what draws it.
+/// Naming a track colour and leaving [trackVisibility] null paints nothing.
+///
+/// **Null is not "off".** Every `bool?` here defaults to null, which means *let
+/// the ambient `ScrollbarTheme` decide, and failing that Flutter*. For
+/// [interactive] that resolves to **draggable** on desktop, not to "display
+/// only". Pass `false` when you mean off.
 class DropdownScrollTheme {
   /// Creates a dropdown scroll theme configuration.
   const DropdownScrollTheme({
@@ -65,44 +75,65 @@ class DropdownScrollTheme {
 
   /// Radius of the scrollbar thumb corners.
   ///
-  /// If null, uses the default scrollbar radius.
-  /// Makes the scrollbar thumb rounded at the corners.
+  /// If null, the ambient `ScrollbarTheme` decides, and failing that Flutter's
+  /// own default: **`Radius.circular(8)` on desktop, square on Android.**
   final Radius? radius;
 
-  /// Color of the scrollbar thumb.
+  /// Color of the scrollbar thumb — the draggable part.
   ///
-  /// If null, uses the theme's default scrollbar color.
-  /// The thumb is the draggable part of the scrollbar.
+  /// If null, the ambient `ScrollbarTheme` decides, and failing that Flutter's
+  /// own default, which fades between an idle and a hovered shade.
   final Color? thumbColor;
 
-  /// Color of the scrollbar track.
+  /// Color of the scrollbar track — the channel the thumb slides along.
   ///
-  /// If null, no track is displayed.
-  /// The track is the background area behind the thumb.
+  /// **Only drawn when [trackVisibility] is true.** A colour on its own paints
+  /// nothing: Flutter resolves the track's colour to transparent whenever the
+  /// track is hidden, and the track is hidden by default.
+  ///
+  /// If null while the track *is* visible, the ambient `ScrollbarTheme`
+  /// decides, and failing that Flutter tints it from `ColorScheme.onSurface`.
   final Color? trackColor;
 
-  /// Color of the scrollbar track border.
+  /// Color of the outline around the scrollbar track.
   ///
-  /// If null, no track border is displayed.
-  /// Creates an outline around the scrollbar track.
+  /// **Only drawn when [trackVisibility] is true**, on the same terms as
+  /// [trackColor].
   final Color? trackBorderColor;
 
-  /// Whether the scrollbar thumb should be visible.
+  /// Whether the thumb stays visible once scrolling stops.
   ///
-  /// If false, hides the scrollbar thumb.
-  /// If true or null, shows the thumb when appropriate.
+  /// If **true**, the thumb is pinned on screen.
+  ///
+  /// If **false or null** — these behave identically — the thumb fades in while
+  /// the list scrolls and fades out shortly after it stops. Neither value hides
+  /// it outright.
+  ///
+  /// Setting [trackVisibility] to true raises this to true, because Flutter
+  /// cannot draw a track without a thumb.
   final bool? thumbVisibility;
 
-  /// Whether the scrollbar track should be visible.
+  /// Whether the track is drawn behind the thumb.
   ///
-  /// If false, hides the scrollbar track.
-  /// If true or null, shows the track when scrollbar is visible.
+  /// If **null**, the ambient `ScrollbarTheme` decides, and failing that
+  /// Flutter's own default: **false**. There is no track, and [trackColor] and
+  /// [trackBorderColor] paint nothing.
+  ///
+  /// If **true**, the track is drawn and [thumbVisibility] is raised to true
+  /// along with it, because Flutter cannot draw a track without a thumb.
+  ///
+  /// Flutter widens a thickness-less scrollbar from 8 to 12 while a pointer
+  /// hovers a visible track. The menu hands `Scrollbar` a concrete [thickness]
+  /// whatever this theme says, so the bar keeps its width. Nothing to do here.
   final bool? trackVisibility;
 
-  /// Whether the scrollbar can be interacted with.
+  /// Whether the user may drag the thumb.
   ///
-  /// If true, users can drag the scrollbar thumb to scroll.
-  /// If false or null, the scrollbar is for display only.
+  /// If **null**, the ambient `ScrollbarTheme` decides, and failing that
+  /// Flutter's own default, which is **draggable on desktop** and not on
+  /// Android. Null does not mean "display only".
+  ///
+  /// Pass **false** for a scrollbar that is drawn but cannot be grabbed.
   final bool? interactive;
 
   /// The margin around the scrollbar's cross axis.
@@ -148,8 +179,8 @@ class DropdownScrollTheme {
   /// ```dart
   /// gradientColors: [
   ///   Colors.white,
-  ///   Colors.white.withOpacity(0.5),
-  ///   Colors.white.withOpacity(0.0),
+  ///   Colors.white.withValues(alpha: 0.5),
+  ///   Colors.white.withValues(alpha: 0.0),
   /// ]
   /// ```
   ///

--- a/test/scrollbar_duplication_test.dart
+++ b/test/scrollbar_duplication_test.dart
@@ -200,4 +200,36 @@ void main() {
       expect(controller.offset, 0, reason: 'nobody may drag this thumb');
     });
   });
+
+  // Guard, not a regression test: this passed before the docs were corrected.
+  //
+  // It pins the claim `interactive`'s dartdoc now makes. `Scrollbar` resolves a
+  // null `interactive` to `!_useAndroidScrollbar` (material/scrollbar.dart:218),
+  // so on desktop the thumb is draggable — the opposite of what the doc used to
+  // say. One gesture per test: an earlier drag wakes the thumb and the next one
+  // lands on it.
+  testWidgets('interactive: null leaves the thumb draggable on desktop', (
+    tester,
+  ) async {
+    await on(TargetPlatform.windows, () async {
+      await openMenu(tester, const DropdownScrollTheme(thumbVisibility: true));
+
+      final controller = tester
+          .widget<ListView>(find.byType(ListView))
+          .controller!;
+      final box = tester.getRect(find.byType(ListView));
+
+      await tester.dragFrom(
+        Offset(box.right - 2, box.top + 5),
+        const Offset(0, 40),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.offset,
+        greaterThan(0),
+        reason: 'null means "ask the ambient theme", and it says draggable',
+      );
+    });
+  });
 }

--- a/test/scrollbar_theme_test.dart
+++ b/test/scrollbar_theme_test.dart
@@ -69,4 +69,31 @@ void main() {
     expect(tester.widget<Scrollbar>(find.byType(Scrollbar)).thickness, 6);
     expect(tester.takeException(), isNull);
   });
+
+  // Guard, not a regression test: this passed before the docs were corrected.
+  //
+  // A track colour is a colour, not a request for a track. `Scrollbar` paints
+  // the track only when `showScrollbar && trackVisibility` — the colour is
+  // resolved to transparent otherwise (material/scrollbar.dart:274).
+  //
+  // Pinned because "you named a track colour, so you want a track" is the
+  // tempting fix, and it would grow a track — and an always-visible thumb —
+  // under every app that names one. Implementing it must break this test.
+  testWidgets('a track colour alone does not ask for a track', (tester) async {
+    await openMenu(tester, const DropdownScrollTheme(trackColor: Colors.red));
+
+    final scrollbar = tester.widget<Scrollbar>(find.byType(Scrollbar));
+    expect(scrollbar.trackVisibility, isNull);
+    expect(scrollbar.thumbVisibility, isNull);
+
+    final data = tester
+        .widget<ScrollbarTheme>(find.byType(ScrollbarTheme))
+        .data;
+    expect(
+      data.trackColor!.resolve({}),
+      Colors.red,
+      reason:
+          'the colour is forwarded; it is Flutter that declines to paint it',
+    );
+  });
 }


### PR DESCRIPTION
Closes #59.

Documentation only. `lib/` gains no statement — every changed line in it is a comment.

## What was wrong

Five fields described a `null` behaviour that is the reverse of Flutter's. Each row was read out of the SDK, not remembered:

| Field | The doc said | Flutter does | Source |
| --- | --- | --- | --- |
| `trackColor` | "If null, no track is displayed" | Non-null displays nothing either — the track needs `trackVisibility: true` | `material/scrollbar.dart:274` |
| `trackBorderColor` | "If null, no track border is displayed" | Same | `material/scrollbar.dart:287` |
| `trackVisibility` | "If true **or null**, shows the track" | `null` → `false`. No track. | `material/scrollbar.dart:222` (`?? false`) |
| `thumbVisibility` | "If **false**, hides the thumb" | `false` and `null` are identical — the thumb fades in on scroll and fades out | `widgets/scrollbar.dart:1388` |
| `interactive` | "If false **or null**, display only" | Reversed. `null` → `!_useAndroidScrollbar` → draggable on desktop | `material/scrollbar.dart:218` |
| `radius` | "the default scrollbar radius" | `Radius.circular(8)` on desktop, **square** on Android | `material/scrollbar.dart:355` |

`interactive` is the worst, and the counter-evidence was already in hand: the probe cut for 3.0.1 measured `interactive: false` → `0px` scrolled and `interactive: null` → `218px`. The number went into the PR; the doc was never corrected.

The class-level example taught the dead combination — a `trackColor` with no `trackVisibility` — which is how a downstream app came to set one and see nothing. It also used `withOpacity`, which is `@Deprecated('Use .withValues() ...')`, as did the `gradientColors` example.

## What changed

- `lib/src/theme/dropdown_scroll_theme.dart` — the six field docs; the class example gains `trackVisibility: true` and loses both `withOpacity` calls. Two rules stated once at the class level: *a colour is not a request*, and *null is not "off"*.
- `README.md` — the scrollbar table gave a `null` default and never said what `null` meant.
- `example/lib/pages/playground_page.dart` — `_dstInteractive` started at `false`, so the shipped demo had a scrollbar nobody could drag. It now starts where a null `interactive` resolves to on desktop.

## Tests

Two characterization tests, both labelled as guards. They pin what the new documentation claims, so a future Flutter release cannot quietly make these docs wrong the way it made the old ones wrong.

- `interactive: null leaves the thumb draggable on desktop` — the counterpart to the existing `interactive: false is still honoured`. Alone, either test proves nothing; the pair distinguishes.
- `a track colour alone does not ask for a track` — also a tripwire. It fails if anyone implements the tempting fix below.

Suite goes 222 → 224. Coverage stays 100.00% (937/937).

## Rejected: make `trackColor` imply `trackVisibility: true`

"You named a track colour, so you want a track" is tempting and wrong.

Flutter keeps colour and visibility apart in `ScrollbarThemeData` deliberately. Adding the implication would make this theme behave unlike the Flutter theme it forwards to — a fresh surprise for the next reader rather than a removed one. It is also a **behaviour change**: every app currently passing a `trackColor` would grow a track, and since a track requires a visible thumb, its scrollbar would stop fading out. Not a patch release.

The bug was in what we taught, so the teaching is what changed.

## Prior art

Third time in this file. #38: `thickness`'s doc had the deprecation arrow backwards. #45: the class examples of `DropdownScrollTheme` and `DropdownStyleTheme` taught the dead field `alwaysVisible`.

The architecture detects a dead *field* — `resolve()` never mentions it. It cannot detect a dead *combination*: `resolve()` does mention `trackColor`. A consumer found this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)