### PR TITLE
feat: FlutterMultiSelectDropdown, a checklist menu that stays open

### DIFF
--- a/lib/flutter_dropdown_button.dart
+++ b/lib/flutter_dropdown_button.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'src/flutter_dropdown_button.dart';
+export 'src/flutter_multi_select_dropdown.dart';
 export 'src/buttons/menu_alignment.dart';
 export 'src/overlay/dropdown_overlay_controller.dart';
 export 'src/presentation/item_presentation.dart';

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -457,6 +457,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>> {
       // answer rather than the `value`.
       isChosen: (item) => widget.value == item,
       onItemTap: widget.onChanged,
+      closeOnTap: true,
       scrollToItem: widget.scrollToSelectedItem ? widget.value : null,
       scrollToItemDuration: widget.scrollToSelectedDuration,
       enabled: isEnabled,

--- a/lib/src/flutter_multi_select_dropdown.dart
+++ b/lib/src/flutter_multi_select_dropdown.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+
+import 'buttons/menu_alignment.dart';
+import 'config/text_dropdown_config.dart';
+import 'overlay/dropdown_overlay_controller.dart';
+import 'presentation/item_presentation.dart';
+import 'shell/dropdown_menu_shell.dart';
+import 'theme/dropdown_style_theme.dart';
+import 'theme/tooltip_theme.dart';
+
+/// A dropdown whose menu is a checklist: several items may be chosen, and the
+/// menu stays open while they are.
+///
+/// Anchored rather than modal. There is no scrim and no confirm button — a tap
+/// on a row calls [onChanged] at once with a **new** `Set`, and an outside tap
+/// dismisses the menu.
+///
+/// ```dart
+/// FlutterMultiSelectDropdown<String>(
+///   items: osFamilies,
+///   selected: chosen,
+///   onChanged: (next) => setState(() => chosen = next),
+///   labelBuilder: (s) => switch (s.length) {
+///     0 => 'All',
+///     1 => s.first,
+///     _ => '${s.length} selected',
+///   },
+///   searchable: true,
+///   itemTrailingBuilder: (v) => Text('${counts[v]}'),
+/// )
+/// ```
+///
+/// [selected] is **yours**. This widget renders what you hand it and never
+/// edits it: a value that is no longer in [items] still counts towards
+/// [labelBuilder], though it draws no row. A list refresh that drops the data
+/// behind a chosen value therefore cannot make the widget throw, nor silently
+/// discard the choice. Offer a way to clear it.
+///
+/// `T` must implement `==` **and** `hashCode` consistently. A `Set` needs both,
+/// where single-select's `value == item` needed only the first.
+///
+/// Rows render as text, so `T` must be a [String] or [label] must say how to
+/// make one.
+class FlutterMultiSelectDropdown<T> extends StatelessWidget {
+  /// Creates a multi-select dropdown.
+  const FlutterMultiSelectDropdown({
+    super.key,
+    required this.items,
+    required this.selected,
+    required this.onChanged,
+    required this.labelBuilder,
+    this.label,
+    this.itemTrailingBuilder,
+    this.config,
+    this.theme,
+    this.width,
+    this.minWidth,
+    this.maxWidth,
+    this.height = 200.0,
+    this.itemHeight = 48.0,
+    this.animationDuration = const Duration(milliseconds: 200),
+    this.enabled = true,
+    this.expand = false,
+    this.trailing,
+    this.minMenuWidth,
+    this.maxMenuWidth,
+    this.menuAlignment = MenuAlignment.left,
+    this.searchable = false,
+    this.searchFilter,
+    this.emptyBuilder,
+  });
+
+  /// The items the menu offers.
+  final List<T> items;
+
+  /// The items currently chosen. Owned by the caller.
+  final Set<T> selected;
+
+  /// Called with a new `Set` the moment a row is tapped.
+  ///
+  /// The `Set` passed to this widget is never mutated; a copy is made.
+  final ValueChanged<Set<T>> onChanged;
+
+  /// Turns [selected] into the button's face.
+  final String Function(Set<T> selected) labelBuilder;
+
+  /// Turns an item into the string its row shows. Required unless `T` is
+  /// [String].
+  final String Function(T item)? label;
+
+  /// Drawn at the end of each row — a count, a badge.
+  ///
+  /// The row's ink well merges its descendants' semantics, so this widget's
+  /// text becomes part of what a screen reader announces for the row.
+  final Widget Function(T item)? itemTrailingBuilder;
+
+  /// Text rendering rules: overflow, alignment, styles.
+  final TextDropdownConfig? config;
+
+  /// Styling for the button, the menu, its scrollbar and its search field.
+  final DropdownStyleTheme? theme;
+
+  /// A fixed button width.
+  final double? width;
+
+  /// The button's minimum width, when [width] is null.
+  final double? minWidth;
+
+  /// The button's maximum width, when [width] is null.
+  final double? maxWidth;
+
+  /// The menu's maximum height. It scrolls beyond this.
+  final double height;
+
+  /// The height of one row.
+  final double itemHeight;
+
+  /// How long the open and close animation takes.
+  final Duration animationDuration;
+
+  /// Whether the button responds to a tap.
+  final bool enabled;
+
+  /// Whether the button fills its parent's cross-axis space.
+  final bool expand;
+
+  /// Replaces the trailing icon.
+  final Widget? trailing;
+
+  /// The menu's minimum width.
+  final double? minMenuWidth;
+
+  /// The menu's maximum width.
+  final double? maxMenuWidth;
+
+  /// Which edge of the button the menu lines up with.
+  final MenuAlignment menuAlignment;
+
+  /// Whether the menu carries a search field.
+  ///
+  /// The query survives a tick: the menu does not close, and only opening and
+  /// closing reset it.
+  final bool searchable;
+
+  /// Overrides the default case-insensitive `contains` over each item's label.
+  final bool Function(T item, String query)? searchFilter;
+
+  /// Drawn when a query matches nothing.
+  final Widget Function(String query)? emptyBuilder;
+
+  /// Closes every open dropdown overlay, of either kind.
+  ///
+  /// Single-open coordination lives in a registry keyed by `Overlay`, so this
+  /// and [FlutterDropdownButton.closeAll] do the same thing.
+  static void closeAll({bool animate = true}) =>
+      DropdownOverlayController.closeAll(animate: animate);
+
+  /// [item] added if it was absent, removed if it was present.
+  ///
+  /// Always a fresh `Set`. The caller's may be unmodifiable, and is theirs.
+  void _toggle(T item) {
+    final next = <T>{...selected};
+    if (!next.remove(item)) next.add(item);
+    onChanged(next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownMenuShell<T>(
+      items: items,
+      presentation: MultiSelectPresentation<T>(
+        selected: selected,
+        label: label,
+        labelBuilder: labelBuilder,
+        config: config ?? TextDropdownConfig.defaultConfig,
+        tooltipTheme: theme?.tooltip ?? DropdownTooltipTheme.defaultTheme,
+        enabled: enabled,
+        itemTrailingBuilder: itemTrailingBuilder,
+      ),
+      // What multi-selection means, said once.
+      isChosen: selected.contains,
+      onItemTap: _toggle,
+      closeOnTap: false,
+      // There is no single chosen row to reveal, so the shell never scrolls.
+      scrollToItem: null,
+      enabled: enabled,
+      showTrailing: true,
+      trailing: trailing,
+      theme: theme,
+      width: width,
+      minWidth: minWidth,
+      maxWidth: maxWidth,
+      height: height,
+      itemHeight: itemHeight,
+      animationDuration: animationDuration,
+      expand: expand,
+      minMenuWidth: minMenuWidth,
+      maxMenuWidth: maxMenuWidth,
+      menuAlignment: menuAlignment,
+      searchable: searchable,
+      searchFilter: searchFilter,
+      emptyBuilder: emptyBuilder,
+    );
+  }
+}

--- a/lib/src/shell/dropdown_menu_shell.dart
+++ b/lib/src/shell/dropdown_menu_shell.dart
@@ -16,9 +16,9 @@ import '../widgets/scroll_gradient_overlay.dart';
 ///
 /// **This file does not know what selection is.** It never sees a `value`, a
 /// `Set`, or an `onChanged`. It is handed a predicate that says whether a row
-/// is chosen and a callback for when one is tapped. What a caller does with
-/// those is what makes a dropdown single- or multi-select; nothing in here
-/// changes.
+/// is chosen, a callback for when one is tapped, and whether a tap closes the
+/// menu. What a caller does with those is what makes a dropdown single- or
+/// multi-select; nothing in here changes.
 ///
 /// Not exported. It is an implementation detail shared by the public widgets,
 /// and every parameter it takes is one of theirs.
@@ -30,6 +30,7 @@ class DropdownMenuShell<T> extends StatefulWidget {
     required this.presentation,
     required this.isChosen,
     required this.onItemTap,
+    required this.closeOnTap,
     required this.enabled,
     required this.showTrailing,
     required this.height,
@@ -60,12 +61,15 @@ class DropdownMenuShell<T> extends StatefulWidget {
   /// Whether [item] is currently chosen. Drives the row's selected styling.
   final bool Function(T item) isChosen;
 
-  /// Called when a row is tapped. The menu closes afterwards.
-  ///
-  /// A checklist will want to stay open instead. That is a `closeOnTap` flag,
-  /// and it arrives with the caller that needs it — a parameter no caller sets
-  /// is a branch no test can reach.
+  /// Called when a row is tapped.
   final void Function(T item) onItemTap;
+
+  /// Whether tapping a row closes the menu.
+  ///
+  /// False repaints it instead, so the next box can be ticked. The query
+  /// survives either way — it is reset by the menu opening and closing, never
+  /// by a tap.
+  final bool closeOnTap;
 
   /// Whether the button responds to a tap.
   final bool enabled;
@@ -592,7 +596,13 @@ class _DropdownMenuShellState<T> extends State<DropdownMenuShell<T>>
         child: InkWell(
           onTap: () {
             widget.onItemTap(item);
-            _menu.close();
+            if (widget.closeOnTap) {
+              _menu.close();
+            } else {
+              // The owner will rebuild us with a new selection; the overlay is
+              // in another element subtree and would not hear about it.
+              _menu.rebuild();
+            }
           },
           mouseCursor: SystemMouseCursors.click,
           splashColor: style.splashColor,

--- a/test/multi_select_test.dart
+++ b/test/multi_select_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The reason this widget exists: ticking a box emits a new `Set` at once, and
+/// the menu stays open so the next box can be ticked.
+
+/// Holds `selected` the way a caller does, so `onChanged` → `setState` → the
+/// open overlay repainting is exercised end to end.
+class Harness extends StatefulWidget {
+  const Harness({
+    super.key,
+    this.items = const ['Apple', 'Banana', 'Cherry'],
+    this.initial = const <String>{},
+    this.searchable = false,
+    this.onChanged,
+  });
+
+  final List<String> items;
+  final Set<String> initial;
+  final bool searchable;
+  final void Function(Set<String>)? onChanged;
+
+  @override
+  State<Harness> createState() => HarnessState();
+}
+
+class HarnessState extends State<Harness> {
+  late Set<String> selected = widget.initial;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: FlutterMultiSelectDropdown<String>(
+            width: 220,
+            height: 200,
+            items: widget.items,
+            selected: selected,
+            searchable: widget.searchable,
+            labelBuilder: (s) => s.isEmpty ? 'All' : '${s.length} selected',
+            onChanged: (next) {
+              widget.onChanged?.call(next);
+              setState(() => selected = next);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> openMenu(WidgetTester tester) async {
+  await tester.tap(find.byType(FlutterMultiSelectDropdown<String>));
+  await tester.pumpAndSettle();
+}
+
+/// The row's tappable area, found by the text it carries.
+Finder row(String label) =>
+    find.ancestor(of: find.text(label), matching: find.byType(InkWell));
+
+void main() {
+  testWidgets('ticking a box emits the item and leaves the menu open', (
+    tester,
+  ) async {
+    Set<String>? emitted;
+    await tester.pumpWidget(Harness(onChanged: (s) => emitted = s));
+    await openMenu(tester);
+
+    await tester.tap(row('Banana').first);
+    await tester.pumpAndSettle();
+
+    expect(emitted, {'Banana'});
+    expect(
+      find.text('Cherry'),
+      findsOneWidget,
+      reason: 'the menu is still open, so the other rows are still drawn',
+    );
+  });
+
+  testWidgets('ticking a chosen box unticks it', (tester) async {
+    Set<String>? emitted;
+    await tester.pumpWidget(
+      Harness(initial: const {'Banana'}, onChanged: (s) => emitted = s),
+    );
+    await openMenu(tester);
+
+    await tester.tap(row('Banana').first);
+    await tester.pumpAndSettle();
+
+    expect(emitted, isEmpty);
+  });
+
+  testWidgets("the caller's Set is never mutated", (tester) async {
+    // A caller may hand over an unmodifiable Set, and it is their state either
+    // way. `_toggle` copies.
+    final owned = <String>{'Apple'};
+    await tester.pumpWidget(Harness(initial: owned));
+    await openMenu(tester);
+
+    await tester.tap(row('Banana').first);
+    await tester.pumpAndSettle();
+
+    expect(owned, {'Apple'}, reason: 'still exactly what we handed in');
+  });
+
+  testWidgets('two ticks accumulate without reopening the menu', (
+    tester,
+  ) async {
+    Set<String>? emitted;
+    await tester.pumpWidget(Harness(onChanged: (s) => emitted = s));
+    await openMenu(tester);
+
+    await tester.tap(row('Apple').first);
+    await tester.pumpAndSettle();
+    await tester.tap(row('Cherry').first);
+    await tester.pumpAndSettle();
+
+    expect(emitted, {'Apple', 'Cherry'});
+  });
+
+  testWidgets('the boxes repaint when the owner rebuilds', (tester) async {
+    // The overlay lives in its own element subtree. Without the shell marking
+    // it dirty after the frame, the ticks would not appear until reopening.
+    await tester.pumpWidget(const Harness());
+    await openMenu(tester);
+
+    await tester.tap(row('Apple').first);
+    await tester.pumpAndSettle();
+
+    final boxes = tester.widgetList<Checkbox>(find.byType(Checkbox)).toList();
+    expect(boxes.map((b) => b.value), [true, false, false]);
+  });
+
+  testWidgets('the face is whatever labelBuilder makes of the set', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const Harness());
+    expect(find.text('All'), findsOneWidget);
+
+    await openMenu(tester);
+    await tester.tap(row('Apple').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('1 selected'), findsOneWidget);
+  });
+
+  testWidgets('a chosen value absent from items counts, but draws no row', (
+    tester,
+  ) async {
+    // The refresh that drops a chosen value's data leaves it in `selected`.
+    // The widget draws what it was handed: the face counts it, the menu does
+    // not invent a row for it, and nothing throws.
+    await tester.pumpWidget(
+      const Harness(items: ['Apple'], initial: {'Apple', 'ghost'}),
+    );
+
+    expect(find.text('2 selected'), findsOneWidget);
+
+    await openMenu(tester);
+
+    expect(find.text('ghost'), findsNothing);
+    expect(find.byType(Checkbox), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the query survives a tick', (tester) async {
+    await tester.pumpWidget(const Harness(searchable: true));
+    await openMenu(tester);
+
+    await tester.enterText(find.byType(TextField), 'an');
+    await tester.pumpAndSettle();
+    expect(find.text('Banana'), findsOneWidget);
+    expect(find.text('Cherry'), findsNothing);
+
+    await tester.tap(row('Banana').first);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(TextField),
+      findsOneWidget,
+      reason: 'the menu did not close',
+    );
+    expect(
+      find.text('Cherry'),
+      findsNothing,
+      reason: 'and the query was not reset by the tap',
+    );
+  });
+
+  testWidgets('closeAll shuts a checklist too', (tester) async {
+    await tester.pumpWidget(const Harness());
+    await openMenu(tester);
+    expect(find.byType(Checkbox), findsNWidgets(3));
+
+    FlutterMultiSelectDropdown.closeAll(animate: false);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Checkbox), findsNothing);
+  });
+
+  testWidgets('opening a plain dropdown closes an open checklist', (
+    tester,
+  ) async {
+    // Single-open coordination is a registry keyed by `Overlay`, so the two
+    // widgets close one another without either knowing the other exists.
+    // Side by side. Stacked, the checklist's menu would cover the second
+    // button, and the tap meant for it would land on a checklist row instead.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Row(
+            children: [
+              FlutterMultiSelectDropdown<String>(
+                width: 200,
+                items: const ['Apple', 'Banana'],
+                selected: const {},
+                labelBuilder: (s) => 'pick',
+                onChanged: (_) {},
+              ),
+              FlutterDropdownButton<String>.text(
+                width: 200,
+                items: const ['One', 'Two'],
+                hint: 'other',
+                onChanged: (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(FlutterMultiSelectDropdown<String>));
+    await tester.pumpAndSettle();
+    expect(find.byType(Checkbox), findsNWidgets(2));
+
+    // The open menu covers the screen with a dismiss barrier, so reaching the
+    // other button may take two taps. Either way, both must never be open.
+    await tester.tap(
+      find.byType(FlutterDropdownButton<String>),
+      warnIfMissed: false,
+    );
+    await tester.pumpAndSettle();
+    if (find.text('One').evaluate().isEmpty) {
+      await tester.tap(find.byType(FlutterDropdownButton<String>));
+      await tester.pumpAndSettle();
+    }
+
+    expect(find.text('One'), findsOneWidget, reason: 'the other one opened');
+    expect(find.byType(Checkbox), findsNothing, reason: 'the checklist closed');
+  });
+
+  testWidgets('reopening the menu does reset the query', (tester) async {
+    // Guard. Opening and closing is what clears the query, and that is driven
+    // from the overlay controller rather than from a tap.
+    await tester.pumpWidget(const Harness(searchable: true));
+    await openMenu(tester);
+
+    await tester.enterText(find.byType(TextField), 'an');
+    await tester.pumpAndSettle();
+    expect(find.text('Cherry'), findsNothing);
+
+    await tester.tap(find.byType(FlutterMultiSelectDropdown<String>));
+    await tester.pumpAndSettle();
+    await openMenu(tester);
+
+    expect(find.text('Cherry'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #65.

A second public widget. Nothing is removed, nothing is deprecated, `FlutterDropdownButton`'s API is untouched.

```dart
FlutterMultiSelectDropdown<String>(
  items: osFamilies,
  selected: chosen,
  onChanged: (next) => setState(() => chosen = next),
  labelBuilder: (s) => s.isEmpty ? 'All' : '${s.length} selected',
  searchable: true,
  itemTrailingBuilder: (v) => Text('${counts[v]}'),
)
```

Anchored, not modal. No scrim, no confirm button, dismissed by an outside tap. A tick calls `onChanged` at once with a **new** `Set` and the menu stays open.

## It is a `StatelessWidget`

There is no state to keep. `DropdownMenuShell` (#63) owns the overlay, the animation, the search and the scrollbar; `selected` belongs to the caller. The widget is a constructor, a `_toggle`, and one `build`:

```dart
isChosen: selected.contains,
onItemTap: _toggle,
closeOnTap: false,
scrollToItem: null,      // no single chosen row to reveal
```

`closeOnTap` lands here, with the caller that passes `false` — it was removed from #63 for having no such caller, and the coverage gate is what noticed.

`value`, `disableWhenSingleItem`, `scrollToSelectedItem` do not exist on this widget, so they cannot be passed to it. **No asserts.** That is what buying the shell paid for; the named-constructor alternative would have put four permanently-dead fields on the public API instead, and #65 records why that was rejected.

## What the tests pin

Eleven, all through the public widget, with a `Harness` that holds `selected` in a `State` the way a caller does — so `tick → onChanged → setState → the open overlay repainting` is exercised end to end rather than assumed.

- ticking emits the item and **leaves the menu open** — sabotaged with `closeOnTap: true`: `Found 0 widgets with text "Cherry"`. Load-bearing.
- ticking a chosen box unticks it; two ticks accumulate without reopening
- **the caller's `Set` is never mutated** — it may be unmodifiable, and it is theirs
- the boxes repaint when the owner rebuilds, with no new machinery: the shell's `didUpdateWidget` already marks the open overlay dirty after the frame
- the face is whatever `labelBuilder` makes of the set
- **a chosen value absent from `items` counts towards the face and draws no row** — the rule adopted in #62, and the reason `selected` can survive a list refresh that drops its data
- the query survives a tick, and a reopen still resets it. `_resetSearch()` fires from `onOpenStateChanged`, never from a tap, so this was free
- `closeAll` shuts a checklist; a plain dropdown opening closes one

## Two reds that were the test's fault, not the code's

The cross-widget single-open test failed twice before it was right.

1. Stacked in a `Column`, the checklist's 200px menu **covers the second button**, so the tap meant for it landed on a checklist row — which, with `closeOnTap: false`, keeps the menu open. Moved to a `Row`.
2. Side by side, it still failed: the open menu's dismiss barrier **eats the first tap**. `test/overlay_lifecycle_test.dart` had already written this down — *"the open menu covers the screen with a dismiss barrier, so reaching the other button may take two taps"*. Reading the neighbouring test first would have saved both rounds.

The code was right both times.

## Scope

Text mode only. `itemBuilder` / `selectedBuilder` / `hintWidget` are custom-mode surface and are absent; a custom multi-select is a fourth presentation and a later request.

## Gates

Run bare.

```
dart format --output=none --set-exit-if-changed .   exit 0
flutter analyze                                     No issues found!
flutter test --coverage                             256 passed
dart run tool/check_coverage.dart --min 100         100.00% (1037/1037)
cd example && flutter analyze                       No issues found!
flutter pub publish --dry-run                       0 warnings
```

Docs, the playground page and the `3.1.0` release are #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)