### PR TITLE
fix: bare-anchor example needs minMenuWidth (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ The button-box params it replaces — `width`, `minWidth`, `maxWidth`, `expand`,
 `trailing` — must be left unset, and combining them asserts. `FlutterMultiSelectDropdown`
 takes the same parameter.
 
+Because the anchor is compact, the menu — which takes its width from the anchor —
+would be compact too. Set **`minMenuWidth`** to give the menu a usable width; it
+is a *menu* width, not the button-box `width`, so it is allowed in bare mode.
+
 #### A value that is not in `items`
 
 A list refresh can drop the row a `value` names while `value` still names it.

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -62,6 +62,7 @@ Only the button *face* becomes yours. The anchored menu — its theming, keyboar
 - **The builder is handed `isOpen`, not a label.** `isOpen` is the one thing you cannot read for yourself; a label you can, from the `value` (or `selected`) you already hold. Passing a label would leak a text-mode notion into a shell that does not know what an item says. Turn an inline chevron with `AnimatedRotation(turns: isOpen ? 0.5 : 0.0, …)`.
 - **`isOpen` flips true the moment the menu opens and false once it has finished closing** — the close animation runs while it is still true, so a chevron animated off it settles back after the menu is gone.
 - **The button-box params it replaces must be left unset.** `width`, `minWidth`, `maxWidth`, `expand` and `trailing` describe the box you no longer have; combining any with `anchorBuilder` asserts in debug.
+- **Set `minMenuWidth` — the menu inherits the anchor's width.** A bare anchor is compact by design, and the menu takes its width from it, so an `[All ▾]` anchor yields an `[All ▾]`-wide menu its rows overflow. `minMenuWidth` (and `maxMenuWidth`) are *menu* widths, not the button-box `width`/`minWidth`/`maxWidth`, so they are allowed in bare mode and are the way to give the menu a usable width of its own.
 - **The anchor is still announced as a button.** The dropped ink well's role is restored with `Semantics(button: true)`, so a screen reader reads your widget as the control it is.
 
 ## FlutterMultiSelectDropdown\<T\>

--- a/documentation/use_cases.md
+++ b/documentation/use_cases.md
@@ -485,6 +485,10 @@ Row(
       items: const ['All', 'Title', 'Body', 'Author'],
       value: field,
       onChanged: (f) => setState(() => field = f!),
+      // The menu takes its width from the anchor, and a bare anchor is tiny;
+      // minMenuWidth gives the menu a usable width. It is a menu width, not the
+      // forbidden button-box width, so it is allowed here.
+      minMenuWidth: 200,
       anchorBuilder: (context, isOpen) => Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
@@ -526,3 +530,10 @@ The chevron turns off `isOpen`, the one thing the builder cannot read for
 itself. Build the label from the `value` you already hold; the builder is not
 handed one. And drop `width`, `expand` and `trailing` — the button box they
 describe is gone, and combining them asserts.
+
+Note the `minMenuWidth`. The menu takes its width from the anchor, and a bare
+anchor is compact on purpose, so without it the menu would be as narrow as
+`[All ▾]` and its rows — a checkbox and a label, in the multi-select case —
+would overflow. `minMenuWidth` and `maxMenuWidth` are *menu* widths, distinct
+from the button-box `width`/`minWidth`/`maxWidth` bare mode forbids, so they are
+the lever that sizes a bare menu.

--- a/example/lib/pages/bare_anchor_page.dart
+++ b/example/lib/pages/bare_anchor_page.dart
@@ -53,6 +53,11 @@ class _BareAnchorPageState extends State<BareAnchorPage> {
                     items: _fields,
                     value: _field,
                     onChanged: (f) => setState(() => _field = f!),
+                    // The anchor is tiny by design, and the menu takes its
+                    // width from the anchor. `minMenuWidth` gives the menu a
+                    // usable width of its own — it is a *menu* width, so it is
+                    // allowed in bare mode where the button-box `width` is not.
+                    minMenuWidth: 200,
                     anchorBuilder: (context, isOpen) =>
                         _AnchorFace(label: _field, isOpen: isOpen),
                   ),
@@ -66,6 +71,10 @@ class _BareAnchorPageState extends State<BareAnchorPage> {
                     items: const ['Title', 'Body', 'Author', 'Tags'],
                     selected: _tags,
                     onChanged: (next) => setState(() => _tags = next),
+                    // Without this the checklist rows would collapse to the
+                    // tiny anchor's width and overflow. See the single-select
+                    // note above.
+                    minMenuWidth: 200,
                     labelBuilder: (s) => switch (s.length) {
                       0 => 'All',
                       1 => s.first,

--- a/test/bare_anchor_test.dart
+++ b/test/bare_anchor_test.dart
@@ -90,6 +90,41 @@ void main() {
       expect(seen.last, isFalse, reason: 'a selection closes it again');
     });
 
+    testWidgets('minMenuWidth widens the menu past the compact anchor', (
+      tester,
+    ) async {
+      // The menu takes its width from the anchor, and a bare anchor is tiny by
+      // design; minMenuWidth is a menu width (allowed in bare mode) that gives
+      // the menu a usable width of its own. This is the lever that keeps a
+      // checklist's rows from overflowing under an `[All ▾]`-wide anchor.
+      await tester.pumpWidget(
+        host(
+          FlutterDropdownButton<String>.text(
+            items: List<String>.generate(12, (i) => 'Item $i'),
+            value: 'Item 0',
+            onChanged: (_) {},
+            minMenuWidth: 200,
+            anchorBuilder: (context, isOpen) => const Text('All'),
+          ),
+        ),
+      );
+
+      final anchorWidth = tester.getSize(find.text('All')).width;
+      expect(anchorWidth, lessThan(120), reason: 'the anchor is compact');
+
+      await tester.tap(find.text('All'));
+      await tester.pumpAndSettle();
+
+      // A long list lays out in a ListView, whose width is the menu's.
+      final menuWidth = tester.getSize(find.byType(ListView)).width;
+      expect(menuWidth, greaterThan(150));
+      expect(
+        menuWidth,
+        lessThan(205),
+        reason: 'driven by minMenuWidth, not the screen',
+      );
+    });
+
     testWidgets('a disabled bare anchor does not open', (tester) async {
       await tester.pumpWidget(
         host(


### PR DESCRIPTION
Follows up #78 (bare anchor, #75) with a fix to the shipped example.

## Problem

The multi-select bare-anchor example opened a menu collapsed to the tiny
`[All ▾]` anchor's width — checkboxes stacked in a sliver, `RIGHT OVERFLOWED BY
15 PIXELS`. The menu takes its width from the anchor (`_resolveWidth` starts from
`buttonSize.width`), and a bare anchor is compact by design, so a compact anchor
yields a compact menu.

## Fix

Not a code bug — the package sizes correctly. The example just needed
`minMenuWidth`, which is a **menu** width (allowed in bare mode) as opposed to
the button-box `width`/`minWidth`/`maxWidth` bare mode forbids. Added it to both
dropdowns on the example page, and documented the gotcha — bare anchors almost
always want `minMenuWidth` — in the README, api_reference and use_cases bare
sections.

Added a guard test: a bare menu under a compact anchor honours `minMenuWidth`
(widens past the ~40px anchor to ~200px). The 150px threshold sits well above
any anchor-width menu, so the test fails if `minMenuWidth` stops taking effect.

## Verification

- 280 tests, 100% line coverage (1090 lines).
- `flutter analyze` (package + example) clean; `dart format` clean.
- No `lib/` change — example, docs and one test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
