### PR TITLE
feat: anchorBuilder — bare anchor mode (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.3.0
+
+Additive. One new optional field on both widgets; nothing removed, nothing else changed.
+
+* **FEAT**: `anchorBuilder` — a **bare anchor** mode on `FlutterDropdownButton` (both constructors) and `FlutterMultiSelectDropdown`. Supplying `Widget Function(BuildContext, bool isOpen)` drops the entire button box — background, border, fixed width, padding, ink and trailing icon — and hangs the same anchored overlay off the widget you return. The point is to embed the dropdown *inside* another field, `[All ▾] │ search…`, where a button's own chrome nests a box inside a box; the only clean alternative was a hand-rolled `PopupMenuButton` that threw away this package's theming, keyboard navigation and searchable menu. Only the button face becomes the caller's — the menu is untouched
+* **FEAT**: the builder is handed `isOpen`, **not a label**. `isOpen` is the one thing a caller cannot read for itself, and drives an inline chevron (`AnimatedRotation(turns: isOpen ? 0.5 : 0.0, …)`); a label the caller already holds, in the `value` or `selected` it drew the anchor from. Passing one would leak a text-mode notion into `DropdownMenuShell`, which does not know what an item says — the invariant that lets one shell back both widgets. The dropped ink well's button role is restored with `Semantics(button: true)`
+* **FEAT**: the field lives on the shell and both public widgets read it, so bare mode composes with text mode, custom mode and the checklist alike — it is orthogonal to what an item renders as, and is a parameter rather than a `.bare()` constructor for exactly that reason. A constructor would have had to pick `itemBuilder` or `label`, leaving the other settable-but-dead — the shape 3.0.0 spent a major version deleting
+* **FEAT**: the button-box params `anchorBuilder` replaces — `width`, `minWidth`, `maxWidth`, `expand`, `trailing` — **assert** when combined with it, rather than being silently ignored. A settable-but-dead field is the smell this package audits for; the assert makes the conflict a debug-time error instead
+* **TEST**: 279 tests, up from 270, still at 100% line coverage (1090 lines). The bare path is asserted at the public seam — the caller's widget is the anchor, no ink well precedes the menu, tapping it opens the same overlay, `isOpen` flips, a disabled anchor stays shut, and the anchor is announced `isButton` — and each behaviour test was shown to fail with the shell's bare branch disabled
+
 ## 3.2.0
 
 Additive. One new optional field; nothing removed, nothing else changed.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A highly customizable dropdown package for Flutter with overlay-based rendering,
 - **Smooth Animations**: Scale and fade effects with configurable timing
 - **Outside-tap Dismissal**: Automatic closure when tapping outside
 - **Flexible Width**: Fixed, min/max constraints, content-based, or flex expansion
+- **Bare Anchor**: Drop the button chrome with `anchorBuilder` and embed the menu inside another field, `[All ▾] │ search…`
 - **Independent Menu Width**: Set menu width separately from button with alignment control
 - **Text Overflow Control**: Ellipsis, fade, clip, or visible overflow options
 - **Smart Tooltip**: Automatic tooltip on overflow with full customization
@@ -44,7 +45,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^3.2.0
+  flutter_dropdown_button: ^3.3.0
 ```
 
 Import the package:
@@ -221,6 +222,22 @@ The unified dropdown widget. Use the default constructor for custom widget rende
 | `searchable` | `bool` | `false` | Enable search/filter field in dropdown |
 | `searchFilter` | `bool Function(T, String)?` | `null` | Custom filter function (required for custom mode) |
 | `emptyBuilder` | `Widget Function(String)?` | `null` | Widget builder for empty search results |
+| `anchorBuilder` | `Widget Function(BuildContext, bool isOpen)?` | `null` | Draw the anchor yourself, dropping the button chrome (**bare** mode) — see below |
+
+#### Bare anchor
+
+Supply `anchorBuilder` to embed the dropdown inside another field — a field-scope
+selector at the head of a search box, `[All ▾] │ search…` — where the button's
+own background, border and fixed width would nest a box inside a box. It drops
+that whole button box and hangs the same anchored menu (theming, keyboard
+navigation, `searchable`, `itemBuilder`) off the widget you return.
+
+The builder is handed `isOpen`, the one thing it cannot read for itself, so an
+inline chevron can turn — `AnimatedRotation(turns: isOpen ? 0.5 : 0.0, …)`. It is
+not handed a label; build the face from the `value` (or `selected`) you hold.
+The button-box params it replaces — `width`, `minWidth`, `maxWidth`, `expand`,
+`trailing` — must be left unset, and combining them asserts. `FlutterMultiSelectDropdown`
+takes the same parameter.
 
 #### A value that is not in `items`
 

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -49,6 +49,21 @@ The button draws `value` whether or not `items` still offers it. A list refresh 
 
 Before 3.1.0, custom mode audited `value` against `items` and fell back to `hintWidget`; text mode never did, having no `items` to consult. The two now agree.
 
+### Bare anchor
+
+```dart
+Widget Function(BuildContext context, bool isOpen)? anchorBuilder
+```
+
+Supplying `anchorBuilder` puts the dropdown in **bare** mode: the button box is dropped — its background, border, fixed width, padding, ink and trailing icon — and the overlay hangs off the widget you return instead. The point is to embed the dropdown inside another field, `[All ▾] │ search…`, where a button's own chrome would nest a box inside a box.
+
+Only the button *face* becomes yours. The anchored menu — its theming, keyboard navigation, `searchable`, `itemBuilder`, the checklist — is unchanged. `FlutterMultiSelectDropdown` takes the same parameter.
+
+- **The builder is handed `isOpen`, not a label.** `isOpen` is the one thing you cannot read for yourself; a label you can, from the `value` (or `selected`) you already hold. Passing a label would leak a text-mode notion into a shell that does not know what an item says. Turn an inline chevron with `AnimatedRotation(turns: isOpen ? 0.5 : 0.0, …)`.
+- **`isOpen` flips true the moment the menu opens and false once it has finished closing** — the close animation runs while it is still true, so a chevron animated off it settles back after the menu is gone.
+- **The button-box params it replaces must be left unset.** `width`, `minWidth`, `maxWidth`, `expand` and `trailing` describe the box you no longer have; combining any with `anchorBuilder` asserts in debug.
+- **The anchor is still announced as a button.** The dropped ink well's role is restored with `Semantics(button: true)`, so a screen reader reads your widget as the control it is.
+
 ## FlutterMultiSelectDropdown\<T\>
 
 A checklist. Several items may be chosen, the menu stays open while they are, and `onChanged` fires the moment a box is ticked — no confirm button. Anchored rather than modal: no scrim, dismissed by an outside tap.

--- a/documentation/use_cases.md
+++ b/documentation/use_cases.md
@@ -466,3 +466,63 @@ beside the button, and the stale one has an exit.
 
 Filter semantics. OR versus AND, `contains` versus `∈`, how an empty set reads —
 all yours. The widget takes a `Set<T>` and gives back a `Set<T>`.
+
+## Field selector inside a search box — Bare anchor
+
+A control toolbar that collapses to one row: a search box with a field-scope
+selector at its head, `[All ▾] │ search…`. The scope must stay field-scoped, so
+it wants this package's anchored, searchable menu — but a full dropdown *button*
+in front of the field nests a box inside a box.
+
+`anchorBuilder` drops the button chrome and hands the anchor to you, so the same
+overlay hangs off a compact inline widget:
+
+```dart
+Row(
+  children: [
+    // The field-scope selector — no border, no background, no fixed width.
+    FlutterDropdownButton<String>.text(
+      items: const ['All', 'Title', 'Body', 'Author'],
+      value: field,
+      onChanged: (f) => setState(() => field = f!),
+      anchorBuilder: (context, isOpen) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(field),
+            AnimatedRotation(
+              turns: isOpen ? 0.5 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: const Icon(Icons.expand_more, size: 16),
+            ),
+          ],
+        ),
+      ),
+    ),
+    const SizedBox(
+      height: 20,
+      child: VerticalDivider(width: 1),
+    ),
+    // The search field fills the rest.
+    const Expanded(
+      child: TextField(
+        decoration: InputDecoration(
+          border: InputBorder.none,
+          hintText: 'Search…',
+        ),
+      ),
+    ),
+  ],
+)
+```
+
+The outer field owns the border and background; the selector contributes only
+its label and chevron. Everything the menu does — theming, keyboard navigation,
+`searchable`, `itemBuilder` — is untouched. `FlutterMultiSelectDropdown` takes
+the same `anchorBuilder` for a multi-scope selector.
+
+The chevron turns off `isOpen`, the one thing the builder cannot read for
+itself. Build the label from the `value` you already hold; the builder is not
+handed one. And drop `width`, `expand` and `trailing` — the button box they
+describe is gone, and combining them asserts.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'pages/playground_page.dart';
 import 'pages/bug_test_page.dart';
 import 'pages/domain_type_page.dart';
 import 'pages/multi_select_page.dart';
+import 'pages/bare_anchor_page.dart';
 import 'pages/result_page.dart';
 
 void main() {
@@ -26,6 +27,7 @@ class MyApp extends StatelessWidget {
         '/dropdown-bug-test': (context) => const DropdownBugTestPage(),
         '/domain-type': (context) => const DomainTypePage(),
         '/multi-select': (context) => const MultiSelectPage(),
+        '/bare-anchor': (context) => const BareAnchorPage(),
         '/result-page': (context) => const ResultPage(),
       },
     );

--- a/example/lib/pages/bare_anchor_page.dart
+++ b/example/lib/pages/bare_anchor_page.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+
+/// The case `anchorBuilder` was built for (#75): a search box with a
+/// field-scope selector at its head, `[All ▾] │ search…`. The selector wants
+/// this package's anchored, searchable menu, but a full dropdown *button* in
+/// front of the field would nest a box inside a box.
+///
+/// Bare mode drops the button chrome and hands the anchor to the caller, so the
+/// outer field owns the border and background and the selector contributes only
+/// its label and chevron. The chevron turns off `isOpen`, the one thing the
+/// builder cannot read for itself.
+class BareAnchorPage extends StatefulWidget {
+  const BareAnchorPage({super.key});
+
+  @override
+  State<BareAnchorPage> createState() => _BareAnchorPageState();
+}
+
+class _BareAnchorPageState extends State<BareAnchorPage> {
+  static const _fields = ['All', 'Title', 'Body', 'Author'];
+
+  String _field = 'All';
+  Set<String> _tags = {};
+  final _searchController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Bare anchor — inline in a field')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 460),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Single-select scope', style: theme.textTheme.labelLarge),
+                const SizedBox(height: 8),
+                _SearchField(
+                  // The scope selector — no border, no background, no width.
+                  scope: FlutterDropdownButton<String>.text(
+                    items: _fields,
+                    value: _field,
+                    onChanged: (f) => setState(() => _field = f!),
+                    anchorBuilder: (context, isOpen) =>
+                        _AnchorFace(label: _field, isOpen: isOpen),
+                  ),
+                  controller: _searchController,
+                ),
+                const SizedBox(height: 32),
+                Text('Multi-select scope', style: theme.textTheme.labelLarge),
+                const SizedBox(height: 8),
+                _SearchField(
+                  scope: FlutterMultiSelectDropdown<String>(
+                    items: const ['Title', 'Body', 'Author', 'Tags'],
+                    selected: _tags,
+                    onChanged: (next) => setState(() => _tags = next),
+                    labelBuilder: (s) => switch (s.length) {
+                      0 => 'All',
+                      1 => s.first,
+                      _ => '${s.length} fields',
+                    },
+                    anchorBuilder: (context, isOpen) => _AnchorFace(
+                      label: switch (_tags.length) {
+                        0 => 'All',
+                        1 => _tags.first,
+                        _ => '${_tags.length} fields',
+                      },
+                      isOpen: isOpen,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The caller-drawn anchor: a label and a chevron that turns while open. No box
+/// of its own — the surrounding field supplies the chrome.
+class _AnchorFace extends StatelessWidget {
+  const _AnchorFace({required this.label, required this.isOpen});
+
+  final String label;
+  final bool isOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          AnimatedRotation(
+            turns: isOpen ? 0.5 : 0.0,
+            duration: const Duration(milliseconds: 200),
+            child: const Icon(Icons.expand_more, size: 18),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The outer field that owns the border and background. The [scope] anchor sits
+/// at its head, then a divider, then the text field.
+class _SearchField extends StatelessWidget {
+  const _SearchField({required this.scope, this.controller});
+
+  final Widget scope;
+  final TextEditingController? controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.dividerColor),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          scope,
+          const SizedBox(height: 24, child: VerticalDivider(width: 1)),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              decoration: const InputDecoration(
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 12,
+                ),
+                hintText: 'Search…',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/playground_page.dart
+++ b/example/lib/pages/playground_page.dart
@@ -404,6 +404,11 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
             onPressed: () => Navigator.pushNamed(context, '/domain-type'),
           ),
           IconButton(
+            icon: const Icon(Icons.manage_search),
+            tooltip: 'Bare Anchor (inline in a field)',
+            onPressed: () => Navigator.pushNamed(context, '/bare-anchor'),
+          ),
+          IconButton(
             icon: const Icon(Icons.bug_report),
             tooltip: 'Overlay Bug Test',
             onPressed: () => Navigator.pushNamed(context, '/dropdown-bug-test'),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.0"
+    version: "3.3.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -81,6 +81,7 @@ class FlutterDropdownButton<T> extends StatefulWidget {
     this.searchable = false,
     this.searchFilter,
     this.emptyBuilder,
+    this.anchorBuilder,
   }) : hintText = null,
        label = null,
        config = null,
@@ -92,6 +93,18 @@ class FlutterDropdownButton<T> extends StatefulWidget {
              maxMenuWidth == null ||
              minMenuWidth <= maxMenuWidth,
          'minMenuWidth must be less than or equal to maxMenuWidth',
+       ),
+       assert(
+         anchorBuilder == null ||
+             (width == null &&
+                 minWidth == null &&
+                 maxWidth == null &&
+                 !expand &&
+                 trailing == null),
+         'anchorBuilder draws the whole anchor, so the button-box params it '
+         'replaces do not apply: drop width, minWidth, maxWidth, expand and '
+         'trailing when supplying one. Menu, scrollbar, search and tooltip '
+         'theming still take effect.',
        );
 
   /// Creates a text-only dropdown button.
@@ -132,6 +145,7 @@ class FlutterDropdownButton<T> extends StatefulWidget {
     this.searchable = false,
     this.searchFilter,
     this.emptyBuilder,
+    this.anchorBuilder,
   }) : hintText = hint,
        hintWidget = null,
        itemBuilder = null,
@@ -141,6 +155,18 @@ class FlutterDropdownButton<T> extends StatefulWidget {
              maxMenuWidth == null ||
              minMenuWidth <= maxMenuWidth,
          'minMenuWidth must be less than or equal to maxMenuWidth',
+       ),
+       assert(
+         anchorBuilder == null ||
+             (width == null &&
+                 minWidth == null &&
+                 maxWidth == null &&
+                 !expand &&
+                 trailing == null),
+         'anchorBuilder draws the whole anchor, so the button-box params it '
+         'replaces do not apply: drop width, minWidth, maxWidth, expand and '
+         'trailing when supplying one. Menu, scrollbar, search and tooltip '
+         'theming still take effect.',
        );
 
   /// The list of items available in this dropdown.
@@ -327,6 +353,42 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   /// ```
   final Widget Function(String query)? emptyBuilder;
 
+  /// Draws the anchor itself, dropping the button chrome (bare mode).
+  ///
+  /// Supply this to embed the dropdown inside another field — a field-scope
+  /// selector at the head of a search box, `[All ▾] │ search…` — where the
+  /// button's own background, border and fixed width would nest a box inside a
+  /// box. The widget you return becomes the whole anchor; the overlay (theme,
+  /// keyboard navigation, [searchable], the menu) still hangs off it exactly as
+  /// before. Only the button face is yours now.
+  ///
+  /// The builder is handed whether the menu is currently open — the one thing
+  /// it cannot read for itself — so an inline chevron can turn. It is not handed
+  /// a label: build the face from the [value] you already hold.
+  ///
+  /// ```dart
+  /// FlutterDropdownButton<String>.text(
+  ///   items: fields,
+  ///   value: field,
+  ///   onChanged: onField,
+  ///   anchorBuilder: (context, isOpen) => Row(
+  ///     mainAxisSize: MainAxisSize.min,
+  ///     children: [
+  ///       Text(field),
+  ///       AnimatedRotation(
+  ///         turns: isOpen ? 0.5 : 0.0,
+  ///         duration: const Duration(milliseconds: 200),
+  ///         child: const Icon(Icons.expand_more, size: 16),
+  ///       ),
+  ///     ],
+  ///   ),
+  /// )
+  /// ```
+  ///
+  /// The button-box params it replaces — [width], [minWidth], [maxWidth],
+  /// [expand] and [trailing] — must be left unset; combining them asserts.
+  final Widget Function(BuildContext context, bool isOpen)? anchorBuilder;
+
   /// Whether this dropdown was built by [FlutterDropdownButton.text].
   ///
   /// Informational. Nothing inside the widget branches on this: rendering is
@@ -477,6 +539,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>> {
       searchable: widget.searchable,
       searchFilter: widget.searchFilter,
       emptyBuilder: widget.emptyBuilder,
+      anchorBuilder: widget.anchorBuilder,
     );
   }
 }

--- a/lib/src/flutter_multi_select_dropdown.dart
+++ b/lib/src/flutter_multi_select_dropdown.dart
@@ -70,7 +70,19 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
     this.searchable = false,
     this.searchFilter,
     this.emptyBuilder,
-  });
+    this.anchorBuilder,
+  }) : assert(
+         anchorBuilder == null ||
+             (width == null &&
+                 minWidth == null &&
+                 maxWidth == null &&
+                 !expand &&
+                 trailing == null),
+         'anchorBuilder draws the whole anchor, so the button-box params it '
+         'replaces do not apply: drop width, minWidth, maxWidth, expand and '
+         'trailing when supplying one. Menu, scrollbar, search and tooltip '
+         'theming still take effect.',
+       );
 
   /// The items the menu offers.
   final List<T> items;
@@ -161,6 +173,37 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
   /// Drawn when a query matches nothing.
   final Widget Function(String query)? emptyBuilder;
 
+  /// Draws the anchor itself, dropping the button chrome (bare mode).
+  ///
+  /// Supply this to embed the checklist inside another field, where the
+  /// button's own background, border and fixed width would nest a box inside a
+  /// box. The widget you return becomes the whole anchor; the menu (theme,
+  /// keyboard navigation, [searchable], the checklist) still hangs off it. Only
+  /// the button face is yours now — build it from [labelBuilder] and the
+  /// [selected] set you already hold.
+  ///
+  /// The builder is handed whether the menu is currently open, so an inline
+  /// chevron can turn. The button-box params it replaces — [width], [minWidth],
+  /// [maxWidth], [expand] and [trailing] — must be left unset; combining them
+  /// asserts.
+  ///
+  /// ```dart
+  /// FlutterMultiSelectDropdown<String>(
+  ///   items: fields,
+  ///   selected: chosen,
+  ///   onChanged: onChanged,
+  ///   labelBuilder: (s) => s.isEmpty ? 'All' : '${s.length}',
+  ///   anchorBuilder: (context, isOpen) => Row(
+  ///     mainAxisSize: MainAxisSize.min,
+  ///     children: [
+  ///       Text(chosen.isEmpty ? 'All' : '${chosen.length}'),
+  ///       const Icon(Icons.expand_more, size: 16),
+  ///     ],
+  ///   ),
+  /// )
+  /// ```
+  final Widget Function(BuildContext context, bool isOpen)? anchorBuilder;
+
   /// Closes every open dropdown overlay, of either kind.
   ///
   /// Single-open coordination lives in a registry keyed by `Overlay`, so this
@@ -215,6 +258,7 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
       searchable: searchable,
       searchFilter: searchFilter,
       emptyBuilder: emptyBuilder,
+      anchorBuilder: anchorBuilder,
     );
   }
 }

--- a/lib/src/shell/dropdown_menu_shell.dart
+++ b/lib/src/shell/dropdown_menu_shell.dart
@@ -45,6 +45,7 @@ class DropdownMenuShell<T> extends StatefulWidget {
     this.emptyBuilder,
     this.theme,
     this.trailing,
+    this.anchorBuilder,
     this.width,
     this.minWidth,
     this.maxWidth,
@@ -115,6 +116,21 @@ class DropdownMenuShell<T> extends StatefulWidget {
 
   /// Replaces the trailing icon.
   final Widget? trailing;
+
+  /// Draws the anchor itself, in place of the button.
+  ///
+  /// Non-null puts the shell in **bare** mode: it drops the whole button box —
+  /// the background, border, fixed width, padding, ink and trailing icon — and
+  /// hangs the overlay off the widget this returns instead. The caller owns
+  /// what the anchor looks like; the shell owns only the key the overlay
+  /// measures against and the gesture that toggles the menu.
+  ///
+  /// It is handed whether the menu is showing (`isOpen`), the one thing the
+  /// caller cannot read for itself, so an inline chevron can turn. It is **not**
+  /// handed a label: the shell does not know what an item says, and the caller
+  /// already holds the selection it would draw. Menu, scrollbar, search and
+  /// tooltip theming still apply — only the button face is the caller's now.
+  final Widget Function(BuildContext context, bool isOpen)? anchorBuilder;
 
   /// A fixed button width.
   final double? width;
@@ -312,6 +328,9 @@ class _DropdownMenuShellState<T> extends State<DropdownMenuShell<T>>
 
   @override
   Widget build(BuildContext context) {
+    final anchorBuilder = widget.anchorBuilder;
+    if (anchorBuilder != null) return _buildBareAnchor(context, anchorBuilder);
+
     final style = _buttonStyle;
 
     Widget button = Container(
@@ -338,6 +357,32 @@ class _DropdownMenuShellState<T> extends State<DropdownMenuShell<T>>
     );
 
     return _applyWidthConstraints(button);
+  }
+
+  /// The anchor when the caller draws it themselves.
+  ///
+  /// No chrome: no `decoration`, no `width`, no `padding`, no ink, no trailing
+  /// icon — the button-box params the widgets assert away in this mode. The
+  /// only things the shell must still own wrap the caller's widget: the
+  /// [DropdownOverlayController.buttonKey] the overlay measures to place the
+  /// menu, and the tap that toggles it. `Semantics(button: …)` restores the
+  /// role the dropped `InkWell` would have announced; the key rides on it
+  /// because a `Semantics` is a render box that takes its child's size, which
+  /// is what [DropdownOverlayController.measurePlacement] reads.
+  Widget _buildBareAnchor(
+    BuildContext context,
+    Widget Function(BuildContext context, bool isOpen) anchorBuilder,
+  ) {
+    return Semantics(
+      key: _menu.buttonKey,
+      button: true,
+      enabled: widget.enabled,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.enabled ? _toggleDropdown : null,
+        child: anchorBuilder(context, _menu.isOpen),
+      ),
+    );
   }
 
   Widget _buildButtonContent(ResolvedButtonStyle style) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 3.2.0
+version: 3.3.0
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues

--- a/test/bare_anchor_test.dart
+++ b/test/bare_anchor_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Bare anchor mode (#75): the caller draws the anchor, the shell drops the
+/// button box and hangs the overlay off the caller's widget instead.
+
+Widget host(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  group('single-select bare anchor', () {
+    testWidgets('draws the caller widget and opens the menu on tap', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana', 'Cherry'],
+            value: 'Apple',
+            onChanged: (_) {},
+            anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+          ),
+        ),
+      );
+
+      // The caller's widget is the anchor.
+      expect(find.text('BARE-ANCHOR'), findsOneWidget);
+      // The menu is closed, and with no button box there is no ink well yet.
+      expect(find.byType(InkWell), findsNothing);
+
+      await tester.tap(find.text('BARE-ANCHOR'));
+      await tester.pumpAndSettle();
+
+      // Tapping the bare anchor opened the same anchored menu.
+      expect(find.text('Banana'), findsOneWidget);
+    });
+
+    testWidgets('no button chrome: the anchor has no decorated box', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana'],
+            value: 'Apple',
+            onChanged: (_) {},
+            anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+          ),
+        ),
+      );
+
+      // The normal button wraps its face in a Container carrying a
+      // BoxDecoration; the bare anchor must not. Nothing between the anchor's
+      // text and the app scaffold paints a decoration of its own.
+      final decorated = find.ancestor(
+        of: find.text('BARE-ANCHOR'),
+        matching: find.byWidgetPredicate(
+          (w) => w is Container && w.decoration != null,
+        ),
+      );
+      expect(decorated, findsNothing);
+    });
+
+    testWidgets('hands the builder whether the menu is open', (tester) async {
+      final seen = <bool>[];
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana'],
+            value: 'Apple',
+            onChanged: (_) {},
+            anchorBuilder: (context, isOpen) {
+              seen.add(isOpen);
+              return const Text('BARE-ANCHOR');
+            },
+          ),
+        ),
+      );
+
+      expect(seen.last, isFalse, reason: 'starts closed');
+
+      await tester.tap(find.text('BARE-ANCHOR'));
+      await tester.pumpAndSettle();
+      expect(seen.last, isTrue, reason: 'open flips it true');
+
+      await tester.tap(find.text('Banana'));
+      await tester.pumpAndSettle();
+      expect(seen.last, isFalse, reason: 'a selection closes it again');
+    });
+
+    testWidgets('a disabled bare anchor does not open', (tester) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana'],
+            value: 'Apple',
+            enabled: false,
+            onChanged: (_) {},
+            anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('BARE-ANCHOR'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Banana'), findsNothing);
+    });
+
+    testWidgets('the anchor is announced as a button', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana'],
+            value: 'Apple',
+            onChanged: (_) {},
+            anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.text('BARE-ANCHOR')),
+        matchesSemantics(
+          label: 'BARE-ANCHOR',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          hasTapAction: true,
+        ),
+      );
+      handle.dispose();
+    });
+
+    testWidgets('combining a button-box param with anchorBuilder asserts', (
+      tester,
+    ) async {
+      expect(
+        () => FlutterDropdownButton<String>.text(
+          items: const ['Apple'],
+          onChanged: (_) {},
+          width: 200,
+          anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    testWidgets('bare mode composes with the default (custom) constructor', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>(
+            items: const ['Apple', 'Banana'],
+            value: 'Apple',
+            itemBuilder: (item, isSelected) => Text(item),
+            onChanged: (_) {},
+            anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('BARE-ANCHOR'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Banana'), findsOneWidget);
+    });
+  });
+
+  group('multi-select bare anchor', () {
+    testWidgets('draws the caller widget and opens the checklist on tap', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          FlutterMultiSelectDropdown<String>(
+            items: const ['Apple', 'Banana', 'Cherry'],
+            selected: const {'Apple'},
+            onChanged: (_) {},
+            labelBuilder: (s) => s.isEmpty ? 'All' : '${s.length}',
+            anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+          ),
+        ),
+      );
+
+      expect(find.byType(Checkbox), findsNothing);
+
+      await tester.tap(find.text('BARE-ANCHOR'));
+      await tester.pumpAndSettle();
+
+      // The checklist opened: a box per row.
+      expect(find.byType(Checkbox), findsNWidgets(3));
+    });
+
+    testWidgets('combining a button-box param with anchorBuilder asserts', (
+      tester,
+    ) async {
+      expect(
+        () => FlutterMultiSelectDropdown<String>(
+          items: const ['Apple'],
+          selected: const {},
+          onChanged: (_) {},
+          labelBuilder: (s) => 'All',
+          expand: true,
+          anchorBuilder: (context, isOpen) => const Text('BARE-ANCHOR'),
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #75.

## What

Adds a **bare anchor** mode via a new optional `anchorBuilder` on both
`FlutterDropdownButton` (both constructors) and `FlutterMultiSelectDropdown`.
Supplying `Widget Function(BuildContext, bool isOpen)` drops the entire button
box — background, border, fixed width, padding, ink and trailing icon — and
hangs the same anchored overlay off the widget the caller returns. This lets the
dropdown live *inside* another field, `[All ▾] │ search…`, without nesting a box
inside a box.

## Design decisions

- **A parameter, not a `.bare()` constructor.** Bare mode is orthogonal to what
  an item renders as (text / custom / checklist), so it lives on the shell and
  every widget reads it. A constructor would have had to pick `itemBuilder` or
  `label` and leave the other settable-but-dead — the shape 3.0.0 spent a major
  version deleting.
- **The builder is handed `isOpen`, not a label.** `isOpen` is the one thing a
  caller cannot read for itself (drives an inline chevron); a label it already
  holds, in the `value`/`selected` it drew the anchor from. Passing a label
  would leak a text-mode notion into `DropdownMenuShell`, which knows nothing of
  what an item says — the invariant that lets one shell back both widgets.
- **The button-box params it replaces assert.** `width`, `minWidth`, `maxWidth`,
  `expand`, `trailing` are a debug-time error when combined with `anchorBuilder`,
  rather than silently ignored.
- **The anchor is still a button.** The dropped ink well's role is restored with
  `Semantics(button: true)`.

## Verification

- 279 tests (up from 270), **100% line coverage** (1090 lines).
- Each bare behaviour test was shown to fail with the shell's bare branch
  disabled (discrimination check).
- `flutter analyze` (package + example) clean; `dart format` clean;
  `pub publish --dry-run` clean bar the uncommitted-git warning.
- Docs swept: README (feature bullet, param table, bare section), api_reference,
  use_cases, CHANGELOG; a runnable `/bare-anchor` example page added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
