### PR TITLE
chore: release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.1.0
+
+Adds a second widget. Nothing was removed; one field is deprecated and one behaviour changed, both described below.
+
+* **FEAT**: `FlutterMultiSelectDropdown<T>` — a checklist. Several items may be chosen, the menu stays open while they are, and `onChanged` fires with a **new** `Set<T>` the moment a box is ticked. Anchored rather than modal: no scrim, no confirm button, dismissed by an outside tap. It shares every layout, theming and search parameter with `FlutterDropdownButton`. The `Set` you pass in is never mutated, and `T` must implement `==` **and** `hashCode` — a `Set` needs both, where `value == item` needed only the first
+* **FEAT**: `MultiSelectPresentation<T>`, the third `DropdownItemPresentation`. Its rows carry a checkbox that is **excluded from the semantics tree**, with the checked state re-attached to the row. A `Checkbox` with `onChanged: null` inside the row's ink well announces `isEnabled: false` once the tree merges, so a screen reader would have called every row of a working checklist *dimmed*. `IgnorePointer` does not help; it suppresses hit-testing, not semantics. Nothing about this is visible on screen
+* **CHANGE**: A `value` that is not in `items` is now **drawn** in custom mode, rather than replaced by `hintWidget`. A list refresh that drops the chosen row's data left `value` naming a row that no longer existed, and the button quietly reverted to its hint — no callback, no error. Text mode never did this, having no `items` to consult, so the two modes disagreed and neither behaviour was documented. **The widget draws what it was handed.** The menu is unchanged: it iterates `items`, and never invented a row
+* **DEPRECATED**: `CustomItemPresentation.items`. It fed the audit removed above and is now read by nothing. It is no longer `required`; drop the argument. Removed in 4.0.0. Only code that constructs a presentation by hand is affected
+* **REFACTOR**: `DropdownMenuShell` (internal) is the button, the overlay, and everything between — 994 of the widget's 1004 lines, none of which knew what selection is. It takes `isChosen(T)`, `onItemTap(T)` and `closeOnTap`; the two public widgets differ only in what they pass. `value`, `scrollToSelectedItem` and `disableWhenSingleItem` are **absent from the multi-select type** rather than asserted against at runtime
+* **TEST**: 256 tests, up from 224, still at 100% line coverage (1037 lines). The shell extraction passed the existing suite with **no test file edited**, the sixth refactor in this package to meet that standard. The coverage floor earned its keep twice: it rejected a `closeOnTap` flag that no caller set, and it caught a test named *merges the disabled style* that never reached the `merge()`
+
 ## 3.0.2
 
 Documentation only. No statement in `lib/` changed — every corrected line is a comment. It is released because pub.dev renders the dartdoc of the version it was published from, so a reader of 3.0.1's API page is still told the opposite of what the code does. A downstream app set a `trackColor`, saw no track, and was right to be confused.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,16 +141,29 @@ package                    dart format --set-exit-if-changed  /  pub publish --d
 
 `flutter_dropdown_button` is a Flutter package providing a single, highly customizable dropdown widget rendered through an `OverlayEntry` rather than Flutter's built-in menu machinery.
 
-There is **one** widget — `FlutterDropdownButton<T>` — with two constructors:
+There are **two** widgets, and both are thin callers of `DropdownMenuShell`.
 
 - `FlutterDropdownButton<T>(...)` — custom mode. `itemBuilder` renders each item as an arbitrary widget.
 - `FlutterDropdownButton<T>.text(...)` — text mode. Items render as text through `SmartTooltipText`, gaining overflow handling, an automatic tooltip, and a default search filter. A `label` callback extracts the string, so `T` need not be `String`.
+- `FlutterMultiSelectDropdown<T>(...)` — a checklist. Emits a `Set<T>` per tick and does not close. **`StatelessWidget`**: the shell holds the state and `selected` belongs to the caller.
 
 `isTextMode` (`itemBuilder == null`) survives as a public informational getter. **Nothing inside the widget branches on it** — see `DropdownItemPresentation` below.
 
+**Cardinality is a type, not a flag.** `value`, `scrollToSelectedItem` and `disableWhenSingleItem` do not exist on the multi-select widget, so no assert has to forbid them. The rejected alternative — a `.multiSelect` named constructor — would have put four settable-but-dead fields on the public API, which is the exact shape 3.0.0 spent a major version deleting.
+
 ## Core Architecture
 
-The widget is a thin shell over five modules, each of which takes plain values rather than a `BuildContext`.
+Both widgets are thin callers of `DropdownMenuShell`, which is itself a thin shell over five modules, each of which takes plain values rather than a `BuildContext`.
+
+### `DropdownMenuShell` — `lib/src/shell/`
+
+The button, the overlay, and everything between. **It does not know what selection is.** No `value`, no `Set`, no `onChanged`. It takes `isChosen(T)`, `onItemTap(T)` and `closeOnTap`, and what a caller supplies for those is what makes a dropdown single- or multi-select.
+
+Internal — not exported. Its parameters are the public widgets' parameters, which is the price of the split: roughly seventeen pass-throughs declared twice. The alternative, a `.multiSelect` named constructor, would have cost four permanently-dead public fields instead. **A dead field is stepped on by users, who get no feedback at all; a missing pass-through is caught by review.**
+
+`scrollToItem: T?` is where a per-mode invariant became unrepresentable rather than asserted: single-select passes its `value`, multi-select passes null, and there is no "scrolling to the selected item in a multi-select" to forbid.
+
+When adding a parameter, add it here **and** to both widgets. Nothing enforces that.
 
 ### `DropdownPlacement` — `lib/src/placement/`
 
@@ -233,7 +246,11 @@ And when you pin a value to stop Flutter changing it, pin **the value it would h
 
 ## Deprecated
 
-**Nothing.** `lib/` contains zero `@Deprecated` annotations.
+**One.** `CustomItemPresentation.items`, since 3.1.0, removed in 4.0.0.
+
+It fed `buildSelected()`'s audit of `value` against `items` — the audit that made a custom-mode button show its hint when a list refresh dropped the chosen row. That rule is gone (`the widget draws what it was handed`), so the field is read by nothing.
+
+It was **deprecated rather than removed**, unlike the three dead fields below, because it did something until the day it stopped. A deprecation window buys a caller time to migrate, and here there is an argument to delete. `required` was dropped from it so callers can.
 
 3.0.0 removed the lot: `DropdownMixin`, `DropdownTheme.animationDuration`, `DropdownTooltipTheme.borderColor` / `.borderWidth`, `DropdownScrollTheme.trackWidth` and `.alwaysVisible`.
 
@@ -249,7 +266,7 @@ Beware the dartdoc link. `See [trackWidth].` inside another member's doc comment
 
 ```bash
 flutter pub get                                    # install dependencies
-flutter test                                       # 222 tests
+flutter test                                       # 256 tests
 flutter test --coverage                            # writes coverage/lcov.info
 dart run tool/check_coverage.dart --min 100 --report
 flutter analyze                                    # exits 1 on a single `info`
@@ -264,14 +281,14 @@ cd example && flutter run                          # the playground app
 
 ## Testing
 
-222 tests, **100% line coverage** (937 lines). 98 of them run without mounting a widget at all.
+256 tests, **100% line coverage** (1037 lines). 107 of them run without mounting a widget at all.
 
 | Suite | What it covers |
 | --- | --- |
 | `test/placement/` | The geometry module, exhaustively. No widgets. |
 | `test/theme/` | Every `resolve()`. No widgets. |
 | `test/overlay/` | The controller's lifecycle. No widgets. |
-| `test/presentation/` | Alignment, the default filter, label extraction. No widgets. |
+| `test/presentation/` | Alignment, the default filter, label extraction. Mostly without widgets — the checklist row's semantics needs one. |
 | `test/search/` | The query, filtering, reset, enable/disable. No widgets. |
 | `test/overlay_bounds_test.dart` | Menus near screen edges, and inside a nested `Overlay` |
 | `test/overlay_resize_test.dart` | An open menu growing, shrinking, and flipping |
@@ -294,6 +311,9 @@ cd example && flutter run                          # the playground app
 | `test/overlay_controller_widget_test.dart` | The controller driven bare, with its own chrome |
 | `test/last_four_lines_test.dart` | Unwrapped overflow; the gradient's controller swap |
 | `test/scrollbar_duplication_test.dart` | One scrollbar per menu, across four platforms |
+| `test/ghost_value_test.dart` | A `value` that `items` no longer offers, on the face and not in the menu |
+| `test/multi_select_test.dart` | Ticking, unticking, the caller's `Set`, the query surviving a tick |
+| `test/presentation/multi_select_presentation_test.dart` | A row announces *checked*, never *disabled* |
 
 **Conventions that matter here:**
 
@@ -307,12 +327,15 @@ cd example && flutter run                          # the playground app
 lib/
 ├── flutter_dropdown_button.dart          # public exports
 └── src/
-    ├── flutter_dropdown_button.dart      # the widget
+    ├── flutter_dropdown_button.dart      # single-select: 10 lines of selection, the rest delegated
+    ├── flutter_multi_select_dropdown.dart # multi-select: a StatelessWidget over the same shell
+    ├── shell/
+    │   └── dropdown_menu_shell.dart      # the button and the menu. Knows nothing of selection
     ├── placement/dropdown_placement.dart # pure geometry
     ├── overlay/
     │   └── dropdown_overlay_controller.dart  # overlay lifetime, animation, spec
     ├── presentation/
-    │   └── item_presentation.dart         # text vs custom rendering, behind one interface
+    │   └── item_presentation.dart         # text / custom / multi-select, behind one interface
     ├── search/
     │   └── dropdown_search_controller.dart  # the query, its field, its lifetime
     ├── theme/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Flutter Dropdown Button
 
-A highly customizable dropdown package for Flutter with overlay-based rendering, smooth animations, and full control over appearance and behavior — all in a single widget.
+A highly customizable dropdown package for Flutter with overlay-based rendering, smooth animations, and full control over appearance and behavior.
 
 [![pub package](https://img.shields.io/pub/v/flutter_dropdown_button.svg)](https://pub.dev/packages/flutter_dropdown_button)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Features
 
-- **Single Unified Widget**: One `FlutterDropdownButton<T>` for all use cases
+- **Two Widgets**: `FlutterDropdownButton<T>` chooses one item; `FlutterMultiSelectDropdown<T>` is a checklist that stays open
 - **Two Modes**: Custom widget rendering (default) or text-only (`.text()`)
+- **Multi-Select**: Tick boxes, get a `Set<T>` at once — anchored, not modal, and no confirm button
 - **Any Type in Text Mode**: Supply a `label` callback and keep tooltips, overflow handling and search
 - **Overlay-based Rendering**: Better positioning and visual effects than Flutter's built-in DropdownButton
 - **Smart Positioning**: Automatically opens up/down based on available space
@@ -43,7 +44,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^3.0.2
+  flutter_dropdown_button: ^3.1.0
 ```
 
 Import the package:
@@ -140,6 +141,29 @@ FlutterDropdownButton<String>(
 )
 ```
 
+### Multi-Select Checklist
+
+Ticking a box calls `onChanged` immediately with a **new** `Set`. The menu stays
+open, so the next box can be ticked. There is no confirm button and no scrim.
+
+```dart
+FlutterMultiSelectDropdown<String>(
+  items: ['Windows', 'Linux', 'macOS'],
+  selected: chosen,
+  labelBuilder: (s) => switch (s.length) {
+    0 => 'All',
+    1 => s.first,
+    _ => '${s.length} selected',
+  },
+  searchable: true,                        // when the list runs long
+  itemTrailingBuilder: (v) => Text('${counts[v]}'),
+  onChanged: (next) => setState(() => chosen = next),
+)
+```
+
+`selected` is yours. The widget copies it before emitting, never edits it, and
+draws whatever you hand it — see [A value that is not in `items`](#a-value-that-is-not-in-items).
+
 ---
 
 ## API Reference
@@ -175,7 +199,7 @@ The unified dropdown widget. Use the default constructor for custom widget rende
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `value` | `T?` | `null` | Currently selected value |
+| `value` | `T?` | `null` | Currently selected value. Drawn on the button whether or not it is in `items` — see below |
 | `width` | `double?` | `null` | Fixed width (`null` = content-based) |
 | `minWidth` | `double?` | `null` | Minimum width constraint |
 | `maxWidth` | `double?` | `null` | Maximum width constraint |
@@ -196,6 +220,48 @@ The unified dropdown widget. Use the default constructor for custom widget rende
 | `searchable` | `bool` | `false` | Enable search/filter field in dropdown |
 | `searchFilter` | `bool Function(T, String)?` | `null` | Custom filter function (required for custom mode) |
 | `emptyBuilder` | `Widget Function(String)?` | `null` | Widget builder for empty search results |
+
+#### A value that is not in `items`
+
+A list refresh can drop the row a `value` names while `value` still names it.
+The button keeps drawing that value; the menu, which iterates `items`, draws no
+row for it. **The widget draws what it was handed** — `value` is yours, and a
+button that silently reverted to its hint would disagree with the state you
+hold. Nothing throws.
+
+`FlutterMultiSelectDropdown` follows the same rule: such a value still counts
+towards `labelBuilder`, so `'3 selected'` can appear beside two ticked rows.
+Give the user a way to clear it.
+
+### FlutterMultiSelectDropdown\<T\>
+
+A checklist. Several items may be chosen, the menu stays open while they are,
+and `onChanged` fires the moment a box is ticked. Anchored rather than modal:
+no scrim, dismissed by an outside tap.
+
+Rows render as text, so `T` must be a `String` or `label` must say how to make
+one. `T` must implement `==` **and** `hashCode` consistently — a `Set` needs
+both, where single-select's `value == item` needed only the first.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| **`items`** | `List<T>` | **required** | List of item values |
+| **`selected`** | `Set<T>` | **required** | The chosen items. Yours; never mutated |
+| **`onChanged`** | `ValueChanged<Set<T>>` | **required** | Called with a **new** `Set` the moment a row is tapped |
+| **`labelBuilder`** | `String Function(Set<T>)` | **required** | Turns `selected` into the button's face |
+| `label` | `String Function(T)?` | `null` | The text a row shows. Required unless `T` is `String` |
+| `itemTrailingBuilder` | `Widget Function(T)?` | `null` | Drawn at the end of each row — a count, a badge |
+| `config` | `TextDropdownConfig?` | `null` | Text rendering configuration |
+
+Everything under **Common Parameters** above applies too, except the five that
+mean nothing to a checklist and therefore do not exist on it: `value`,
+`scrollToSelectedItem`, `scrollToSelectedDuration`, `disableWhenSingleItem` and
+`hideIconWhenSingleItem`. They are absent from the type rather than asserted
+against at runtime.
+
+```dart
+FlutterMultiSelectDropdown.closeAll();   // the same registry as the other widget
+```
 
 ### MenuAlignment
 

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -6,7 +6,7 @@ Complete reference for all classes and widgets in the flutter_dropdown_button pa
 
 ## FlutterDropdownButton<T>
 
-The one dropdown widget. Two constructors.
+Chooses one item. Two constructors.
 
 ```dart
 // Custom mode — render each item as any widget
@@ -40,6 +40,50 @@ Full parameter tables live in `README.md`. The two constructors share every layo
 | Member | Description |
 |--------|-------------|
 | `closeAll({bool animate = true})` | Closes every open menu. Pass `animate: false` right before navigation, when the widget may be disposed before an animation could finish |
+
+### A value that is not in `items`
+
+The button draws `value` whether or not `items` still offers it. A list refresh can drop the chosen row's data while `value` still names it; the button keeps showing it, the menu draws no row for it, and nothing throws.
+
+**The widget draws what it was handed.** `value` belongs to the caller, and a button that silently reverted to its hint would disagree with the state its owner holds — with no callback and no error to explain why.
+
+Before 3.1.0, custom mode audited `value` against `items` and fell back to `hintWidget`; text mode never did, having no `items` to consult. The two now agree.
+
+## FlutterMultiSelectDropdown\<T\>
+
+A checklist. Several items may be chosen, the menu stays open while they are, and `onChanged` fires the moment a box is ticked — no confirm button. Anchored rather than modal: no scrim, dismissed by an outside tap.
+
+```dart
+FlutterMultiSelectDropdown<T>({
+  required List<T> items,
+  required Set<T> selected,
+  required ValueChanged<Set<T>> onChanged,
+  required String Function(Set<T> selected) labelBuilder,
+  String Function(T item)? label,          // required unless T is String
+  Widget Function(T item)? itemTrailingBuilder,
+  TextDropdownConfig? config,
+  ...
+})
+```
+
+It shares every layout, theming and search parameter with `FlutterDropdownButton`. It does **not** have `value`, `scrollToSelectedItem`, `scrollToSelectedDuration`, `disableWhenSingleItem` or `hideIconWhenSingleItem`: those mean nothing to a checklist, so they are absent from the type rather than asserted against at runtime.
+
+Text mode only. An item that needs more than text — an avatar, two lines — is a fourth `DropdownItemPresentation` and does not exist yet.
+
+### Contracts
+
+- **`selected` is yours.** `onChanged` receives a fresh `Set`; the one you pass in is never mutated and may be unmodifiable.
+- **`T` needs `==` and `hashCode`.** `selected.contains(item)` uses both, where single-select's `value == item` used only the first. A `T` with a hand-written `==` and the default `hashCode` will let a `Set` hold duplicates that look identical.
+- **A chosen value absent from `items`** still counts towards `labelBuilder`, and draws no row. `'3 selected'` can appear beside two ticked boxes after a refresh drops the third. Offer a way to clear it.
+- **The query survives a tick.** Only opening and closing the menu reset it.
+- **Rows announce their checked state.** The box is drawn but excluded from the semantics tree; the row carries `checked` instead. A live `Checkbox` inside the row's ink well would announce every row as *disabled*.
+- **A trailing widget's text is merged into the row's announced label.** The ink well merges its descendants, so `itemTrailingBuilder: (v) => Text('42')` makes a screen reader read `"Apple\n42"`.
+
+### Statics
+
+| Member | Description |
+|--------|-------------|
+| `closeAll({bool animate = true})` | The same registry as `FlutterDropdownButton.closeAll`. Either closes both kinds |
 
 ## DropdownTheme
 
@@ -262,6 +306,29 @@ A `value` that is not among `items` — the state a list refresh leaves behind w
 The menu is a separate matter. It iterates `items`, so an absent value is never a row.
 
 `items` is therefore read by nothing and is **deprecated**; it will be removed in 4.0.0.
+
+### MultiSelectPresentation\<T\>
+
+Renders items as a checklist: a box, a label, and an optional trailing widget. The button's face is whatever `labelBuilder` makes of the chosen set. `FlutterMultiSelectDropdown` uses it; nothing stops you from driving it yourself.
+
+```dart
+final presentation = MultiSelectPresentation<String>(
+  selected: chosen,
+  labelBuilder: (s) => '${s.length} selected',
+  label: null,                                 // required unless T is String
+  config: TextDropdownConfig.defaultConfig,
+  tooltipTheme: DropdownTooltipTheme.defaultTheme,
+  enabled: true,
+  itemTrailingBuilder: (item) => Text('${counts[item]}'),
+);
+```
+
+The interface is unchanged. `buildSelected()` still takes no argument: `TextItemPresentation` swallows a `value` as a field, and this one swallows a `Set` and a `labelBuilder` the same way.
+
+Two things it does that are not visible on screen:
+
+- The `Checkbox` is **presentational** and **excluded from the semantics tree**, and the row carries `Semantics(checked:)` instead. `onChanged: null` gives the box no gesture recognizer — a tap on it falls through to the row — but it *does* put `isEnabled: false` on the merged row, which makes a screen reader call every row of a working checklist *dimmed*. `IgnorePointer` does not help; it suppresses hit-testing, not semantics.
+- The row's ink well **merges** its descendants' semantics, so `itemTrailingBuilder`'s text becomes part of the announced label: `"Apple\n42"`.
 
 ## DropdownSearchController\<T\>
 

--- a/documentation/migration.md
+++ b/documentation/migration.md
@@ -1,5 +1,37 @@
 # Migration Guide
 
+## Upgrading to 3.1.0
+
+A new widget, one behaviour change, one deprecation. Nothing was removed.
+
+**`FlutterMultiSelectDropdown<T>` is new.** A checklist that stays open, emits a `Set<T>` the moment a box is ticked, and needs no confirm button. It shares every layout, theming and search parameter with `FlutterDropdownButton`. Nothing you already wrote changes.
+
+**Custom mode now draws a `value` that is not in `items`.** Previously `FlutterDropdownButton(itemBuilder: ...)` audited `value` against `items` and fell back to `hintWidget` when it was absent — silently, with no callback and no error. Text mode never did this, having no `items` to consult. The two now agree: **the widget draws what it was handed.**
+
+You see a difference only if a `value` outlives its row — the state a list refresh leaves behind. Where the button used to show the hint, it now shows the value. The menu is unchanged; it iterates `items` and never invented a row for it.
+
+If you were relying on the old fallback to detect a stale `value`, do it where the state lives:
+
+```dart
+// Before: the button told you, by showing the hint.
+// After:
+if (value != null && !items.contains(value)) {
+  // clear it, or offer the user a way to
+}
+```
+
+**`CustomItemPresentation.items` is deprecated.** It fed the audit above and is now read by nothing. It is no longer `required`; drop the argument. It will be removed in 4.0.0.
+
+```dart
+// Before
+CustomItemPresentation<T>(itemBuilder: ..., items: items, value: value)
+
+// After
+CustomItemPresentation<T>(itemBuilder: ..., value: value)
+```
+
+Only code that constructs a presentation by hand — a dropdown built on `DropdownOverlayController` — is affected. `FlutterDropdownButton` callers see nothing.
+
 ## Upgrading to 3.0.1
 
 No API changed. Three bugs did, and two of them are visible.

--- a/documentation/theming.md
+++ b/documentation/theming.md
@@ -96,6 +96,45 @@ DropdownTheme(
 )
 ```
 
+### The checkbox in a multi-select row
+
+`DropdownTheme` does not style it. A `FlutterMultiSelectDropdown` row draws a
+plain `Checkbox`, which reads the ambient `CheckboxThemeData` and `ColorScheme`
+like any other:
+
+```dart
+Theme(
+  data: Theme.of(context).copyWith(
+    checkboxTheme: CheckboxThemeData(
+      fillColor: WidgetStateProperty.resolveWith(
+        (states) => states.contains(WidgetState.selected)
+            ? Colors.teal
+            : null,
+      ),
+    ),
+  ),
+  child: FlutterMultiSelectDropdown<String>(...),
+)
+```
+
+Everything around it — the row's hover, splash, margin, radius, and the
+selected row's background — is `DropdownTheme`'s, exactly as for a single-select
+menu.
+
+`itemHeight` must leave room for the box. A `Checkbox` measures **48×48** with
+Flutter's default `materialTapTargetSize`, and **40×40** under
+`MaterialTapTargetSize.shrinkWrap` — measured, not remembered. This package's
+default `itemHeight` is 48, so a shorter row needs the smaller tap target too:
+
+```dart
+Theme(
+  data: Theme.of(context).copyWith(
+    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+  ),
+  child: FlutterMultiSelectDropdown<String>(itemHeight: 40, ...),
+)
+```
+
 ## Advanced Theming
 
 ### Custom Decorations

--- a/documentation/use_cases.md
+++ b/documentation/use_cases.md
@@ -380,3 +380,85 @@ FlutterDropdownButton<String>.text(
 | `minWidth: 100, maxWidth: 300` | Content-driven, clamped to 100~300px |
 | `expand: true` | Fills available flex space |
 | None | Shrinks to content, no limit |
+
+---
+
+## Filter Panel — Multi-Select
+
+The case this widget was built for. A side panel, 350px wide, filters a list of
+server nodes by fields whose values are finite and discovered at runtime: OS
+family, protocol, status. The user wants several values ORed together, applied
+the moment they are ticked, beside chip filters that already behave that way.
+
+A `showDialog` + `CheckboxListTile` gets you there, but it dims the page, it
+forces an *Apply* button, and it breaks gesture parity with the chips.
+
+```dart
+class OsFilter extends StatefulWidget {
+  const OsFilter({super.key, required this.nodes, required this.onFilter});
+
+  final List<Node> nodes;
+  final ValueChanged<Set<String>> onFilter;
+
+  @override
+  State<OsFilter> createState() => _OsFilterState();
+}
+
+class _OsFilterState extends State<OsFilter> {
+  Set<String> chosen = {};
+
+  @override
+  Widget build(BuildContext context) {
+    // The values, and how many nodes carry each, come from the data.
+    final counts = <String, int>{};
+    for (final node in widget.nodes) {
+      counts[node.os] = (counts[node.os] ?? 0) + 1;
+    }
+    final values = counts.keys.toList()..sort();
+
+    return FlutterMultiSelectDropdown<String>(
+      width: 320,
+      items: values,
+      selected: chosen,
+      labelBuilder: (s) => switch (s.length) {
+        0 => 'All operating systems',
+        1 => s.first,
+        _ => '${s.length} selected',
+      },
+      // Ten values is where scanning stops working.
+      searchable: values.length > 10,
+      itemTrailingBuilder: (v) => Text('${counts[v]}'),
+      onChanged: (next) {
+        setState(() => chosen = next);
+        widget.onFilter(next);   // OR semantics are yours; the widget has none
+      },
+    );
+  }
+}
+```
+
+### Why a list rather than chips
+
+`Windows Active Directory` is a real value. As a chip in a `Wrap` it eats a whole
+row of a 350px panel. A list row uses the full width and ellipsises what does not
+fit, with the full string in a tooltip — so the layout is immune to how long the
+values turn out to be.
+
+### The value that disappears
+
+Refresh the node list and every machine running `Solaris` may be gone. `chosen`
+still holds `'Solaris'`; `items` no longer offers it.
+
+Nothing breaks. The widget draws what it was handed: no row is invented for the
+missing value, no exception is thrown, and the choice is not silently discarded.
+What it *does* do is count it — `labelBuilder` sees a set of three beside two
+ticked boxes.
+
+That is deliberate: `chosen` is your state, and a widget that edited it behind
+your back would be the harder bug. Show the chosen values as removable chips
+beside the button, and the stale one has an exit.
+
+### What the widget does not do
+
+Filter semantics. OR versus AND, `contains` versus `∈`, how an empty set reads —
+all yours. The widget takes a `Set<T>` and gives back a `Set<T>`.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'pages/playground_page.dart';
 import 'pages/bug_test_page.dart';
 import 'pages/domain_type_page.dart';
+import 'pages/multi_select_page.dart';
 import 'pages/result_page.dart';
 
 void main() {
@@ -24,6 +25,7 @@ class MyApp extends StatelessWidget {
       routes: {
         '/dropdown-bug-test': (context) => const DropdownBugTestPage(),
         '/domain-type': (context) => const DomainTypePage(),
+        '/multi-select': (context) => const MultiSelectPage(),
         '/result-page': (context) => const ResultPage(),
       },
     );

--- a/example/lib/pages/multi_select_page.dart
+++ b/example/lib/pages/multi_select_page.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+
+/// One row of the fake server list the filter runs over.
+class Node {
+  const Node(this.name, this.os);
+
+  final String name;
+  final String os;
+}
+
+const _allNodes = <Node>[
+  Node('web-01', 'Windows Active Directory'),
+  Node('web-02', 'Windows Active Directory'),
+  Node('db-01', 'Linux'),
+  Node('db-02', 'Linux'),
+  Node('db-03', 'Linux'),
+  Node('build-01', 'macOS'),
+  Node('legacy-01', 'Solaris'),
+  Node('mainframe-01', 'AIX'),
+  Node('edge-01', 'FreeBSD'),
+  Node('edge-02', 'OpenBSD'),
+  Node('lab-01', 'Plan 9'),
+  Node('lab-02', 'Haiku'),
+];
+
+/// The case `FlutterMultiSelectDropdown` was built for: a narrow side panel
+/// filtering a list by a field whose values are finite and discovered at
+/// runtime, several values ORed together, applied the instant they are ticked.
+///
+/// Two things this page exists to show, because neither is visible in a
+/// screenshot:
+///
+///  * **Long values do not break the layout.** `Windows Active Directory` would
+///    eat a whole row as a chip. As a list row it ellipsises, with the full
+///    string in a tooltip.
+///  * **A chosen value may disappear from `items`.** Press *Drop Solaris* while
+///    it is ticked. Nothing throws, no row is invented, the choice is not
+///    silently discarded — and the face still counts it.
+class MultiSelectPage extends StatefulWidget {
+  const MultiSelectPage({super.key});
+
+  @override
+  State<MultiSelectPage> createState() => _MultiSelectPageState();
+}
+
+class _MultiSelectPageState extends State<MultiSelectPage> {
+  Set<String> _chosen = {};
+  bool _solarisGone = false;
+  bool _searchable = true;
+
+  List<Node> get _nodes => _solarisGone
+      ? _allNodes.where((n) => n.os != 'Solaris').toList()
+      : _allNodes;
+
+  /// Values, and how many nodes carry each, come from the data.
+  Map<String, int> get _counts {
+    final counts = <String, int>{};
+    for (final node in _nodes) {
+      counts[node.os] = (counts[node.os] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  /// OR semantics. The widget has none of its own.
+  List<Node> get _filtered => _chosen.isEmpty
+      ? _nodes
+      : _nodes.where((n) => _chosen.contains(n.os)).toList();
+
+  @override
+  Widget build(BuildContext context) {
+    final counts = _counts;
+    final values = counts.keys.toList()..sort();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Multi-Select Filter')),
+      body: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 350,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Operating system',
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 8),
+                  FlutterMultiSelectDropdown<String>(
+                    width: 318,
+                    height: 260,
+                    items: values,
+                    selected: _chosen,
+                    searchable: _searchable,
+                    labelBuilder: (s) => switch (s.length) {
+                      0 => 'All operating systems',
+                      1 => s.first,
+                      _ => '${s.length} selected',
+                    },
+                    itemTrailingBuilder: (v) => Text(
+                      '${counts[v]}',
+                      style: TextStyle(color: Colors.grey.shade600),
+                    ),
+                    onChanged: (next) => setState(() => _chosen = next),
+                  ),
+                  const SizedBox(height: 12),
+                  if (_chosen.isNotEmpty)
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      children: [
+                        for (final value in _chosen)
+                          InputChip(
+                            label: Text(value, overflow: TextOverflow.ellipsis),
+                            // A value with no rows left still has an exit.
+                            avatar: counts.containsKey(value)
+                                ? null
+                                : const Icon(Icons.warning_amber, size: 16),
+                            onDeleted: () => setState(
+                              () => _chosen = {..._chosen}..remove(value),
+                            ),
+                          ),
+                      ],
+                    ),
+                  const Divider(height: 32),
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('searchable'),
+                    value: _searchable,
+                    onChanged: (v) => setState(() => _searchable = v),
+                  ),
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Drop Solaris from the data'),
+                    subtitle: const Text(
+                      'Tick Solaris first, then flip this: the row goes, the '
+                      'choice stays, the count still includes it.',
+                    ),
+                    value: _solarisGone,
+                    onChanged: (v) => setState(() => _solarisGone = v),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Text(
+                  '${_filtered.length} of ${_nodes.length} nodes',
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 8),
+                for (final node in _filtered)
+                  ListTile(
+                    dense: true,
+                    title: Text(node.name),
+                    subtitle: Text(node.os),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/playground_page.dart
+++ b/example/lib/pages/playground_page.dart
@@ -394,6 +394,11 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
         title: const Text('Dropdown Playground'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.checklist),
+            tooltip: 'Multi-Select Filter',
+            onPressed: () => Navigator.pushNamed(context, '/multi-select'),
+          ),
+          IconButton(
             icon: const Icon(Icons.travel_explore),
             tooltip: 'Domain Types & Controller',
             onPressed: () => Navigator.pushNamed(context, '/domain-type'),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.2"
+    version: "3.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 3.0.2
+version: 3.1.0
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues


### PR DESCRIPTION
Closes #66.

Two commits: the consistency sweep, then the release.

## The sweep

Code-only changes do not exist here. Every surface that describes behaviour was walked, and one of them had been made false by this very work.

**`README.md` said "Single Unified Widget: One `FlutterDropdownButton<T>` for all use cases"**, and its subtitle said *"all in a single widget"*. Both were true when written and are not now. Also: a `FlutterMultiSelectDropdown` section with its parameter table, a **Multi-Select Checklist** quick-start example, and a subsection on a `value` that is not in `items` — which the `value` row of the common table now points at.

**`documentation/api_reference.md`** — the new widget, its six contracts (`selected` is yours; `T` needs `hashCode`; an absent value counts; the query survives a tick; rows announce *checked*; a trailing widget's text merges into the announced label), and `MultiSelectPresentation`. Its `closeAll` section was checked against the code and is **already correct** — #66 described it as stale from memory of an older session. Nothing to fix there.

**`documentation/migration.md`** — an `Upgrading to 3.1.0` section, because a behaviour did change. A caller who relied on the old custom-mode fallback to *detect* a stale `value` is shown where to do it instead.

**`documentation/theming.md`** — `DropdownTheme` does not style the checkbox; the ambient `CheckboxThemeData` does. And `itemHeight` must leave room for it. That number was measured rather than remembered:

```
PROBE default size = Size(48.0, 48.0)
PROBE shrinkWrap  = Size(40.0, 40.0)
```

**`documentation/use_cases.md`** — the filter panel, written from the reporter's actual problem: a 350px side panel, values discovered at runtime, `Windows Active Directory` as a chip eating a whole row, and the value that vanishes on refresh.

**`example/`** — a `MultiSelectPage` that demonstrates the two things a screenshot cannot: a long value ellipsising rather than wrapping, and a *Drop Solaris from the data* switch that makes a chosen value outlive its row. It shows the removable-chip exit the docs recommend, marked with a warning icon when its rows are gone. Routed from the playground.

**`CLAUDE.md`** — four claims had gone false: *"There is **one** widget"*, *"`## Deprecated` — **Nothing**"*, `222 tests`, `937 lines`. Now two widgets, one deprecation, 256 tests, 1037 lines, plus the shell in the architecture section and the three new suites in the test table.

## The release

`3.1.0`. Adding a widget is a minor bump.

The changelog names the symptom, not the cause: *a custom-mode button showed its hint when a list refresh dropped the chosen row's data — no callback, no error*.

## Gates

Run bare. Never piped.

```
dart format --output=none --set-exit-if-changed .   exit 0
flutter analyze                                     No issues found!
flutter test --coverage                             256 passed
dart run tool/check_coverage.dart --min 100         100.00% (1037/1037)
cd example && flutter analyze                       No issues found!
flutter pub publish --dry-run                       0 warnings
```

Archive checked by ASCII name, both directions:

```
included: flutter_multi_select_dropdown.dart (6 KB)
included: dropdown_menu_shell.dart (23 KB)
excluded: lcov / coverage/ / tool/ / docs/agents  -> none
```

`flutter pub publish` is not run by an agent. pub.dev has no version deletion, only retraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)