### PR TITLE
docs: the leading slot in the filter-panel use case and the theming guide

### DIFF
--- a/documentation/theming.md
+++ b/documentation/theming.md
@@ -121,6 +121,16 @@ Everything around it — the row's hover, splash, margin, radius, and the
 selected row's background — is `DropdownTheme`'s, exactly as for a single-select
 menu.
 
+The widgets `itemLeadingBuilder` and `itemTrailingBuilder` return are **yours**.
+The package places them and styles nothing about them; colour and size are
+whatever you build:
+
+```dart
+itemLeadingBuilder: (v) => Icon(osIcon[v], size: 18, color: theme.iconColor),
+itemTrailingBuilder: (v) => Text('${counts[v]}',
+    style: TextStyle(color: Colors.grey.shade600)),
+```
+
 `itemHeight` must leave room for the box. A `Checkbox` measures **48×48** with
 Flutter's default `materialTapTargetSize`, and **40×40** under
 `MaterialTapTargetSize.shrinkWrap` — measured, not remembered. This package's

--- a/documentation/use_cases.md
+++ b/documentation/use_cases.md
@@ -427,6 +427,10 @@ class _OsFilterState extends State<OsFilter> {
       },
       // Ten values is where scanning stops working.
       searchable: values.length > 10,
+      // A row is [checkbox] [leading] [label] [trailing]. Both slots are
+      // builders because each value wants a different icon and a different
+      // count. Only the label gives way when the row runs out of room.
+      itemLeadingBuilder: (v) => Icon(osIcon[v], size: 18),
       itemTrailingBuilder: (v) => Text('${counts[v]}'),
       onChanged: (next) {
         setState(() => chosen = next);


### PR DESCRIPTION
A gap found by grepping for `itemLeadingBuilder` across every surface after #73 merged.

```
README.md                        2
documentation/api_reference.md   3
documentation/use_cases.md       0   <-
documentation/theming.md         0   <-
CHANGELOG.md                     1
example/…/multi_select_page.dart 2
```

**`use_cases.md` and `example/` disagreed.** The filter-panel use case is the story the playground page tells, and the page maps an icon per operating system while the prose showed only a count. Two descriptions of the same screen, one of them incomplete.

**`theming.md` said what themes the checkbox and stopped there.** It never said that the widgets `itemLeadingBuilder` and `itemTrailingBuilder` return are the caller's, styled by nobody. Someone hunting for an icon colour in `DropdownTheme` would have hunted a while.

Documentation only. No `lib/` change.

```
dart format --output=none --set-exit-if-changed .   exit 0
flutter analyze                                     No issues found!
flutter test --coverage                             259 passed
dart run tool/check_coverage.dart --min 100         100.00% (1040/1040)
```

The three numbers are quoted together on purpose. A coverage percentage over a collapsed denominator is meaningless, which #73 learned the hard way: `100.00% (45/45)` while 33 tests were failing to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)