### PR TITLE
fix: the button draws the value it was handed, even when items no longer offers it

### DIFF
--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -255,7 +255,13 @@ presentation.defaultSearchFilter!(user, 'ann');
 
 Renders each item as whatever `itemBuilder` returns. `defaultSearchFilter` is null: it cannot match an arbitrary widget against a query, so a caller who wants search must supply `searchFilter`.
 
-`buildSelected()` falls back to `hintWidget` when `value` is null **or is not among `items`**.
+`buildSelected()` falls back to `hintWidget` only when `value` is **null**.
+
+A `value` that is not among `items` — the state a list refresh leaves behind when the chosen row's data disappears — is still drawn. **The widget draws what it was handed**: `value` belongs to the caller, and auditing it against `items` would make the button disagree with the state its owner holds. Text mode never audited it, having no `items` to consult; since 3.1.0 custom mode does not either.
+
+The menu is a separate matter. It iterates `items`, so an absent value is never a row.
+
+`items` is therefore read by nothing and is **deprecated**; it will be removed in 4.0.0.
 
 ## DropdownSearchController\<T\>
 

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -156,6 +156,12 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   final ValueChanged<T?> onChanged;
 
   /// The currently selected value.
+  ///
+  /// Drawn on the button whether or not it appears in [items]. A list that
+  /// refreshes can drop the chosen row while this still names it; the button
+  /// keeps showing it rather than quietly reverting to the hint, because this
+  /// value belongs to the caller. The menu is a separate matter — it iterates
+  /// [items], so an absent value is never a row.
   final T? value;
 
   // --- Custom mode fields ---
@@ -423,7 +429,6 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>>
     if (itemBuilder != null) {
       return CustomItemPresentation<T>(
         itemBuilder: itemBuilder,
-        items: widget.items,
         value: widget.value,
         selectedBuilder: widget.selectedBuilder,
         hintWidget: widget.hintWidget,

--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -220,8 +220,13 @@ class CustomItemPresentation<T> implements DropdownItemPresentation<T> {
   /// Creates the custom-widget presentation.
   const CustomItemPresentation({
     required this.itemBuilder,
-    required this.items,
     required this.value,
+    @Deprecated(
+      'Read by nothing since 3.1.0. The button draws `value` whether or not it '
+      'appears in `items`, the way text mode always has. Drop the argument. '
+      'This parameter will be removed in 4.0.0.',
+    )
+    this.items = const [],
     this.selectedBuilder,
     this.hintWidget,
   });
@@ -229,7 +234,16 @@ class CustomItemPresentation<T> implements DropdownItemPresentation<T> {
   /// Builds one item row.
   final Widget Function(T item, bool isSelected) itemBuilder;
 
-  /// The items on offer, consulted to decide whether [value] is still one.
+  /// The items on offer.
+  ///
+  /// Read by nothing. [buildSelected] once consulted it to decide whether
+  /// [value] was still on offer, and drew [hintWidget] when it was not. It no
+  /// longer does: the widget draws what it was handed.
+  @Deprecated(
+    'Read by nothing since 3.1.0. The button draws `value` whether or not it '
+    'appears in `items`, the way text mode always has. Drop the argument. '
+    'This field will be removed in 4.0.0.',
+  )
   final List<T> items;
 
   /// The chosen item, if any.
@@ -255,7 +269,7 @@ class CustomItemPresentation<T> implements DropdownItemPresentation<T> {
   @override
   Widget buildSelected() {
     final selected = value;
-    if (selected != null && items.contains(selected)) {
+    if (selected != null) {
       final build = selectedBuilder;
       if (build != null) return build(selected);
       return itemBuilder(selected, true);

--- a/test/ghost_value_test.dart
+++ b/test/ghost_value_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A **ghost value** is a `value` that is not in `items` — the state a list
+/// refresh leaves behind when the chosen row's data disappears.
+///
+/// The rule: **the widget draws what it was handed.** `value` belongs to the
+/// caller, and the widget renders it rather than auditing it against `items`.
+///
+/// Text mode always did this; it has no `items` to consult. Custom mode used to
+/// fall back to `hintWidget`, so a caller who set a `value` was silently told
+/// that nothing was selected.
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  testWidgets('custom mode draws a ghost value rather than the hint', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>(
+          width: 200,
+          items: const ['a', 'b'],
+          value: 'ghost',
+          itemBuilder: (item, isSelected) => Text(item),
+          hintWidget: const Text('HINT'),
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('ghost'), findsOneWidget);
+    expect(find.text('HINT'), findsNothing);
+  });
+
+  // Guard, not a regression test: text mode passed before the rule was written
+  // down, because `TextItemPresentation` holds no `items` and could not have
+  // filtered. It is pinned so the two modes cannot drift apart again.
+  testWidgets('text mode draws a ghost value rather than the hint', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>.text(
+          width: 200,
+          items: const ['a', 'b'],
+          value: 'ghost',
+          hint: 'HINT',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('ghost'), findsOneWidget);
+    expect(find.text('HINT'), findsNothing);
+  });
+
+  // Guard. The menu iterates `items`, so it never drew a ghost row, and the
+  // face's rule must not leak into the list.
+  testWidgets('the open menu draws no row for a ghost value', (tester) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>.text(
+          width: 200,
+          items: const ['a', 'b'],
+          value: 'ghost',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+    await tester.tap(find.byType(FlutterDropdownButton<String>));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('ghost'),
+      findsOneWidget,
+      reason: 'the button face, and no row',
+    );
+    expect(find.text('a'), findsOneWidget);
+    expect(find.text('b'), findsOneWidget);
+  });
+
+  testWidgets('a null value still shows the hint in both modes', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        FlutterDropdownButton<String>(
+          width: 200,
+          items: const ['a'],
+          itemBuilder: (item, isSelected) => Text(item),
+          hintWidget: const Text('HINT'),
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.text('HINT'), findsOneWidget);
+  });
+}

--- a/test/presentation/item_presentation_test.dart
+++ b/test/presentation/item_presentation_test.dart
@@ -33,7 +33,6 @@ TextItemPresentation<T> text<T>({
 }
 
 CustomItemPresentation<T> custom<T>({
-  required List<T> items,
   T? value,
   Widget Function(T)? selectedBuilder,
   Widget? hintWidget,
@@ -41,7 +40,6 @@ CustomItemPresentation<T> custom<T>({
   return CustomItemPresentation<T>(
     // The flag is in the text so a caller can see which one it was handed.
     itemBuilder: (item, isSelected) => Text('$item/$isSelected'),
-    items: items,
     value: value,
     selectedBuilder: selectedBuilder,
     hintWidget: hintWidget,
@@ -64,10 +62,7 @@ void main() {
     });
 
     test('custom mode is always left, whatever the text config says', () {
-      expect(
-        custom<String>(items: const ['a']).contentAlignment,
-        Alignment.centerLeft,
-      );
+      expect(custom<String>().contentAlignment, Alignment.centerLeft);
     });
   });
 
@@ -81,7 +76,7 @@ void main() {
     });
 
     test('custom mode has none — it cannot read a widget', () {
-      expect(custom<String>(items: const ['a']).defaultSearchFilter, isNull);
+      expect(custom<String>().defaultSearchFilter, isNull);
     });
   });
 
@@ -107,26 +102,28 @@ void main() {
   });
 
   group('custom selected widget', () {
-    test('a value absent from items falls back to the hint', () {
-      final presentation = custom<String>(
-        items: const ['a', 'b'],
-        value: 'gone',
-        hintWidget: const Text('pick one'),
-      );
+    // The contract changed. This test used to assert the opposite — that a
+    // value absent from `items` fell back to the hint — and that is what text
+    // mode never did, because `TextItemPresentation` has no `items` to consult.
+    // The widget draws what it was handed; `value` is the caller's.
+    test(
+      'a value absent from items is still drawn, not swapped for the hint',
+      () {
+        final presentation = custom<String>(
+          value: 'gone',
+          hintWidget: const Text('pick one'),
+        );
 
-      expect((presentation.buildSelected() as Text).data, 'pick one');
-    });
+        expect((presentation.buildSelected() as Text).data, 'gone/true');
+      },
+    );
 
     test('no value and no hint widget draws nothing', () {
-      expect(
-        custom<String>(items: const ['a']).buildSelected(),
-        isA<SizedBox>(),
-      );
+      expect(custom<String>().buildSelected(), isA<SizedBox>());
     });
 
     test('selectedBuilder wins over itemBuilder for the button face', () {
       final presentation = custom<String>(
-        items: const ['a'],
         value: 'a',
         selectedBuilder: (item) => Text('face:$item'),
       );
@@ -135,7 +132,7 @@ void main() {
     });
 
     test('without selectedBuilder, itemBuilder draws the face as selected', () {
-      final presentation = custom<String>(items: const ['a'], value: 'a');
+      final presentation = custom<String>(value: 'a');
 
       expect(
         (presentation.buildSelected() as Text).data,
@@ -145,7 +142,7 @@ void main() {
     });
 
     test('an item row is drawn unselected unless it is the value', () {
-      final presentation = custom<String>(items: const ['a', 'b'], value: 'a');
+      final presentation = custom<String>(value: 'a');
 
       expect((presentation.buildItem('a', true) as Text).data, 'a/true');
       expect((presentation.buildItem('b', false) as Text).data, 'b/false');


### PR DESCRIPTION
Closes #62.

## The bug

A `value` that is not in `items` — a **ghost value**, the state a list refresh leaves behind when the chosen row's data disappears — reached the button's face differently in each mode. Probe, `items: ['a', 'b']`, `value: 'ghost'`:

```
TEXT    ghost visible: 1   hint visible: 0     // drew the ghost's label
CUSTOM  ghost visible: 0   hint visible: 1     // fell back to hintWidget
OPEN    ghost occurrences: 1   rows a/b: 1/1   // neither drew a ghost row
```

Nobody decided this. `CustomItemPresentation` held `items` and checked it (`item_presentation.dart:258`); `TextItemPresentation` has no `items` field and could not have checked if it wanted to. Two behaviours, one of them undocumented and the other documented backwards — `api_reference.md:258` taught the custom-mode rule as though it were the rule.

The custom-mode half is the surprising one: set a `value`, get the **hint**. Silently, with no callback and no error, the widget said nothing was selected.

## The rule

**The widget draws what it was handed.** `value` belongs to the caller. Auditing it against `items` makes the button disagree with the state its owner holds, and when they disagree the owner debugs their own state first.

The menu is untouched: it iterates `items` (`:769`, `:799`), so a ghost is still never a row.

## `CustomItemPresentation.items` is now read by nothing

Deprecated, not removed. It is `required` on an exported class, so removing it is breaking, and — unlike `trackWidth` and `alwaysVisible`, which 3.0.0 deleted outright — this field **did** something until today. Callers have an argument to drop. That is what a deprecation window is for.

Removed in 4.0.0. Annotated on the field **and** on the constructor parameter separately: `@Deprecated` does not propagate from a field to its initializing formal, and 3.0.0 was bitten by exactly that with `DropdownTheme.animationDuration`. Verified from `example/`, which is a separate package — inside this one the analyzer stays quiet:

```
info - 'items' is deprecated ... This parameter will be removed in 4.0.0 - lib\_probe_dep.dart:10:5
info - 'items' is deprecated ... This field will be removed in 4.0.0     - lib\_probe_dep.dart:13:19
```

Two distinct messages, so both annotations bite. The probe was deleted.

## Tests

`test/presentation/item_presentation_test.dart` had a test named **`a value absent from items falls back to the hint`**. It was not wrong; it was the old contract, written down. It is rewritten to the new one, and that is what made red.

`test/ghost_value_test.dart` is new. Its distinguishing power was proved by reverting the fix — `git stash push -- lib/` — after which **exactly one** of the four goes red:

```
custom mode draws a ghost value rather than the hint   [E]   <- the regression test
text mode draws a ghost value rather than the hint           <- guard: passed before
the open menu draws no row for a ghost value                 <- guard: passed before
a null value still shows the hint in both modes              <- guard: passed before
```

The three guards say so in their comments. Path-scoped `stash push -- lib/`, so the new test file was not stashed along with the fix into a vacuous green.

228 tests, up from 224. Coverage 100.00% (935/935 — two lines fewer, the deleted guard).

## Not in this PR

`CHANGELOG.md`. #66 owns the `3.1.0` section, and the deprecation message promises 3.1.0. The entry is a `CHANGE`, naming the symptom: custom-mode buttons showed the hint when `value` went stale.

## Gates

Run bare.

```
dart format --output=none --set-exit-if-changed .   exit 0
flutter analyze                                     No issues found!
flutter test --coverage                             228 passed
dart run tool/check_coverage.dart --min 100         100.00% (935/935)
cd example && flutter analyze                       No issues found!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)