### PR TITLE
feat: MultiSelectPresentation, whose checkbox rows announce checked rather than disabled

### DIFF
--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -278,6 +278,134 @@ class CustomItemPresentation<T> implements DropdownItemPresentation<T> {
   }
 }
 
+/// Renders items as a checklist: a box, a label, and an optional trailing
+/// widget. The button's face is whatever [labelBuilder] makes of the chosen set.
+class MultiSelectPresentation<T> implements DropdownItemPresentation<T> {
+  /// Creates the checklist presentation.
+  MultiSelectPresentation({
+    required this.selected,
+    required this.labelBuilder,
+    required this.label,
+    required this.config,
+    required this.tooltipTheme,
+    required this.enabled,
+    this.itemTrailingBuilder,
+  }) : assert(
+         label != null || T == String,
+         'FlutterMultiSelectDropdown<$T> needs a `label` callback.\n'
+         'Rows render as text, so it must know how to turn a $T into a String.',
+       );
+
+  /// The chosen items, as the caller holds them.
+  final Set<T> selected;
+
+  /// Turns an item into the string that represents it.
+  final String Function(T item)? label;
+
+  /// Turns the chosen set into the button's face.
+  final String Function(Set<T> selected) labelBuilder;
+
+  /// Text rendering rules: overflow, alignment, styles.
+  final TextDropdownConfig config;
+
+  /// Styling and behaviour of the overflow tooltip.
+  final DropdownTooltipTheme tooltipTheme;
+
+  /// Whether the button is interactive, which selects the disabled text style.
+  final bool enabled;
+
+  /// Drawn at the end of each row. Its text is merged into the row's announced
+  /// label by the row's `InkWell`, so a count reads as part of the item.
+  final Widget Function(T item)? itemTrailingBuilder;
+
+  /// The text [item] displays.
+  String labelOf(T item) {
+    final extract = label;
+    if (extract != null) return extract(item);
+    if (item is String) return item;
+
+    // coverage:ignore-start
+    throw FlutterError(
+      'FlutterMultiSelectDropdown<$T> needs a `label` callback.',
+    );
+    // coverage:ignore-end
+  }
+
+  @override
+  Alignment get contentAlignment => _alignmentOf(config.textAlign);
+
+  @override
+  DropdownSearchFilter<T>? get defaultSearchFilter =>
+      (item, query) =>
+          labelOf(item).toLowerCase().contains(query.toLowerCase());
+
+  SmartTooltipText _text(String text, TextStyle? style) => SmartTooltipText(
+    text: text,
+    tooltipTheme: tooltipTheme,
+    style: style,
+    textAlign: config.textAlign,
+    maxLines: config.maxLines,
+    overflow: config.overflow,
+    softWrap: config.softWrap,
+    textDirection: config.textDirection,
+    locale: config.locale,
+    textScaler: config.textScaler,
+  );
+
+  /// One checklist row.
+  ///
+  /// The box is **presentational**. `onChanged: null` gives it no gesture
+  /// recognizer, so a tap on it falls through to the row's `InkWell` — measured,
+  /// not assumed: a row taps once whether or not the box is wrapped in an
+  /// `IgnorePointer`, so there is no wrapper here.
+  ///
+  /// What `onChanged: null` *does* cost is the semantics tree. Once the
+  /// `InkWell` merges its descendants, the row inherits the box's
+  /// `isEnabled: false`, and a screen reader calls every row of a working
+  /// checklist *dimmed*. `IgnorePointer` does not help — it suppresses
+  /// hit-testing, not semantics. So the box is excluded from the tree and the
+  /// checked state is re-attached to the row, which is the interactive thing.
+  ///
+  /// None of this is visible on screen. It was found with a semantics probe.
+  @override
+  Widget buildItem(T item, bool isSelected) {
+    final trailing = itemTrailingBuilder?.call(item);
+
+    return Semantics(
+      checked: isSelected,
+      child: Row(
+        children: [
+          ExcludeSemantics(child: Checkbox(value: isSelected, onChanged: null)),
+          Flexible(
+            child: _text(
+              labelOf(item),
+              isSelected
+                  ? config.selectedTextStyle ?? config.textStyle
+                  : config.textStyle,
+            ),
+          ),
+          if (trailing != null) trailing,
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget buildSelected() {
+    final baseStyle = config.textStyle;
+    final resolvedStyle = !enabled && config.disabledTextStyle != null
+        ? (baseStyle?.merge(config.disabledTextStyle) ??
+              config.disabledTextStyle)
+        : baseStyle;
+
+    final face = _text(labelBuilder(selected), resolvedStyle);
+
+    final describe = config.semanticsLabel;
+    if (describe == null) return face;
+    return Semantics(label: describe, child: face);
+  }
+}
+
 Alignment _alignmentOf(TextAlign textAlign) {
   switch (textAlign) {
     case TextAlign.center:

--- a/test/presentation/multi_select_presentation_test.dart
+++ b/test/presentation/multi_select_presentation_test.dart
@@ -1,0 +1,314 @@
+import 'dart:ui' show CheckedState, Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A checklist row must announce that it is checked, and must not announce
+/// that it is disabled.
+///
+/// A presentational `Checkbox` — one with `onChanged: null`, so the row's own
+/// `InkWell` owns the gesture — carries `isEnabled: false` into the semantics
+/// tree. `IgnorePointer` does not strip it; it suppresses hit-testing only.
+/// Nothing on screen differs, so this is invisible to a render test.
+
+MultiSelectPresentation<T> multi<T>({
+  required Set<T> selected,
+  String Function(T)? label,
+  String Function(Set<T>)? labelBuilder,
+  Widget Function(T)? itemTrailingBuilder,
+  bool enabled = true,
+  TextDropdownConfig config = TextDropdownConfig.defaultConfig,
+}) {
+  return MultiSelectPresentation<T>(
+    selected: selected,
+    label: label,
+    labelBuilder: labelBuilder ?? (s) => '${s.length} selected',
+    config: config,
+    tooltipTheme: DropdownTooltipTheme.defaultTheme,
+    enabled: enabled,
+    itemTrailingBuilder: itemTrailingBuilder,
+  );
+}
+
+/// The style the face was actually rendered with.
+TextStyle? faceStyle(WidgetTester tester) =>
+    tester.widget<Text>(find.byType(Text).first).style;
+
+/// Renders [child] the way `DropdownMenuShell` does: inside the row's InkWell,
+/// which merges its descendants' semantics into one node.
+Future<SemanticsNode> rowNode(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Material(
+          child: InkWell(onTap: () {}, child: child),
+        ),
+      ),
+    ),
+  );
+  return tester.getSemantics(find.byType(InkWell).first);
+}
+
+void main() {
+  group('semantics', () {
+    testWidgets('a chosen row announces that it is checked', (tester) async {
+      final handle = tester.ensureSemantics();
+      final presentation = multi<String>(selected: {'a'});
+
+      final node = await rowNode(tester, presentation.buildItem('a', true));
+
+      expect(
+        node.getSemanticsData().flagsCollection.isChecked,
+        CheckedState.isTrue,
+      );
+      handle.dispose();
+    });
+
+    testWidgets('an unchosen row announces that it is not checked', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final presentation = multi<String>(selected: {'a'});
+
+      final node = await rowNode(tester, presentation.buildItem('b', false));
+
+      expect(
+        node.getSemanticsData().flagsCollection.isChecked,
+        CheckedState.isFalse,
+      );
+      handle.dispose();
+    });
+
+    testWidgets('a row never announces that it is disabled', (tester) async {
+      // The regression test. A bare `Checkbox(onChanged: null)` — and one
+      // wrapped in `IgnorePointer` — both put `isEnabled: false` on the merged
+      // row, so a screen reader calls every row of the checklist dimmed.
+      final handle = tester.ensureSemantics();
+      final presentation = multi<String>(selected: {'a'});
+
+      final node = await rowNode(tester, presentation.buildItem('a', true));
+
+      expect(
+        node.getSemanticsData().flagsCollection.isEnabled,
+        isNot(Tristate.isFalse),
+        reason: 'the box is presentational; the row is what is interactive',
+      );
+      handle.dispose();
+    });
+  });
+
+  group('hit testing', () {
+    // Guard, not a regression test. It pins the measurement that removed an
+    // `IgnorePointer` around the box: a `Checkbox` with `onChanged: null` has
+    // no gesture recognizer, so the tap reaches the row beneath it.
+    testWidgets('a tap on the box is a tap on the row', (tester) async {
+      var taps = 0;
+      final presentation = multi<String>(selected: const {});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Material(
+              child: InkWell(
+                onTap: () => taps++,
+                child: SizedBox(
+                  width: 200,
+                  height: 48,
+                  child: presentation.buildItem('a', false),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byType(Checkbox));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+  });
+
+  group('rows', () {
+    testWidgets('the box follows the chosen state', (tester) async {
+      final presentation = multi<String>(selected: {'a'});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                presentation.buildItem('a', true),
+                presentation.buildItem('b', false),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final boxes = tester.widgetList<Checkbox>(find.byType(Checkbox)).toList();
+      expect(boxes.map((b) => b.value), [true, false]);
+    });
+
+    testWidgets('a trailing widget is drawn after the label', (tester) async {
+      final presentation = multi<String>(
+        selected: const {},
+        itemTrailingBuilder: (item) => Text('#$item'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: presentation.buildItem('a', false))),
+      );
+
+      expect(find.text('#a'), findsOneWidget);
+    });
+
+    testWidgets('without an itemTrailingBuilder nothing trails', (
+      tester,
+    ) async {
+      final presentation = multi<String>(selected: const {});
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: presentation.buildItem('a', false))),
+      );
+
+      expect(find.byType(Checkbox), findsOneWidget);
+      expect(find.text('a'), findsOneWidget);
+    });
+  });
+
+  group('the button face', () {
+    testWidgets('is whatever labelBuilder makes of the chosen set', (
+      tester,
+    ) async {
+      final presentation = multi<String>(
+        selected: {'a', 'b'},
+        labelBuilder: (s) => '${s.length} chosen',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: presentation.buildSelected())),
+      );
+
+      expect(find.text('2 chosen'), findsOneWidget);
+    });
+
+    testWidgets('a semanticsLabel describes the control', (tester) async {
+      final handle = tester.ensureSemantics();
+      final presentation = MultiSelectPresentation<String>(
+        selected: const {},
+        labelBuilder: (s) => 'All',
+        label: null,
+        config: const TextDropdownConfig(semanticsLabel: 'OS filter'),
+        tooltipTheme: DropdownTooltipTheme.defaultTheme,
+        enabled: true,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: presentation.buildSelected())),
+      );
+
+      expect(find.bySemanticsLabel(RegExp('OS filter')), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('a disabled face merges the disabled style into the base', (
+      tester,
+    ) async {
+      final presentation = multi<String>(
+        selected: const {},
+        enabled: false,
+        config: const TextDropdownConfig(
+          textStyle: TextStyle(fontSize: 20, color: Colors.black),
+          disabledTextStyle: TextStyle(color: Colors.grey),
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: presentation.buildSelected())),
+      );
+
+      final style = faceStyle(tester)!;
+      expect(style.color, Colors.grey, reason: 'the disabled style wins');
+      expect(style.fontSize, 20, reason: 'and the base style survives it');
+    });
+
+    testWidgets('a disabled face with no base style takes the disabled one', (
+      tester,
+    ) async {
+      final presentation = multi<String>(
+        selected: const {},
+        enabled: false,
+        config: const TextDropdownConfig(
+          disabledTextStyle: TextStyle(color: Colors.grey),
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: presentation.buildSelected())),
+      );
+
+      expect(faceStyle(tester)!.color, Colors.grey);
+    });
+
+    testWidgets('an enabled face ignores the disabled style', (tester) async {
+      final presentation = multi<String>(
+        selected: const {},
+        config: const TextDropdownConfig(
+          textStyle: TextStyle(color: Colors.black),
+          disabledTextStyle: TextStyle(color: Colors.grey),
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: presentation.buildSelected())),
+      );
+
+      expect(faceStyle(tester)!.color, Colors.black);
+    });
+  });
+
+  group('pure', () {
+    test('contentAlignment follows the configured textAlign', () {
+      expect(
+        multi<String>(selected: const {}).contentAlignment,
+        Alignment.centerLeft,
+      );
+    });
+
+    test('the default filter matches the label, case-insensitively', () {
+      final filter = multi<String>(selected: const {}).defaultSearchFilter!;
+
+      expect(filter('Banana', 'NAN'), isTrue);
+      expect(filter('Apple', 'ban'), isFalse);
+    });
+
+    test('a String is its own label', () {
+      expect(multi<String>(selected: const {}).labelOf('Apple'), 'Apple');
+    });
+
+    test('any other T goes through the callback', () {
+      final presentation = multi<_Fruit>(
+        selected: const {},
+        label: (f) => f.name,
+      );
+
+      // ignore: prefer_const_constructors
+      expect(presentation.labelOf(_Fruit('Kiwi')), 'Kiwi');
+    });
+
+    test('a non-String T without a label fails at construction', () {
+      expect(
+        () => multi<_Fruit>(selected: const {}),
+        throwsAssertionError,
+        reason: 'rows render as text, so it must know how to make one',
+      );
+    });
+  });
+}
+
+class _Fruit {
+  const _Fruit(this.name);
+  final String name;
+}

--- a/test/presentation/multi_select_presentation_test.dart
+++ b/test/presentation/multi_select_presentation_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' show CheckedState, Tristate;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
@@ -12,6 +10,15 @@ import 'package:flutter_test/flutter_test.dart';
 /// `InkWell` owns the gesture — carries `isEnabled: false` into the semantics
 /// tree. `IgnorePointer` does not strip it; it suppresses hit-testing only.
 /// Nothing on screen differs, so this is invisible to a render test.
+///
+/// `containsSemantics` is deprecated after Flutter 3.40 in favour of
+/// `isSemantics`, which does not exist on the 3.32 floor this package declares.
+/// `SemanticsData.flagsCollection` has the mirror problem, and `hasFlag` the
+/// mirror of that. `matchesSemantics` survives both but insists on describing
+/// every flag on the node, so an `InkWell` gaining one would break it.
+///
+/// So: `containsSemantics`, ignored deliberately. Drop the ignores when the
+/// floor moves past `isSemantics`.
 
 MultiSelectPresentation<T> multi<T>({
   required Set<T> selected,
@@ -59,10 +66,8 @@ void main() {
 
       final node = await rowNode(tester, presentation.buildItem('a', true));
 
-      expect(
-        node.getSemanticsData().flagsCollection.isChecked,
-        CheckedState.isTrue,
-      );
+      // ignore: deprecated_member_use
+      expect(node, containsSemantics(hasCheckedState: true, isChecked: true));
       handle.dispose();
     });
 
@@ -74,10 +79,8 @@ void main() {
 
       final node = await rowNode(tester, presentation.buildItem('b', false));
 
-      expect(
-        node.getSemanticsData().flagsCollection.isChecked,
-        CheckedState.isFalse,
-      );
+      // ignore: deprecated_member_use
+      expect(node, containsSemantics(hasCheckedState: true, isChecked: false));
       handle.dispose();
     });
 
@@ -91,8 +94,9 @@ void main() {
       final node = await rowNode(tester, presentation.buildItem('a', true));
 
       expect(
-        node.getSemanticsData().flagsCollection.isEnabled,
-        isNot(Tristate.isFalse),
+        node,
+        // ignore: deprecated_member_use
+        containsSemantics(hasEnabledState: false),
         reason: 'the box is presentational; the row is what is interactive',
       );
       handle.dispose();


### PR DESCRIPTION
Closes #64.

A third `DropdownItemPresentation<T>`. **The interface did not change** — `buildSelected()` still takes no argument, because `TextItemPresentation` swallows a `value` as a field and this one swallows a `Set<T>` and a `labelBuilder` the same way. That the interface survived untouched is the evidence this is the right seam.

Nothing renders it yet. `FlutterMultiSelectDropdown` is #65.

## The bug the probe found

A menu row is already an `InkWell`, so the checkbox has to be presentational. `tester.getSemantics()` on the row's node, in a real open menu:

| Row contents | `isChecked` | `isEnabled` |
| --- | --- | --- |
| A. `Checkbox(value: x, onChanged: null)` | `isTrue` | **`isFalse`** |
| B. `IgnorePointer(child: Checkbox(onChanged: null))` | `isTrue` | **`isFalse`** |
| C. `Semantics(checked: x)` + `ExcludeSemantics(box)` | `isTrue` | `none` |
| D. two plain `Text`s | `none` | `none`, label `"Apple\n42"` |

A and B announce every row of a working checklist as **dimmed**. `IgnorePointer` suppresses hit-testing, not semantics. Nothing on screen differs, so no render test can see it — the same shape as #37, where `semanticsLabel` read "Fruit picker" for every row and `find.text('Apple')` passed happily.

C ships.

D is the `InkWell` merging its descendants, again. A trailing count widget therefore becomes part of the announced label: `"Apple\n42"`. Contract, not defect; it is on `itemTrailingBuilder`'s dartdoc.

## Red was real

The naive implementation went in first — a bare `Checkbox(onChanged: null)`. Of the three semantics tests, exactly one failed:

```
+2: a chosen row announces that it is checked
+2: an unchosen row announces that it is not checked
+2 -1: a row never announces that it is disabled  [E]
       Expected: not Tristate:<Tristate.isFalse>
         Actual: Tristate:<Tristate.isFalse>
```

Then `ExcludeSemantics` + `Semantics(checked:)`, and green. The other two are guards and say so.

## My issue body was wrong, and a probe said so

#64 claimed a bare `onChanged: null` box would leave a **dead zone** — a region where taps do nothing — and so needed an `IgnorePointer`. Measured:

```
PROBE bare    : taps=1
PROBE ignoring: taps=1
```

A disabled `Checkbox` has no gesture recognizer, so the tap falls through to the row either way. The `IgnorePointer` was removed; it was dead code. `a tap on the box is a tap on the row` pins the measurement, labelled as the guard it is.

## `T` needs `==` and `hashCode`

`selected.contains(item)` uses both, where single-select's `value == item` used only the first. Documented on the class. The test with a custom `T` drops `const` and says why: Dart canonicalises `const` constructors with identical arguments into the same instance, so `const Fruit('Kiwi')` proves nothing about distinct objects — a trap `test/text_label_test.dart` already fell into.

## Coverage found a test that was green for the wrong reason

`a disabled face merges the disabled text style` passed while never reaching the merge:

```
98.1%  105/107  lib/src/presentation/item_presentation.dart
       uncovered: 397-398
```

`TextDropdownConfig.defaultConfig` has a null `disabledTextStyle`, so the ternary took the other arm. The test asserted `merges` and `merge()` was never called. It is now three tests: base + disabled merged, disabled with no base, and enabled ignoring the disabled style.

## Gates

Run bare.

```
dart format --output=none --set-exit-if-changed .   exit 0
flutter analyze                                     No issues found!
flutter test --coverage                             245 passed
dart run tool/check_coverage.dart --min 100         100.00% (999/999)
cd example && flutter analyze                       No issues found!
```

`SemanticsFlag.hasFlag` is deprecated on 3.32 and `flutter analyze` exits 1 on one `info`, so the tests read `getSemanticsData().flagsCollection.isChecked` — a `CheckedState` of `none | isTrue | isFalse | mixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)