### PR TITLE
feat: DropdownCheckboxTheme — style the multi-select checklist checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.2.0
+
+Additive. One new optional field; nothing removed, nothing else changed.
+
+* **FEAT**: `DropdownCheckboxTheme` — styles the checkbox on each row of a `FlutterMultiSelectDropdown`, reached through the new `checkbox` slot on `DropdownStyleTheme`. It carries the eight fields that actually render on the row's box: `activeColor`, `fillColor`, `checkColor`, `side`, `shape`, `materialTapTargetSize`, `visualDensity`, `mouseCursor`. The box is drawn `onChanged: null` with its semantics excluded, so an interactive checkbox's focus/hover/splash fields are absent by construction rather than settable-but-dead. `mouseCursor` is kept because its `MouseRegion` is installed regardless of interactivity — so it lets you match the box's cursor to the row's
+* **FEAT**: `activeColor` — the fill of a **checked** box — is the common case. The box is non-interactive, which puts it in Flutter's `disabled` state, where a raw `Checkbox.activeColor` is dropped before it is read. The theme resolves `activeColor` into `fillColor`, which `Checkbox` consults first, so it survives. Set `fillColor` yourself for per-state control; it wins over `activeColor`
+* **FIX**: `documentation/theming.md` taught a checkbox `Theme(...)` wrapped around the dropdown. It silently did nothing: the menu is drawn in the root `Overlay`, out of a local `Theme`'s subtree, so `CheckboxTheme.of` at the box resolved to the app theme, not the local one (pinned with a probe — the box's resolved fill came back null). Only an app-wide `CheckboxThemeData` reached it, and now `DropdownCheckboxTheme` reaches just this dropdown
+* **TEST**: line coverage stays at 100%, with the checked box's fill asserted against the `{disabled, selected}` state it is actually in — the state a naive `activeColor` test would miss
+
 ## 3.1.0
 
 Adds a second widget. Nothing was removed; one field is deprecated and one behaviour changed, both described below.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^3.1.0
+  flutter_dropdown_button: ^3.2.0
 ```
 
 Import the package:
@@ -279,14 +279,15 @@ Alignment of the dropdown menu relative to the button when the menu is wider.
 
 ## Theme System
 
-Theme is applied via the `theme` parameter using `DropdownStyleTheme`, which groups four theme objects:
+Theme is applied via the `theme` parameter using `DropdownStyleTheme`, which groups five theme objects:
 
 ```dart
 DropdownStyleTheme(
-  dropdown: DropdownTheme(...),        // General dropdown styling
-  scroll: DropdownScrollTheme(...),    // Scrollbar styling
-  tooltip: DropdownTooltipTheme(...),  // Tooltip styling
-  search: SearchFieldTheme(...),       // Search field styling
+  dropdown: DropdownTheme(...),          // General dropdown styling
+  scroll: DropdownScrollTheme(...),      // Scrollbar styling
+  tooltip: DropdownTooltipTheme(...),    // Tooltip styling
+  search: SearchFieldTheme(...),         // Search field styling
+  checkbox: DropdownCheckboxTheme(...),  // Multi-select row checkbox styling
 )
 ```
 
@@ -454,6 +455,23 @@ Controls the appearance and behavior of the search text field when `searchable` 
 | `textAlign` | `TextAlign` | `.start` | Text alignment |
 | `keyboardType` | `TextInputType?` | `.text` | Keyboard type |
 | `textInputAction` | `TextInputAction?` | `.search` | Keyboard action button |
+
+### DropdownCheckboxTheme
+
+Styles the checkbox on each row of a `FlutterMultiSelectDropdown`. Reaches the box even though the menu is drawn in the root overlay, where a `Theme` wrapped around the widget cannot — only an app-wide `CheckboxThemeData` otherwise could, and that restyles every checkbox in the app. Only the fields that render on the presentational (`onChanged: null`, semantics-excluded) box are here.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `activeColor` | `Color?` | `null` | Fill of a **checked** box. Routed through `fillColor` so it survives the box's disabled state |
+| `fillColor` | `WidgetStateProperty<Color?>?` | `null` | Per-state fill, for full control. Wins over `activeColor` |
+| `checkColor` | `Color?` | `null` | Color of the checkmark |
+| `side` | `BorderSide?` | `null` | Outline of an **unchecked** box (a checked box's fill covers it) |
+| `shape` | `OutlinedBorder?` | `null` | Box shape, e.g. rounded corners |
+| `materialTapTargetSize` | `MaterialTapTargetSize?` | `null` | Size class the box occupies |
+| `visualDensity` | `VisualDensity?` | `null` | Density adjustment to the box's size |
+| `mouseCursor` | `MouseCursor?` | `null` | Cursor over the box. Set to `SystemMouseCursors.click` to match the row's |
+
+Each null field defers to the ambient `CheckboxThemeData`.
 
 ### TextDropdownConfig
 

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -326,6 +326,8 @@ final presentation = MultiSelectPresentation<String>(
 );
 ```
 
+An optional `checkboxTheme` (a `DropdownCheckboxTheme`, default `defaultTheme`) styles the row's box. It resolves the box's `activeColor` through `fillColor` so the accent survives the box's `onChanged: null` disabled state; see [theming](theming.md).
+
 The interface is unchanged. `buildSelected()` still takes no argument: `TextItemPresentation` swallows a `value` as a field, and this one swallows a `Set` and a `labelBuilder` the same way.
 
 Two things it does that are not visible on screen:

--- a/documentation/theming.md
+++ b/documentation/theming.md
@@ -98,28 +98,52 @@ DropdownTheme(
 
 ### The checkbox in a multi-select row
 
-`DropdownTheme` does not style it. A `FlutterMultiSelectDropdown` row draws a
-plain `Checkbox`, which reads the ambient `CheckboxThemeData` and `ColorScheme`
-like any other:
+Style it with `DropdownCheckboxTheme`, the `checkbox` slot on
+`DropdownStyleTheme`:
 
 ```dart
-Theme(
-  data: Theme.of(context).copyWith(
-    checkboxTheme: CheckboxThemeData(
-      fillColor: WidgetStateProperty.resolveWith(
-        (states) => states.contains(WidgetState.selected)
-            ? Colors.teal
-            : null,
+FlutterMultiSelectDropdown<String>(
+  theme: DropdownStyleTheme(
+    checkbox: DropdownCheckboxTheme(
+      activeColor: Colors.teal,                         // fill of a checked box
+      checkColor: Colors.white,                         // the checkmark
+      side: BorderSide(color: Colors.grey, width: 2),   // an unchecked box's outline
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(4),
       ),
     ),
   ),
-  child: FlutterMultiSelectDropdown<String>(...),
+  ...
 )
 ```
 
-Everything around it — the row's hover, splash, margin, radius, and the
-selected row's background — is `DropdownTheme`'s, exactly as for a single-select
-menu.
+Only the fields that render are here — `activeColor`, `fillColor`, `checkColor`,
+`side`, `shape`, `materialTapTargetSize`, `visualDensity`, `mouseCursor`. The
+row's box is drawn `onChanged: null` (a tap falls through to the row) with its
+semantics excluded, so the focus, hover and splash of an interactive checkbox
+never appear. `mouseCursor` is the exception — its `MouseRegion` is installed
+either way, so set it to `SystemMouseCursors.click` to match the row's cursor.
+
+`activeColor` is the common case — the fill of a **checked** box. Because the box
+is non-interactive, Flutter would drop a raw `Checkbox.activeColor`; the theme
+routes it through `fillColor` so it takes. For per-state control, set `fillColor`
+directly (it wins over `activeColor`):
+
+```dart
+DropdownCheckboxTheme(
+  fillColor: WidgetStateProperty.resolveWith(
+    (states) => states.contains(WidgetState.selected) ? Colors.teal : null,
+  ),
+)
+```
+
+**A `Theme` wrapped around the dropdown does not reach the box.** The menu is
+drawn in the root `Overlay`, out of a local `Theme`'s subtree — a
+`CheckboxThemeData` you want to apply must live on `MaterialApp.theme`, and it
+then restyles every checkbox in the app. `DropdownCheckboxTheme` is how you reach
+just this dropdown's boxes. Everything *around* the box — the row's hover,
+splash, margin, radius, and the selected row's background — stays `DropdownTheme`'s,
+exactly as for a single-select menu.
 
 The widgets `itemLeadingBuilder` and `itemTrailingBuilder` return are **yours**.
 The package places them and styles nothing about them; colour and size are
@@ -134,14 +158,18 @@ itemTrailingBuilder: (v) => Text('${counts[v]}',
 `itemHeight` must leave room for the box. A `Checkbox` measures **48×48** with
 Flutter's default `materialTapTargetSize`, and **40×40** under
 `MaterialTapTargetSize.shrinkWrap` — measured, not remembered. This package's
-default `itemHeight` is 48, so a shorter row needs the smaller tap target too:
+default `itemHeight` is 48, so a shorter row needs the smaller tap target too —
+and, unlike the ambient theme, `DropdownCheckboxTheme` scopes it to this dropdown:
 
 ```dart
-Theme(
-  data: Theme.of(context).copyWith(
-    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+FlutterMultiSelectDropdown<String>(
+  itemHeight: 40,
+  theme: DropdownStyleTheme(
+    checkbox: DropdownCheckboxTheme(
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    ),
   ),
-  child: FlutterMultiSelectDropdown<String>(itemHeight: 40, ...),
+  ...
 )
 ```
 

--- a/example/lib/pages/multi_select_page.dart
+++ b/example/lib/pages/multi_select_page.dart
@@ -114,6 +114,21 @@ class _MultiSelectPageState extends State<MultiSelectPage> {
                       1 => s.first,
                       _ => '${s.length} selected',
                     },
+                    // The row checkbox, scoped to this dropdown — an app-wide
+                    // CheckboxThemeData would be the only ambient way to reach a
+                    // box drawn in the root overlay, and it would restyle every
+                    // checkbox in the app. `click` matches the box's cursor to
+                    // the row's.
+                    theme: const DropdownStyleTheme(
+                      checkbox: DropdownCheckboxTheme(
+                        activeColor: Colors.indigo,
+                        checkColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(4)),
+                        ),
+                        mouseCursor: SystemMouseCursors.click,
+                      ),
+                    ),
                     // An icon between the box and the label; the count after
                     // it. One slot could not have held both on the right sides.
                     itemLeadingBuilder: (v) =>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.2.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/flutter_dropdown_button.dart
+++ b/lib/flutter_dropdown_button.dart
@@ -7,6 +7,7 @@ export 'src/overlay/dropdown_overlay_controller.dart';
 export 'src/presentation/item_presentation.dart';
 export 'src/search/dropdown_search_controller.dart';
 export 'src/config/text_dropdown_config.dart';
+export 'src/theme/dropdown_checkbox_theme.dart';
 export 'src/theme/dropdown_scroll_theme.dart';
 export 'src/theme/dropdown_style_theme.dart';
 export 'src/theme/dropdown_theme.dart';

--- a/lib/src/flutter_multi_select_dropdown.dart
+++ b/lib/src/flutter_multi_select_dropdown.dart
@@ -5,6 +5,7 @@ import 'config/text_dropdown_config.dart';
 import 'overlay/dropdown_overlay_controller.dart';
 import 'presentation/item_presentation.dart';
 import 'shell/dropdown_menu_shell.dart';
+import 'theme/dropdown_checkbox_theme.dart';
 import 'theme/dropdown_style_theme.dart';
 import 'theme/tooltip_theme.dart';
 
@@ -108,7 +109,8 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
   /// Text rendering rules: overflow, alignment, styles.
   final TextDropdownConfig? config;
 
-  /// Styling for the button, the menu, its scrollbar and its search field.
+  /// Styling for the button, the menu, its scrollbar, its search field and its
+  /// row checkboxes ([DropdownStyleTheme.checkbox]).
   final DropdownStyleTheme? theme;
 
   /// A fixed button width.
@@ -186,6 +188,7 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
         config: config ?? TextDropdownConfig.defaultConfig,
         tooltipTheme: theme?.tooltip ?? DropdownTooltipTheme.defaultTheme,
         enabled: enabled,
+        checkboxTheme: theme?.checkbox ?? DropdownCheckboxTheme.defaultTheme,
         itemLeadingBuilder: itemLeadingBuilder,
         itemTrailingBuilder: itemTrailingBuilder,
       ),

--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../config/text_dropdown_config.dart';
+import '../theme/dropdown_checkbox_theme.dart';
 import '../theme/tooltip_theme.dart';
 import '../widgets/smart_tooltip_text.dart';
 
@@ -289,6 +290,7 @@ class MultiSelectPresentation<T> implements DropdownItemPresentation<T> {
     required this.config,
     required this.tooltipTheme,
     required this.enabled,
+    this.checkboxTheme = DropdownCheckboxTheme.defaultTheme,
     this.itemLeadingBuilder,
     this.itemTrailingBuilder,
   }) : assert(
@@ -314,6 +316,10 @@ class MultiSelectPresentation<T> implements DropdownItemPresentation<T> {
 
   /// Whether the button is interactive, which selects the disabled text style.
   final bool enabled;
+
+  /// Styling for the row's checkbox. Resolved once per row into the concrete
+  /// [Checkbox] arguments.
+  final DropdownCheckboxTheme checkboxTheme;
 
   /// Drawn between the checkbox and the label — an icon that varies by item.
   ///
@@ -381,12 +387,29 @@ class MultiSelectPresentation<T> implements DropdownItemPresentation<T> {
   Widget buildItem(T item, bool isSelected) {
     final leading = itemLeadingBuilder?.call(item);
     final trailing = itemTrailingBuilder?.call(item);
+    final checkbox = checkboxTheme.resolve();
 
     return Semantics(
       checked: isSelected,
       child: Row(
         children: [
-          ExcludeSemantics(child: Checkbox(value: isSelected, onChanged: null)),
+          // `onChanged: null` keeps the box presentational — the tap falls
+          // through to the row's InkWell. Every resolved slot is null unless the
+          // theme named it, so an unset theme leaves the box to the ambient
+          // CheckboxThemeData exactly as before.
+          ExcludeSemantics(
+            child: Checkbox(
+              value: isSelected,
+              onChanged: null,
+              fillColor: checkbox.fillColor,
+              checkColor: checkbox.checkColor,
+              side: checkbox.side,
+              shape: checkbox.shape,
+              materialTapTargetSize: checkbox.materialTapTargetSize,
+              visualDensity: checkbox.visualDensity,
+              mouseCursor: checkbox.mouseCursor,
+            ),
+          ),
           if (leading != null)
             Padding(padding: const EdgeInsets.only(right: 8.0), child: leading),
           // Only the label gives way. A squeezed icon is never what was meant.

--- a/lib/src/theme/dropdown_checkbox_theme.dart
+++ b/lib/src/theme/dropdown_checkbox_theme.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+
+import 'resolved_dropdown_style.dart';
+
+/// Styling for the checkbox drawn on each row of a [FlutterMultiSelectDropdown].
+///
+/// The menu is drawn in an [OverlayEntry] inserted at the root [Overlay], so a
+/// local [Theme] wrapping the dropdown never reaches it — only an app-wide
+/// [CheckboxThemeData] does, and that restyles every checkbox in the app. This
+/// theme is how you recolour *just this dropdown's* boxes. Naming a field
+/// overrides that slot; leaving it null defers to the ambient
+/// [CheckboxThemeData]. See [resolve].
+///
+/// Only the fields that actually render are here. The box is drawn with
+/// `onChanged: null` (it is presentational — a tap falls through to the row) and
+/// with its semantics excluded (the row announces the checked state). That rules
+/// out every focus/hover/splash/overlay/semantic-label field, which a
+/// non-interactive, semantics-excluded checkbox never shows. [mouseCursor] is
+/// the exception: its `MouseRegion` is installed whether or not the box is
+/// interactive, so it is honoured here.
+///
+/// ```dart
+/// FlutterMultiSelectDropdown<String>(
+///   // …
+///   theme: DropdownStyleTheme(
+///     checkbox: DropdownCheckboxTheme(
+///       activeColor: Colors.teal,        // fill of a checked box
+///       checkColor: Colors.white,        // the checkmark
+///       side: BorderSide(color: Colors.grey, width: 2), // unchecked outline
+///       shape: RoundedRectangleBorder(
+///         borderRadius: BorderRadius.circular(4),
+///       ),
+///     ),
+///   ),
+/// )
+/// ```
+class DropdownCheckboxTheme {
+  /// Creates a checkbox theme configuration.
+  const DropdownCheckboxTheme({
+    this.activeColor,
+    this.fillColor,
+    this.checkColor,
+    this.side,
+    this.shape,
+    this.materialTapTargetSize,
+    this.visualDensity,
+    this.mouseCursor,
+  });
+
+  /// The fill of a **checked** box.
+  ///
+  /// A convenience for the common case: it is resolved into [fillColor] for the
+  /// selected state. The box is drawn with `onChanged: null`, which Flutter
+  /// treats as `disabled`; a plain `Checkbox.activeColor` is dropped in that
+  /// state, so this is routed through [fillColor] — which [Checkbox] consults
+  /// first — to make it survive. If [fillColor] is also given, that wins and
+  /// this is ignored.
+  final Color? activeColor;
+
+  /// The box's fill per [WidgetState], for full control.
+  ///
+  /// Takes precedence over [activeColor]. To colour the checked box, return a
+  /// colour for the `selected` state (it arrives alongside `disabled`, since the
+  /// box is non-interactive) and null otherwise, so an unchecked box keeps the
+  /// ambient default.
+  final WidgetStateProperty<Color?>? fillColor;
+
+  /// The colour of the checkmark. If null, the ambient [CheckboxThemeData]
+  /// decides.
+  final Color? checkColor;
+
+  /// The outline of an **unchecked** box. A checked box draws no outline — its
+  /// fill covers it. If null, the ambient [CheckboxThemeData] decides.
+  final BorderSide? side;
+
+  /// The box's shape — rounded corners, say. If null, the ambient
+  /// [CheckboxThemeData] decides.
+  final OutlinedBorder? shape;
+
+  /// The size class the box occupies. If null, the ambient [CheckboxThemeData]
+  /// decides.
+  final MaterialTapTargetSize? materialTapTargetSize;
+
+  /// The density adjustment applied to the box's size. If null, the ambient
+  /// [CheckboxThemeData] decides.
+  final VisualDensity? visualDensity;
+
+  /// The cursor shown while a pointer is over the box.
+  ///
+  /// The box's `MouseRegion` is installed regardless of its (non-)interactivity,
+  /// so this is honoured even though the box is drawn `onChanged: null`. The box
+  /// sits inside the row's ink well, which shows a click cursor; by default the
+  /// box's own cursor differs over its small area, so set this to
+  /// [SystemMouseCursors.click] to make the whole row read as one target. If
+  /// null, the ambient [CheckboxThemeData] decides.
+  final MouseCursor? mouseCursor;
+
+  /// Creates a copy of this theme with the given fields replaced.
+  DropdownCheckboxTheme copyWith({
+    Color? activeColor,
+    WidgetStateProperty<Color?>? fillColor,
+    Color? checkColor,
+    BorderSide? side,
+    OutlinedBorder? shape,
+    MaterialTapTargetSize? materialTapTargetSize,
+    VisualDensity? visualDensity,
+    MouseCursor? mouseCursor,
+  }) {
+    return DropdownCheckboxTheme(
+      activeColor: activeColor ?? this.activeColor,
+      fillColor: fillColor ?? this.fillColor,
+      checkColor: checkColor ?? this.checkColor,
+      side: side ?? this.side,
+      shape: shape ?? this.shape,
+      materialTapTargetSize:
+          materialTapTargetSize ?? this.materialTapTargetSize,
+      visualDensity: visualDensity ?? this.visualDensity,
+      mouseCursor: mouseCursor ?? this.mouseCursor,
+    );
+  }
+
+  /// The checkbox as it should be drawn.
+  ///
+  /// Pure — it reads no [BuildContext]. Its one job is turning the convenience
+  /// [activeColor] into a [fillColor] that answers for the selected state
+  /// whether or not `disabled` is also present, which is the state the box is
+  /// actually in. Every other field is passed straight through, and an unset
+  /// field stays null so the ambient [CheckboxThemeData] keeps control.
+  ResolvedCheckboxStyle resolve() {
+    return ResolvedCheckboxStyle(
+      fillColor: fillColor ?? _fillFromActiveColor(),
+      checkColor: checkColor,
+      side: side,
+      shape: shape,
+      materialTapTargetSize: materialTapTargetSize,
+      visualDensity: visualDensity,
+      mouseCursor: mouseCursor,
+    );
+  }
+
+  /// [activeColor] as a [fillColor]: the accent when the box is selected — with
+  /// or without `disabled` — and null (defer to ambient) when it is not.
+  WidgetStateProperty<Color?>? _fillFromActiveColor() {
+    final accent = activeColor;
+    if (accent == null) return null;
+    return WidgetStateProperty.resolveWith(
+      (states) => states.contains(WidgetState.selected) ? accent : null,
+    );
+  }
+
+  /// Default theme: every slot deferred to the ambient [CheckboxThemeData].
+  static const DropdownCheckboxTheme defaultTheme = DropdownCheckboxTheme();
+}

--- a/lib/src/theme/dropdown_style_theme.dart
+++ b/lib/src/theme/dropdown_style_theme.dart
@@ -1,3 +1,4 @@
+import 'dropdown_checkbox_theme.dart';
 import 'dropdown_scroll_theme.dart';
 import 'dropdown_theme.dart';
 import 'search_field_theme.dart';
@@ -36,6 +37,7 @@ class DropdownStyleTheme {
     this.scroll = const DropdownScrollTheme(),
     this.tooltip = const DropdownTooltipTheme(),
     this.search = const SearchFieldTheme(),
+    this.checkbox = const DropdownCheckboxTheme(),
   });
 
   /// General dropdown styling configuration.
@@ -64,18 +66,29 @@ class DropdownStyleTheme {
   /// is enabled.
   final SearchFieldTheme search;
 
+  /// Checklist checkbox styling configuration.
+  ///
+  /// Controls the appearance of the checkbox on each row of a
+  /// [FlutterMultiSelectDropdown]. Ignored by the single-select
+  /// [FlutterDropdownButton], which draws no checkbox. Naming a field recolours
+  /// just this dropdown's boxes, where an app-wide [CheckboxThemeData] cannot —
+  /// the menu is drawn in the root [Overlay], out of a local [Theme]'s reach.
+  final DropdownCheckboxTheme checkbox;
+
   /// Creates a copy of this theme with the given fields replaced.
   DropdownStyleTheme copyWith({
     DropdownTheme? dropdown,
     DropdownScrollTheme? scroll,
     DropdownTooltipTheme? tooltip,
     SearchFieldTheme? search,
+    DropdownCheckboxTheme? checkbox,
   }) {
     return DropdownStyleTheme(
       dropdown: dropdown ?? this.dropdown,
       scroll: scroll ?? this.scroll,
       tooltip: tooltip ?? this.tooltip,
       search: search ?? this.search,
+      checkbox: checkbox ?? this.checkbox,
     );
   }
 

--- a/lib/src/theme/resolved_dropdown_style.dart
+++ b/lib/src/theme/resolved_dropdown_style.dart
@@ -297,6 +297,55 @@ class ResolvedOverlayStyle {
   final EdgeInsets? padding;
 }
 
+/// The checklist checkbox's appearance, in the shape [Checkbox] takes.
+///
+/// Every field is handed straight to the [Checkbox] the multi-select menu
+/// draws. A slot the theme left unset stays **null**, which a [Checkbox] reads
+/// as "ask the ambient [CheckboxThemeData]" — writing a default in would
+/// silence an app-wide theme.
+///
+/// [fillColor] is the resolved form of the theme's convenience `activeColor`:
+/// the box is drawn with `onChanged: null`, so Flutter marks it `disabled` and
+/// drops a plain `activeColor` before reading it. Routing the accent through
+/// [fillColor] — which [Checkbox] consults first — is what makes it survive.
+class ResolvedCheckboxStyle {
+  /// Creates a resolved checkbox style.
+  const ResolvedCheckboxStyle({
+    this.fillColor,
+    this.checkColor,
+    this.side,
+    this.shape,
+    this.materialTapTargetSize,
+    this.visualDensity,
+    this.mouseCursor,
+  });
+
+  /// The box's fill per state. Null defers to the ambient [CheckboxThemeData].
+  final WidgetStateProperty<Color?>? fillColor;
+
+  /// The checkmark's colour. Null defers to the ambient theme.
+  final Color? checkColor;
+
+  /// The outline of an **unchecked** box. A checked box has none — its fill
+  /// covers it. Null defers to the ambient theme.
+  final BorderSide? side;
+
+  /// The box's shape. Null defers to the ambient theme.
+  final OutlinedBorder? shape;
+
+  /// The size class the box occupies. Null defers to the ambient theme.
+  final MaterialTapTargetSize? materialTapTargetSize;
+
+  /// The density adjustment applied to the box's size. Null defers to the
+  /// ambient theme.
+  final VisualDensity? visualDensity;
+
+  /// The cursor over the box. Honoured despite `onChanged: null` — the box's
+  /// `MouseRegion` is installed regardless of interactivity. Null defers to the
+  /// ambient theme.
+  final MouseCursor? mouseCursor;
+}
+
 /// One item row's appearance, with every slot filled in.
 class ResolvedItemStyle {
   /// Creates a resolved item style.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 3.1.0
+version: 3.2.0
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues

--- a/test/multi_select_test.dart
+++ b/test/multi_select_test.dart
@@ -14,12 +14,14 @@ class Harness extends StatefulWidget {
     this.initial = const <String>{},
     this.searchable = false,
     this.onChanged,
+    this.theme,
   });
 
   final List<String> items;
   final Set<String> initial;
   final bool searchable;
   final void Function(Set<String>)? onChanged;
+  final DropdownStyleTheme? theme;
 
   @override
   State<Harness> createState() => HarnessState();
@@ -38,6 +40,7 @@ class HarnessState extends State<Harness> {
             height: 200,
             items: widget.items,
             selected: selected,
+            theme: widget.theme,
             searchable: widget.searchable,
             labelBuilder: (s) => s.isEmpty ? 'All' : '${s.length} selected',
             onChanged: (next) {
@@ -301,5 +304,35 @@ void main() {
     await openMenu(tester);
 
     expect(find.text('Cherry'), findsOneWidget);
+  });
+
+  testWidgets('a checkbox theme reaches the boxes in the overlay', (
+    tester,
+  ) async {
+    // End to end: the theme travels the whole path a consumer relies on —
+    // DropdownStyleTheme → the widget → the shell → the presentation → the
+    // Checkbox drawn in the root Overlay, which a local Theme could not reach.
+    await tester.pumpWidget(
+      const Harness(
+        initial: {'Apple'},
+        theme: DropdownStyleTheme(
+          checkbox: DropdownCheckboxTheme(
+            activeColor: Color(0xFF00AA88),
+            checkColor: Color(0xFFFFFFFF),
+            side: BorderSide(color: Color(0xFFDDDDDD), width: 2),
+          ),
+        ),
+      ),
+    );
+    await openMenu(tester);
+
+    final box = tester.widget<Checkbox>(find.byType(Checkbox).first);
+    expect(box.checkColor, const Color(0xFFFFFFFF));
+    expect(box.side, const BorderSide(color: Color(0xFFDDDDDD), width: 2));
+    expect(
+      box.fillColor!.resolve({WidgetState.disabled, WidgetState.selected}),
+      const Color(0xFF00AA88),
+      reason: 'the checked box fills with the accent even while disabled',
+    );
   });
 }

--- a/test/presentation/multi_select_presentation_test.dart
+++ b/test/presentation/multi_select_presentation_test.dart
@@ -28,6 +28,7 @@ MultiSelectPresentation<T> multi<T>({
   Widget Function(T)? itemTrailingBuilder,
   bool enabled = true,
   TextDropdownConfig config = TextDropdownConfig.defaultConfig,
+  DropdownCheckboxTheme checkboxTheme = DropdownCheckboxTheme.defaultTheme,
 }) {
   return MultiSelectPresentation<T>(
     selected: selected,
@@ -36,10 +37,15 @@ MultiSelectPresentation<T> multi<T>({
     config: config,
     tooltipTheme: DropdownTooltipTheme.defaultTheme,
     enabled: enabled,
+    checkboxTheme: checkboxTheme,
     itemLeadingBuilder: itemLeadingBuilder,
     itemTrailingBuilder: itemTrailingBuilder,
   );
 }
+
+/// The `Checkbox` a row was actually rendered with.
+Checkbox renderedBox(WidgetTester tester) =>
+    tester.widget<Checkbox>(find.byType(Checkbox).first);
 
 /// The style the face was actually rendered with.
 TextStyle? faceStyle(WidgetTester tester) =>
@@ -223,6 +229,80 @@ void main() {
       );
 
       expect(find.byType(Icon), findsNothing);
+    });
+  });
+
+  group('checkbox theme', () {
+    // Pump a row and read the Checkbox it built. The box is `onChanged: null`,
+    // so Flutter resolves its colours in the `disabled` state — asserting the
+    // widget's own `fillColor` against `{disabled, selected}` is what proves the
+    // accent survives, since a raw `activeColor` would be dropped there.
+    Future<void> pumpRow(WidgetTester tester, MultiSelectPresentation p) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: p.buildItem('a', true))),
+      );
+    }
+
+    testWidgets('an unthemed row leaves every checkbox slot null', (
+      tester,
+    ) async {
+      await pumpRow(tester, multi<String>(selected: {'a'}));
+
+      final box = renderedBox(tester);
+      expect(box.fillColor, isNull, reason: 'defer to ambient CheckboxTheme');
+      expect(box.checkColor, isNull);
+      expect(box.side, isNull);
+      expect(box.shape, isNull);
+      expect(box.materialTapTargetSize, isNull);
+      expect(box.visualDensity, isNull);
+      expect(box.mouseCursor, isNull);
+    });
+
+    testWidgets('activeColor reaches the box and holds in the disabled state', (
+      tester,
+    ) async {
+      await pumpRow(
+        tester,
+        multi<String>(
+          selected: {'a'},
+          checkboxTheme: const DropdownCheckboxTheme(
+            activeColor: Color(0xFF00AA88),
+          ),
+        ),
+      );
+
+      final fill = renderedBox(tester).fillColor;
+      expect(fill, isNotNull);
+      expect(
+        fill!.resolve({WidgetState.disabled, WidgetState.selected}),
+        const Color(0xFF00AA88),
+        reason: 'the state the presentational box is actually in',
+      );
+    });
+
+    testWidgets('checkColor, side and shape are handed to the box', (
+      tester,
+    ) async {
+      const side = BorderSide(color: Color(0xFFDDDDDD), width: 2);
+      const shape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(6)),
+      );
+      await pumpRow(
+        tester,
+        multi<String>(
+          selected: {'a'},
+          checkboxTheme: const DropdownCheckboxTheme(
+            checkColor: Color(0xFFFFFFFF),
+            side: side,
+            shape: shape,
+          ),
+        ),
+      );
+
+      final box = renderedBox(tester);
+      expect(box.checkColor, const Color(0xFFFFFFFF));
+      expect(box.side, side);
+      expect(box.shape, shape);
     });
   });
 

--- a/test/theme/dropdown_checkbox_theme_test.dart
+++ b/test/theme/dropdown_checkbox_theme_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The checklist checkbox is drawn with `onChanged: null`, so Flutter treats it
+/// as **disabled** and resolves its fill through the `disabled` state. A plain
+/// `activeColor` is dropped before it is ever read (`checkbox.dart:452`); only
+/// `fillColor` survives (`checkbox.dart:543`). So `resolve()` must turn a simple
+/// `activeColor` into a `fillColor` that answers for the selected state whether
+/// or not `disabled` is also present. These tests pin exactly that.
+void main() {
+  // The state sets Flutter's Checkbox actually asks `fillColor` about.
+  const selected = <WidgetState>{WidgetState.selected};
+  const disabledSelected = <WidgetState>{
+    WidgetState.disabled,
+    WidgetState.selected,
+  };
+  const unselected = <WidgetState>{};
+  const disabledUnselected = <WidgetState>{WidgetState.disabled};
+
+  group('resolve — empty theme leaves every slot to Flutter', () {
+    test('a default theme resolves every field to null', () {
+      final r = const DropdownCheckboxTheme().resolve();
+
+      expect(
+        r.fillColor,
+        isNull,
+        reason: 'null defers to ambient CheckboxTheme',
+      );
+      expect(r.checkColor, isNull);
+      expect(r.side, isNull);
+      expect(r.shape, isNull);
+      expect(r.materialTapTargetSize, isNull);
+      expect(r.visualDensity, isNull);
+    });
+  });
+
+  group(
+    'resolve — activeColor routes into fillColor and survives disabled',
+    () {
+      test('the checked box takes activeColor even while disabled', () {
+        final r = const DropdownCheckboxTheme(
+          activeColor: Color(0xFF00AA88),
+        ).resolve();
+
+        expect(r.fillColor, isNotNull);
+        expect(
+          r.fillColor!.resolve(selected),
+          const Color(0xFF00AA88),
+          reason: 'selected → the accent fills the box',
+        );
+        expect(
+          r.fillColor!.resolve(disabledSelected),
+          const Color(0xFF00AA88),
+          reason:
+              'the whole point: onChanged:null adds `disabled`, and the '
+              'accent must still win — a raw activeColor is dropped here',
+        );
+      });
+
+      test('the unchecked box keeps the ambient default fill', () {
+        final r = const DropdownCheckboxTheme(
+          activeColor: Color(0xFF00AA88),
+        ).resolve();
+
+        expect(r.fillColor!.resolve(unselected), isNull);
+        expect(r.fillColor!.resolve(disabledUnselected), isNull);
+      });
+    },
+  );
+
+  group('resolve — fillColor is the escape hatch and wins', () {
+    test('an explicit fillColor is used verbatim over activeColor', () {
+      final explicit = WidgetStateProperty.resolveWith<Color?>(
+        (states) => states.contains(WidgetState.selected)
+            ? const Color(0xFF112233)
+            : const Color(0xFF445566),
+      );
+      final r = DropdownCheckboxTheme(
+        activeColor: const Color(0xFF00AA88),
+        fillColor: explicit,
+      ).resolve();
+
+      expect(identical(r.fillColor, explicit), isTrue);
+      expect(r.fillColor!.resolve(selected), const Color(0xFF112233));
+      expect(r.fillColor!.resolve(unselected), const Color(0xFF445566));
+    });
+  });
+
+  group('resolve — the remaining fields pass straight through', () {
+    test('checkColor, side, shape, tapTarget, density and cursor pass', () {
+      const side = BorderSide(color: Color(0xFFDDDDDD), width: 2);
+      const shape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(6)),
+      );
+      final r = const DropdownCheckboxTheme(
+        checkColor: Color(0xFFFFFFFF),
+        side: side,
+        shape: shape,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: VisualDensity.compact,
+        mouseCursor: SystemMouseCursors.click,
+      ).resolve();
+
+      expect(r.checkColor, const Color(0xFFFFFFFF));
+      expect(r.side, side);
+      expect(r.shape, shape);
+      expect(r.materialTapTargetSize, MaterialTapTargetSize.shrinkWrap);
+      expect(r.visualDensity, VisualDensity.compact);
+      expect(r.mouseCursor, SystemMouseCursors.click);
+    });
+  });
+
+  group('copyWith', () {
+    const base = DropdownCheckboxTheme(
+      activeColor: Color(0xFF00AA88),
+      checkColor: Color(0xFF000000),
+    );
+
+    test('replaces the named field and keeps the rest', () {
+      final next = base.copyWith(checkColor: const Color(0xFFFFFFFF));
+
+      expect(next.activeColor, const Color(0xFF00AA88), reason: 'kept');
+      expect(next.checkColor, const Color(0xFFFFFFFF), reason: 'replaced');
+    });
+
+    test('an unnamed field falls back to the original', () {
+      // Exercises the fallback branch of every field: nothing is passed, so
+      // each `x ?? this.x` must take `this.x`.
+      const side = BorderSide(width: 3);
+      const shape = CircleBorder();
+      final full = base.copyWith(
+        activeColor: const Color(0xFF010101),
+        fillColor: WidgetStateProperty.all(const Color(0xFF020202)),
+        side: side,
+        shape: shape,
+        materialTapTargetSize: MaterialTapTargetSize.padded,
+        visualDensity: VisualDensity.standard,
+        mouseCursor: SystemMouseCursors.click,
+      );
+      final unchanged = full.copyWith();
+
+      expect(unchanged.activeColor, const Color(0xFF010101));
+      expect(unchanged.checkColor, const Color(0xFF000000));
+      expect(unchanged.fillColor, full.fillColor);
+      expect(unchanged.side, side);
+      expect(unchanged.shape, shape);
+      expect(unchanged.materialTapTargetSize, MaterialTapTargetSize.padded);
+      expect(unchanged.visualDensity, VisualDensity.standard);
+      expect(unchanged.mouseCursor, SystemMouseCursors.click);
+    });
+  });
+}


### PR DESCRIPTION
Closes #76.

## What

Adds `DropdownCheckboxTheme`, a fifth slot on `DropdownStyleTheme`, to style the
checkbox on each row of a `FlutterMultiSelectDropdown`. Additive and
non-breaking — one new optional field, nothing removed.

Before, the row's box was a bare `Checkbox(onChanged: null)`; the only way to
recolour it was an app-wide `CheckboxThemeData`, which restyles every checkbox in
the app. A `Theme` wrapped around the widget could not reach it — the menu is
drawn in the root `Overlay`, out of a local `Theme`'s subtree (pinned with a
throwaway probe: the box's resolved fill came back `null`). So this is mechanism
only the package can own; the colour values stay the caller's.

## The non-obvious part — `activeColor` is dropped for a disabled box

The box is deliberately `onChanged: null` (presentational — a tap falls through
to the row) with its semantics excluded. That puts it in Flutter's `disabled`
state, where `_widgetFillColor` returns null before it reads `activeColor`
(`checkbox.dart:452`). The theme resolves `activeColor` into `fillColor` — which
`Checkbox` consults first (`checkbox.dart:543`) — so the accent survives. The
tests assert the checked box's fill against the `{disabled, selected}` state it
is actually in, which a naive `activeColor` test would miss.

## Scope — 8 fields

`activeColor`, `fillColor`, `checkColor`, `side`, `shape`,
`materialTapTargetSize`, `visualDensity`, `mouseCursor`. These are exactly the
`Checkbox` params that render something on a non-interactive, semantics-excluded
box; the other 12 were verified dead against the real Flutter source. An
adversarial completeness pass caught one I had wrongly rejected — `mouseCursor`,
whose `MouseRegion` is installed regardless of interactivity — and it was added
(see the correction on #76).

## Also fixed

`documentation/theming.md` taught a checkbox `Theme(...)` wrapped around the
dropdown that silently did nothing (the overlay never saw it). Rewritten to lead
with `DropdownCheckboxTheme` and to state that only an app-wide `CheckboxThemeData`
reaches the box otherwise. Logged as a `FIX` in the changelog.

## Proof

- Pure `resolve()` unit tests, including the disabled-survives routing (RED
  verified: a naive resolver that drops the accent on `disabled` fails the test).
- Widget-seam tests: the rendered `Checkbox` carries every resolved slot; an
  unthemed row leaves them all null (no change to the default).
- End-to-end: a `DropdownStyleTheme(checkbox: …)` reaches the box drawn in the
  root overlay.
- `flutter analyze`, `example analyze`, `dart format`, 270 tests, **100% line
  coverage (1076/1076)** — all green. `pub publish --dry-run` clean apart from
  the expected uncommitted-changes note.

`pubspec.yaml` is bumped to 3.2.0 and the changelog opened, but `flutter pub
publish` is left for a maintainer to run.
