### PR TITLE
chore: release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.0.2
+
+Documentation only. No statement in `lib/` changed — every corrected line is a comment. It is released because pub.dev renders the dartdoc of the version it was published from, so a reader of 3.0.1's API page is still told the opposite of what the code does. A downstream app set a `trackColor`, saw no track, and was right to be confused.
+
+* **CHANGE**: `DropdownScrollTheme.interactive`'s dartdoc said `null` meant "display only". It means the opposite: `Scrollbar` resolves a null `interactive` to `!_useAndroidScrollbar`, so the thumb is **draggable on desktop**. Pass `false` when you mean off
+* **CHANGE**: `DropdownScrollTheme.trackColor` and `.trackBorderColor` said "if null, no track is displayed", implying a colour draws one. It does not. The track is drawn by `trackVisibility: true` and by nothing else; Flutter resolves a hidden track's colour to transparent. **A colour is not a request**
+* **CHANGE**: `DropdownScrollTheme.trackVisibility` said "if true **or null**, shows the track". Null resolves to `false`. There is no track by default
+* **CHANGE**: `DropdownScrollTheme.thumbVisibility` said `false` hides the thumb. `false` and `null` behave identically — the thumb fades in while the list scrolls and fades out after. Only `true` pins it. Setting `trackVisibility: true` raises this to `true`, because Flutter cannot draw a track without a thumb
+* **CHANGE**: `DropdownScrollTheme.radius`'s "the default scrollbar radius" is `Radius.circular(8)` on desktop and **square on Android**
+* **CHANGE**: The class-level example for `DropdownScrollTheme` taught a `trackColor` with no `trackVisibility` — the combination that draws nothing — and used `withOpacity`, which is deprecated. Both fixed, here and in the `gradientColors` example. The playground's `interactive` toggle started at `false`, shipping a demo scrollbar nobody could drag
+* **TEST**: 224 tests, up from 222, still at 100% line coverage. Both new ones are guards on the corrected docs: a null `interactive` is draggable, and a track colour alone does not ask for a track. The second fails if anyone makes `trackColor` imply `trackVisibility`
+
 ## 3.0.1
 
 * **FIX**: The menu drew **two scrollbars** on desktop. `MaterialScrollBehavior` wraps every scroll view in a `Scrollbar` of its own, and this package added a second on top without suppressing it. The one underneath answered to nothing `DropdownScrollTheme` says. The list is now wrapped in `ScrollConfiguration(scrollbars: false)`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^3.0.1
+  flutter_dropdown_button: ^3.0.2
 ```
 
 Import the package:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 3.0.1
+version: 3.0.2
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues


### PR DESCRIPTION
Documentation only. No statement in `lib/` changed between 3.0.1 and this — every corrected line is a comment.

## Why release at all

pub.dev renders the dartdoc of the version it was published from. A reader landing on 3.0.1's API page is still told that `interactive: null` means "display only" and that a `trackColor` draws a track. Both are false, and a downstream app followed the class example, set a `trackColor`, and saw nothing.

The correction only reaches anyone if it is published.

## Contents

The doc fix merged in #60 (closes #59):

- `interactive: null` is **draggable on desktop**, not "display only" — `material/scrollbar.dart:218`
- `trackColor` / `trackBorderColor` paint nothing without `trackVisibility: true` — `material/scrollbar.dart:274`
- `trackVisibility: null` resolves to `false` — `material/scrollbar.dart:222`
- `thumbVisibility: false` and `null` are identical — `widgets/scrollbar.dart:1388`
- `radius: null` is `Radius.circular(8)` on desktop, **square** on Android — `material/scrollbar.dart:355`
- The class example taught the dead `trackColor`-without-`trackVisibility` combination, and used `withOpacity`
- The playground's `interactive` toggle started at `false`, shipping a demo scrollbar nobody could drag

## Gates

Run bare, not piped.

```
dart format --output=none --set-exit-if-changed .   exit 0
flutter analyze                                     No issues found!
flutter test --coverage                             224 passed
dart run tool/check_coverage.dart --min 100         100.00% (937/937)
flutter pub publish --dry-run                       0 warnings
cd example && flutter analyze                       No issues found!
```

`flutter pub publish` is not run by an agent. pub.dev has no version deletion, only retraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)