### PR TITLE
feat: multi-select checkbox via flutter_checkbox; redesign DropdownCheckboxTheme (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,24 @@
 # Changelog
 
-## 3.3.0
+## 4.0.0
 
-Additive. One new optional field on both widgets; nothing removed, nothing else changed.
+Breaking. The multi-select checklist now draws its boxes with the [`flutter_checkbox`](https://pub.dev/packages/flutter_checkbox) package instead of Flutter's built-in `Checkbox`, and `DropdownCheckboxTheme` is redesigned around it — several Material-only fields are removed. The **SDK floor is unchanged** (`>=3.32.0`): `flutter_checkbox` `0.3.1` needs only Flutter 3.27. This release also folds in the bare-anchor feature, which was never published on its own.
+
+### Multi-select checkbox → `flutter_checkbox`
+
+* **BREAKING**: `DropdownCheckboxTheme` is rebuilt around `flutter_checkbox`'s `CheckboxStyle`. **Removed** — the Material-`Checkbox` concepts the new box has no equivalent for: `fillColor` (`WidgetStateProperty`), `side` (`BorderSide`), `shape` (`OutlinedBorder`), `materialTapTargetSize`, `visualDensity`. **Kept**: `activeColor`, `checkColor`, `mouseCursor`. **Added**: `inactiveColor`, `borderColor`, `borderWidth`, `borderRadius`, `size`, `checkStrokeWidth`, `checkScale`, and `shape` now typed `CheckboxShape` (an enum: `rectangle` / `circle`). `resolve()` now returns a `CheckboxStyle`, and the `ResolvedCheckboxStyle` class is removed. Migration map in `documentation/migration.md`
+* **FEAT**: the box is a `FlutterCheckbox`, drawn `onChanged: null` but left `enabled: true` — presentational (a tap falls through to the row) **without** being greyed. This deletes the `activeColor` → `fillColor` workaround 3.2.0 needed: Material forced an `onChanged: null` box into its disabled state and dropped a plain `activeColor`; `FlutterCheckbox` does not, so the accent is read straight (`CheckboxStyle.activeColor`)
+* **FEAT**: `CheckboxShape` and `CheckboxStyle` are re-exported from the package barrel, so `DropdownCheckboxTheme(shape: CheckboxShape.circle)` needs no extra import
+* **CHANGE**: the box's semantics are still excluded and the row still carries `checked`. Unlike Material, `FlutterCheckbox(onChanged: null)` announces `enabled: true` — so the row no longer risks a *dimmed* announcement leaking from the box — but the box still emits its own `checked` node, which the exclusion drops to keep the row the single source of the checked state
+* **MIGRATION**: `side` → `borderColor` + `borderWidth`; `shape: RoundedRectangleBorder(borderRadius: …)` → `shape: CheckboxShape.rectangle` + `borderRadius`; `fillColor` → `activeColor` (checked) / `inactiveColor` (unchecked). `materialTapTargetSize` and `visualDensity` have no equivalent — the box sizes via `size`
+* **TEST**: 280 tests at 100% line coverage (1085 lines). The box is asserted presentational-but-not-greyed (`onChanged` null, `enabled` true), the accent reaches `style.activeColor` directly, and the semantics contract (row `checked`, never *disabled*) is held at the semantics tree
+
+### Bare anchor (folds in the unreleased 3.3.0)
 
 * **FEAT**: `anchorBuilder` — a **bare anchor** mode on `FlutterDropdownButton` (both constructors) and `FlutterMultiSelectDropdown`. Supplying `Widget Function(BuildContext, bool isOpen)` drops the entire button box — background, border, fixed width, padding, ink and trailing icon — and hangs the same anchored overlay off the widget you return. The point is to embed the dropdown *inside* another field, `[All ▾] │ search…`, where a button's own chrome nests a box inside a box; the only clean alternative was a hand-rolled `PopupMenuButton` that threw away this package's theming, keyboard navigation and searchable menu. Only the button face becomes the caller's — the menu is untouched
 * **FEAT**: the builder is handed `isOpen`, **not a label**. `isOpen` is the one thing a caller cannot read for itself, and drives an inline chevron (`AnimatedRotation(turns: isOpen ? 0.5 : 0.0, …)`); a label the caller already holds, in the `value` or `selected` it drew the anchor from. Passing one would leak a text-mode notion into `DropdownMenuShell`, which does not know what an item says — the invariant that lets one shell back both widgets. The dropped ink well's button role is restored with `Semantics(button: true)`
 * **FEAT**: the field lives on the shell and both public widgets read it, so bare mode composes with text mode, custom mode and the checklist alike — it is orthogonal to what an item renders as, and is a parameter rather than a `.bare()` constructor for exactly that reason. A constructor would have had to pick `itemBuilder` or `label`, leaving the other settable-but-dead — the shape 3.0.0 spent a major version deleting
-* **FEAT**: the button-box params `anchorBuilder` replaces — `width`, `minWidth`, `maxWidth`, `expand`, `trailing` — **assert** when combined with it, rather than being silently ignored. A settable-but-dead field is the smell this package audits for; the assert makes the conflict a debug-time error instead
-* **TEST**: 279 tests, up from 270, still at 100% line coverage (1090 lines). The bare path is asserted at the public seam — the caller's widget is the anchor, no ink well precedes the menu, tapping it opens the same overlay, `isOpen` flips, a disabled anchor stays shut, and the anchor is announced `isButton` — and each behaviour test was shown to fail with the shell's bare branch disabled
+* **FEAT**: the button-box params `anchorBuilder` replaces — `width`, `minWidth`, `maxWidth`, `expand`, `trailing` — **assert** when combined with it, rather than being silently ignored. A bare anchor is compact by design and the menu takes its width from it, so set `minMenuWidth` (a *menu* width, still allowed) to give the menu a usable width
 
 ## 3.2.0
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^3.3.0
+  flutter_dropdown_button: ^4.0.0
 ```
 
 Import the package:
@@ -479,20 +479,23 @@ Controls the appearance and behavior of the search text field when `searchable` 
 
 ### DropdownCheckboxTheme
 
-Styles the checkbox on each row of a `FlutterMultiSelectDropdown`. Reaches the box even though the menu is drawn in the root overlay, where a `Theme` wrapped around the widget cannot — only an app-wide `CheckboxThemeData` otherwise could, and that restyles every checkbox in the app. Only the fields that render on the presentational (`onChanged: null`, semantics-excluded) box are here.
+Styles the checkbox on each row of a `FlutterMultiSelectDropdown`. The box is a `FlutterCheckbox` (the [`flutter_checkbox`](https://pub.dev/packages/flutter_checkbox) package), reached even though the menu is drawn in the root overlay where a `Theme` wrapped around the widget cannot. Only the fields that render on the presentational (`onChanged: null`, semantics-excluded) box are here.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `activeColor` | `Color?` | `null` | Fill of a **checked** box. Routed through `fillColor` so it survives the box's disabled state |
-| `fillColor` | `WidgetStateProperty<Color?>?` | `null` | Per-state fill, for full control. Wins over `activeColor` |
+| `activeColor` | `Color?` | `null` | Fill of a **checked** box |
 | `checkColor` | `Color?` | `null` | Color of the checkmark |
-| `side` | `BorderSide?` | `null` | Outline of an **unchecked** box (a checked box's fill covers it) |
-| `shape` | `OutlinedBorder?` | `null` | Box shape, e.g. rounded corners |
-| `materialTapTargetSize` | `MaterialTapTargetSize?` | `null` | Size class the box occupies |
-| `visualDensity` | `VisualDensity?` | `null` | Density adjustment to the box's size |
+| `inactiveColor` | `Color?` | `null` | Fill of an **unchecked** box |
+| `borderColor` | `Color?` | `null` | Outline of an **unchecked** box (a checked box's fill covers it) |
+| `borderWidth` | `double?` | `null` (`2`) | Width of the unchecked outline |
+| `shape` | `CheckboxShape?` | `null` (`rectangle`) | `CheckboxShape.rectangle` or `.circle` |
+| `borderRadius` | `double?` | `null` (`4`) | Corner radius of a rectangle box |
+| `size` | `double?` | `null` (`24`) | Box size in logical pixels |
+| `checkStrokeWidth` | `double?` | `null` (`2.5`) | Checkmark stroke width |
+| `checkScale` | `double?` | `null` (`1.0`) | Checkmark size within the box |
 | `mouseCursor` | `MouseCursor?` | `null` | Cursor over the box. Set to `SystemMouseCursors.click` to match the row's |
 
-Each null field defers to the ambient `CheckboxThemeData`.
+A null colour defers to the ambient `ThemeData`; a null number keeps `CheckboxStyle`'s default (in parentheses). `CheckboxShape` is exported from this package.
 
 ### TextDropdownConfig
 

--- a/docs/agents/lessons.md
+++ b/docs/agents/lessons.md
@@ -40,6 +40,13 @@
   전달됐지만 `hasCustomWidths` 를 먹였고, 그게 **non-null `thickness`** 분기를 열었다.
   `trackWidth` 만 설정한 테마는 hover 두께가 *우연히* 못박혀 있었고 제거가 그걸 풀었다.
   삭제 전 **모든 read site 를 grep** 한다 — 불리언 하나 계산하는 곳까지.
+- **#80/#81 (상류 pubspec 은 버전마다 실측).** flutter_checkbox 도입 시 0.3.0 pubspec 이
+  `sdk ^3.9.2 / flutter >=3.35.0` 를 선언해 "우리 바닥을 3.35 로 올려야 한다"는 슬라이스
+  (#80)를 만들었다. 그러나 사용자가 지정한 **0.3.1** 은 실제 사용 API(`Color.withValues`,
+  3.27)에 맞춰 `>=3.27.0` 으로 바닥을 도로 넓혔고 — 0.3.0 은 *빌드된 SDK* 를 바닥으로 박은
+  과선언이었다. 현재 바닥(3.32)이 이미 충족해 **바닥 상승은 통째로 불필요**, #80 을 닫았다.
+  버전을 지정받으면 *그 버전* 의 `environment` 를 직접 연다 — 다른 버전의 숫자를 재사용 금지
+  (#47 의 거울: 이번엔 상류가 자기 바닥을 *낮췄다*).
 
 ## Step 2 — 경계 규칙
 
@@ -88,6 +95,14 @@
   더하고 있음을 찾았다 — 2.3.2·2.5.0 에서 두 번 터진 그 버그의 원인. 두 에이전트가
   `semanticsLabel` 비대칭을 두고 다르게 말했고 **둘 다 맞았다**(비대칭은 실재하나 그
   리팩터가 만든 게 아님) — 렌즈를 나누는 이유.
+- **#81 (상류 위젯의 semantics 는 Material 과 다르다).** 체크박스를 `FlutterCheckbox` 로
+  바꾼 뒤 판별력 검증(`ExcludeSemantics` 제거)에서 "행은 disabled 를 알리지 않는다" 테스트가
+  **여전히 초록**이었다. 원인: `FlutterCheckbox(onChanged: null)` 은 `enabled: true` 를
+  emit 한다(Material 의 `onChanged: null` 은 `false`). 그래서 그 테스트는 새 구현에선
+  판별력을 잃었다. 그럼에도 `ExcludeSemantics` 는 **유지** — 박스가 자기 `checked` 노드를
+  emit 하므로 배제하지 않으면 행의 `Semantics(checked:)` 와 중복되고, flutter_checkbox 는
+  0.x 라 semantics 가 바뀔 수 있다. 상류 위젯을 갈아끼우면 그 semantics 를 소스
+  (`checkbox_interaction.dart`)로 확인한다 — 렌더 결과만 보면 놓친다(#37).
 
 ## Step 6 — 정합성 스윕
 

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -93,7 +93,7 @@ Text mode only. An item that needs more than text — an avatar, two lines — i
 - **`T` needs `==` and `hashCode`.** `selected.contains(item)` uses both, where single-select's `value == item` used only the first. A `T` with a hand-written `==` and the default `hashCode` will let a `Set` hold duplicates that look identical.
 - **A chosen value absent from `items`** still counts towards `labelBuilder`, and draws no row. `'3 selected'` can appear beside two ticked boxes after a refresh drops the third. Offer a way to clear it.
 - **The query survives a tick.** Only opening and closing the menu reset it.
-- **Rows announce their checked state.** The box is drawn but excluded from the semantics tree; the row carries `checked` instead. A live `Checkbox` inside the row's ink well would announce every row as *disabled*.
+- **Rows announce their checked state.** The box (a `FlutterCheckbox`) is drawn but excluded from the semantics tree; the row carries `checked` instead, so the row is the single interactive node a screen reader sees.
 - **A trailing widget's text is merged into the row's announced label.** The ink well merges its descendants, so `itemTrailingBuilder: (v) => Text('42')` makes a screen reader read `"Apple\n42"`. `itemLeadingBuilder` is the same; an `Icon` carries no label and stays silent.
 - **The row is `[checkbox] [leading] [label] [trailing]`.** Only the label gives way when space runs out, so it ellipsises and neither slot is squeezed. Material has no such arrangement — `CheckboxListTile`'s `secondary` sits on the *opposite* side of the box (`checkbox_list_tile.dart:590`), which is the layout `itemTrailingBuilder` alone gives you.
 
@@ -342,13 +342,13 @@ final presentation = MultiSelectPresentation<String>(
 );
 ```
 
-An optional `checkboxTheme` (a `DropdownCheckboxTheme`, default `defaultTheme`) styles the row's box. It resolves the box's `activeColor` through `fillColor` so the accent survives the box's `onChanged: null` disabled state; see [theming](theming.md).
+An optional `checkboxTheme` (a `DropdownCheckboxTheme`, default `defaultTheme`) styles the row's box, which is a `FlutterCheckbox` (the `flutter_checkbox` package). It resolves into a `CheckboxStyle`; see [theming](theming.md).
 
 The interface is unchanged. `buildSelected()` still takes no argument: `TextItemPresentation` swallows a `value` as a field, and this one swallows a `Set` and a `labelBuilder` the same way.
 
 Two things it does that are not visible on screen:
 
-- The `Checkbox` is **presentational** and **excluded from the semantics tree**, and the row carries `Semantics(checked:)` instead. `onChanged: null` gives the box no gesture recognizer — a tap on it falls through to the row — but it *does* put `isEnabled: false` on the merged row, which makes a screen reader call every row of a working checklist *dimmed*. `IgnorePointer` does not help; it suppresses hit-testing, not semantics.
+- The `FlutterCheckbox` is **presentational** and **excluded from the semantics tree**, and the row carries `Semantics(checked:)` instead. `onChanged: null` gives the box no gesture recognizer — a tap on it falls through to the row — while leaving it `enabled`, so (unlike Material) it does not stamp `isEnabled: false` onto the merged row. It still emits its own `checked` node, which the exclusion drops so the row is the single source of the checked state. `IgnorePointer` does not help; it suppresses hit-testing, not semantics.
 - The row's ink well **merges** its descendants' semantics, so `itemTrailingBuilder`'s text becomes part of the announced label: `"Apple\n42"`.
 
 ## DropdownSearchController\<T\>

--- a/documentation/migration.md
+++ b/documentation/migration.md
@@ -1,5 +1,57 @@
 # Migration Guide
 
+## Upgrading to 4.0.0
+
+Breaking in two places: the multi-select checkbox theme, and one field that 3.1.0 deprecated. The **SDK floor is unchanged** (`>=3.32.0`). If you use neither, nothing changes.
+
+### `DropdownCheckboxTheme` is redesigned around `flutter_checkbox`
+
+The checklist box is now a `FlutterCheckbox` (the `flutter_checkbox` package) rather than Flutter's built-in `Checkbox`, so `DropdownCheckboxTheme` speaks its `CheckboxStyle` vocabulary. Remap the removed Material fields:
+
+| Removed (3.x, Material) | Replacement (4.0.0) |
+|---|---|
+| `side: BorderSide(color: c, width: w)` | `borderColor: c` + `borderWidth: w` |
+| `shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(r))` | `shape: CheckboxShape.rectangle` + `borderRadius: r` |
+| `shape: CircleBorder()` | `shape: CheckboxShape.circle` |
+| `fillColor: WidgetStateProperty...` | `activeColor` (checked) / `inactiveColor` (unchecked) |
+| `materialTapTargetSize`, `visualDensity` | *no equivalent* — size the box with `size` |
+
+`activeColor`, `checkColor` and `mouseCursor` are unchanged. `CheckboxShape` is re-exported from the package, so it needs no extra import. `resolve()` now returns a `CheckboxStyle`, and the `ResolvedCheckboxStyle` class is removed — only code building a presentation by hand is affected.
+
+```dart
+// Before (3.x)
+DropdownCheckboxTheme(
+  activeColor: Colors.teal,
+  side: BorderSide(color: Colors.grey, width: 2),
+  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+)
+
+// After (4.0.0)
+DropdownCheckboxTheme(
+  activeColor: Colors.teal,
+  borderColor: Colors.grey,
+  borderWidth: 2,
+  shape: CheckboxShape.rectangle,
+  borderRadius: 4,
+)
+```
+
+A bonus: the `activeColor` → `fillColor` dance 3.2.0 documented is gone. `FlutterCheckbox` is drawn `onChanged: null` but stays `enabled`, so it is presentational without being greyed, and `activeColor` shows on a checked box directly.
+
+### `CustomItemPresentation.items` is removed
+
+Deprecated in 3.1.0 (read by nothing since), now removed. Drop the argument:
+
+```dart
+// Before
+CustomItemPresentation<T>(itemBuilder: ..., items: items, value: value)
+
+// After
+CustomItemPresentation<T>(itemBuilder: ..., value: value)
+```
+
+Only code that constructs a presentation by hand — a dropdown built on `DropdownOverlayController` — is affected.
+
 ## Upgrading to 3.1.0
 
 A new widget, one behaviour change, one deprecation. Nothing was removed.

--- a/documentation/theming.md
+++ b/documentation/theming.md
@@ -98,52 +98,45 @@ DropdownTheme(
 
 ### The checkbox in a multi-select row
 
-Style it with `DropdownCheckboxTheme`, the `checkbox` slot on
-`DropdownStyleTheme`:
+The box is a `FlutterCheckbox` (the `flutter_checkbox` package). Style it with
+`DropdownCheckboxTheme`, the `checkbox` slot on `DropdownStyleTheme`:
 
 ```dart
 FlutterMultiSelectDropdown<String>(
   theme: DropdownStyleTheme(
     checkbox: DropdownCheckboxTheme(
-      activeColor: Colors.teal,                         // fill of a checked box
-      checkColor: Colors.white,                         // the checkmark
-      side: BorderSide(color: Colors.grey, width: 2),   // an unchecked box's outline
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(4),
-      ),
+      activeColor: Colors.teal,        // fill of a checked box
+      checkColor: Colors.white,        // the checkmark
+      borderColor: Colors.grey,        // an unchecked box's outline
+      borderWidth: 2,
+      shape: CheckboxShape.rectangle,  // or CheckboxShape.circle
+      borderRadius: 4,
     ),
   ),
   ...
 )
 ```
 
-Only the fields that render are here — `activeColor`, `fillColor`, `checkColor`,
-`side`, `shape`, `materialTapTargetSize`, `visualDensity`, `mouseCursor`. The
-row's box is drawn `onChanged: null` (a tap falls through to the row) with its
-semantics excluded, so the focus, hover and splash of an interactive checkbox
+Only the fields that render on the presentational box are here — `activeColor`,
+`checkColor`, `inactiveColor`, `borderColor`, `borderWidth`, `shape`,
+`borderRadius`, `size`, `checkStrokeWidth`, `checkScale`, `mouseCursor`. The box
+is drawn `onChanged: null` (a tap falls through to the row) with its semantics
+excluded, so `flutter_checkbox`'s hover/focus/splash ring and disabled-opacity
 never appear. `mouseCursor` is the exception — its `MouseRegion` is installed
 either way, so set it to `SystemMouseCursors.click` to match the row's cursor.
 
-`activeColor` is the common case — the fill of a **checked** box. Because the box
-is non-interactive, Flutter would drop a raw `Checkbox.activeColor`; the theme
-routes it through `fillColor` so it takes. For per-state control, set `fillColor`
-directly (it wins over `activeColor`):
-
-```dart
-DropdownCheckboxTheme(
-  fillColor: WidgetStateProperty.resolveWith(
-    (states) => states.contains(WidgetState.selected) ? Colors.teal : null,
-  ),
-)
-```
+`activeColor` fills a **checked** box. Unlike Material, no workaround is needed:
+`FlutterCheckbox` is drawn `onChanged: null` but stays `enabled`, so it is
+presentational without being greyed and the accent is read straight.
+`inactiveColor` fills an unchecked box (transparent by default) and `borderColor`
+outlines it; `CheckboxShape` is exported from this package.
 
 **A `Theme` wrapped around the dropdown does not reach the box.** The menu is
-drawn in the root `Overlay`, out of a local `Theme`'s subtree — a
-`CheckboxThemeData` you want to apply must live on `MaterialApp.theme`, and it
-then restyles every checkbox in the app. `DropdownCheckboxTheme` is how you reach
-just this dropdown's boxes. Everything *around* the box — the row's hover,
-splash, margin, radius, and the selected row's background — stays `DropdownTheme`'s,
-exactly as for a single-select menu.
+drawn in the root `Overlay`, out of a local `Theme`'s subtree.
+`DropdownCheckboxTheme` is how you reach just this dropdown's boxes — a null
+field defers to the ambient `ThemeData`. Everything *around* the box — the row's
+hover, splash, margin, radius, and the selected row's background — stays
+`DropdownTheme`'s, exactly as for a single-select menu.
 
 The widgets `itemLeadingBuilder` and `itemTrailingBuilder` return are **yours**.
 The package places them and styles nothing about them; colour and size are
@@ -155,19 +148,15 @@ itemTrailingBuilder: (v) => Text('${counts[v]}',
     style: TextStyle(color: Colors.grey.shade600)),
 ```
 
-`itemHeight` must leave room for the box. A `Checkbox` measures **48×48** with
-Flutter's default `materialTapTargetSize`, and **40×40** under
-`MaterialTapTargetSize.shrinkWrap` — measured, not remembered. This package's
-default `itemHeight` is 48, so a shorter row needs the smaller tap target too —
-and, unlike the ambient theme, `DropdownCheckboxTheme` scopes it to this dropdown:
+`itemHeight` must leave room for the box. A `FlutterCheckbox` is `size` logical
+pixels square — **24×24** by default — with no Material tap-target padding to
+account for. Shrink the box with `size` for a shorter row:
 
 ```dart
 FlutterMultiSelectDropdown<String>(
   itemHeight: 40,
   theme: DropdownStyleTheme(
-    checkbox: DropdownCheckboxTheme(
-      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-    ),
+    checkbox: DropdownCheckboxTheme(size: 18),
   ),
   ...
 )

--- a/example/lib/pages/multi_select_page.dart
+++ b/example/lib/pages/multi_select_page.dart
@@ -123,9 +123,8 @@ class _MultiSelectPageState extends State<MultiSelectPage> {
                       checkbox: DropdownCheckboxTheme(
                         activeColor: Colors.indigo,
                         checkColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.all(Radius.circular(4)),
-                        ),
+                        shape: CheckboxShape.rectangle,
+                        borderRadius: 4,
                         mouseCursor: SystemMouseCursors.click,
                       ),
                     ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -62,13 +62,21 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_checkbox:
+    dependency: transitive
+    description:
+      name: flutter_checkbox
+      sha256: "0195e97055befd708698303a4bb1886613eaed2c2ecc6b85dfbb267e064226b9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   flutter_dropdown_button:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "3.3.0"
+    version: "4.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/flutter_dropdown_button.dart
+++ b/lib/flutter_dropdown_button.dart
@@ -1,5 +1,11 @@
 library;
 
+// The multi-select checklist draws its boxes with `flutter_checkbox`.
+// `DropdownCheckboxTheme` takes a `CheckboxShape`, and its `resolve()` returns a
+// `CheckboxStyle`, so both are re-exported for callers who name them.
+export 'package:flutter_checkbox/flutter_checkbox.dart'
+    show CheckboxShape, CheckboxStyle;
+
 export 'src/flutter_dropdown_button.dart';
 export 'src/flutter_multi_select_dropdown.dart';
 export 'src/buttons/menu_alignment.dart';

--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_checkbox/flutter_checkbox.dart';
 
 import '../config/text_dropdown_config.dart';
 import '../theme/dropdown_checkbox_theme.dart';
@@ -222,30 +223,12 @@ class CustomItemPresentation<T> implements DropdownItemPresentation<T> {
   const CustomItemPresentation({
     required this.itemBuilder,
     required this.value,
-    @Deprecated(
-      'Read by nothing since 3.1.0. The button draws `value` whether or not it '
-      'appears in `items`, the way text mode always has. Drop the argument. '
-      'This parameter will be removed in 4.0.0.',
-    )
-    this.items = const [],
     this.selectedBuilder,
     this.hintWidget,
   });
 
   /// Builds one item row.
   final Widget Function(T item, bool isSelected) itemBuilder;
-
-  /// The items on offer.
-  ///
-  /// Read by nothing. [buildSelected] once consulted it to decide whether
-  /// [value] was still on offer, and drew [hintWidget] when it was not. It no
-  /// longer does: the widget draws what it was handed.
-  @Deprecated(
-    'Read by nothing since 3.1.0. The button draws `value` whether or not it '
-    'appears in `items`, the way text mode always has. Drop the argument. '
-    'This field will be removed in 4.0.0.',
-  )
-  final List<T> items;
 
   /// The chosen item, if any.
   final T? value;
@@ -370,44 +353,41 @@ class MultiSelectPresentation<T> implements DropdownItemPresentation<T> {
 
   /// One checklist row.
   ///
-  /// The box is **presentational**. `onChanged: null` gives it no gesture
-  /// recognizer, so a tap on it falls through to the row's `InkWell` — measured,
-  /// not assumed: a row taps once whether or not the box is wrapped in an
-  /// `IgnorePointer`, so there is no wrapper here.
+  /// The box is a [FlutterCheckbox], drawn **presentationally**. `onChanged: null`
+  /// gives it no gesture recognizer, so a tap on it falls through to the row's
+  /// `InkWell` — measured, not assumed. Unlike Material, `onChanged: null` does
+  /// not grey the box out: `FlutterCheckbox` dims only on `enabled: false`, which
+  /// is left at its default `true`, so the accent shows on a checked box directly
+  /// (no `activeColor` → `fillColor` workaround needed).
   ///
-  /// What `onChanged: null` *does* cost is the semantics tree. Once the
-  /// `InkWell` merges its descendants, the row inherits the box's
-  /// `isEnabled: false`, and a screen reader calls every row of a working
-  /// checklist *dimmed*. `IgnorePointer` does not help — it suppresses
-  /// hit-testing, not semantics. So the box is excluded from the tree and the
-  /// checked state is re-attached to the row, which is the interactive thing.
+  /// What a presentational box still costs is the semantics tree. Once the row's
+  /// `InkWell` merges its descendants, the box's own checked/enabled node would
+  /// merge in and a screen reader would announce every row confusingly. So the
+  /// box is excluded from the tree and the checked state is re-attached to the
+  /// row, which is the interactive thing. `IgnorePointer` would not help — it
+  /// suppresses hit-testing, not semantics.
   ///
   /// None of this is visible on screen. It was found with a semantics probe.
   @override
   Widget buildItem(T item, bool isSelected) {
     final leading = itemLeadingBuilder?.call(item);
     final trailing = itemTrailingBuilder?.call(item);
-    final checkbox = checkboxTheme.resolve();
+    final checkboxStyle = checkboxTheme.resolve();
 
     return Semantics(
       checked: isSelected,
       child: Row(
         children: [
-          // `onChanged: null` keeps the box presentational — the tap falls
-          // through to the row's InkWell. Every resolved slot is null unless the
-          // theme named it, so an unset theme leaves the box to the ambient
-          // CheckboxThemeData exactly as before.
+          // Presentational: `onChanged: null` (tap falls through), semantics
+          // excluded (the row carries `checked`). Unset style slots keep
+          // CheckboxStyle's defaults, which FlutterCheckbox resolves against the
+          // ambient ThemeData — so an unthemed box follows the app theme.
           ExcludeSemantics(
-            child: Checkbox(
+            child: FlutterCheckbox(
               value: isSelected,
               onChanged: null,
-              fillColor: checkbox.fillColor,
-              checkColor: checkbox.checkColor,
-              side: checkbox.side,
-              shape: checkbox.shape,
-              materialTapTargetSize: checkbox.materialTapTargetSize,
-              visualDensity: checkbox.visualDensity,
-              mouseCursor: checkbox.mouseCursor,
+              style: checkboxStyle,
+              mouseCursor: checkboxTheme.mouseCursor,
             ),
           ),
           if (leading != null)

--- a/lib/src/theme/dropdown_checkbox_theme.dart
+++ b/lib/src/theme/dropdown_checkbox_theme.dart
@@ -1,35 +1,37 @@
 import 'package:flutter/material.dart';
-
-import 'resolved_dropdown_style.dart';
+import 'package:flutter_checkbox/flutter_checkbox.dart';
 
 /// Styling for the checkbox drawn on each row of a [FlutterMultiSelectDropdown].
 ///
-/// The menu is drawn in an [OverlayEntry] inserted at the root [Overlay], so a
-/// local [Theme] wrapping the dropdown never reaches it — only an app-wide
-/// [CheckboxThemeData] does, and that restyles every checkbox in the app. This
-/// theme is how you recolour *just this dropdown's* boxes. Naming a field
-/// overrides that slot; leaving it null defers to the ambient
-/// [CheckboxThemeData]. See [resolve].
+/// The box is a [FlutterCheckbox] (the `flutter_checkbox` package), not Flutter's
+/// built-in [Checkbox]. It is drawn presentationally — `onChanged: null` so a tap
+/// falls through to the row's ink well, and with its semantics excluded so the
+/// row announces the checked state. A `FlutterCheckbox` with `onChanged: null`
+/// stays at full opacity (it is not forced into a disabled look the way Material
+/// is), so the accent set here shows on a checked box directly.
 ///
-/// Only the fields that actually render are here. The box is drawn with
-/// `onChanged: null` (it is presentational — a tap falls through to the row) and
-/// with its semantics excluded (the row announces the checked state). That rules
-/// out every focus/hover/splash/overlay/semantic-label field, which a
-/// non-interactive, semantics-excluded checkbox never shows. [mouseCursor] is
-/// the exception: its `MouseRegion` is installed whether or not the box is
-/// interactive, so it is honoured here.
+/// Only the fields that actually render on a presentational box are here. That
+/// rules out `flutter_checkbox`'s hover/focus/splash-ring and disabled-opacity
+/// fields — a non-interactive, ring-less box never shows them — and its
+/// animation-timing fields, which are left at the package default. [mouseCursor]
+/// is the exception: the box's `MouseRegion` is installed regardless of
+/// interactivity, so it is honoured.
+///
+/// The menu is drawn in an [OverlayEntry] at the root [Overlay], out of a local
+/// [Theme]'s subtree, so only an app-wide theme would otherwise reach the box.
+/// This theme recolours *just this dropdown's* boxes. A field left null keeps
+/// [CheckboxStyle]'s default, which [FlutterCheckbox] resolves against the
+/// ambient [ThemeData] — so an unset colour still follows the app theme.
 ///
 /// ```dart
 /// FlutterMultiSelectDropdown<String>(
 ///   // …
 ///   theme: DropdownStyleTheme(
 ///     checkbox: DropdownCheckboxTheme(
-///       activeColor: Colors.teal,        // fill of a checked box
-///       checkColor: Colors.white,        // the checkmark
-///       side: BorderSide(color: Colors.grey, width: 2), // unchecked outline
-///       shape: RoundedRectangleBorder(
-///         borderRadius: BorderRadius.circular(4),
-///       ),
+///       activeColor: Colors.teal,          // fill of a checked box
+///       checkColor: Colors.white,          // the checkmark
+///       borderColor: Colors.grey,          // unchecked outline
+///       shape: CheckboxShape.circle,       // rectangle (default) or circle
 ///     ),
 ///   ),
 /// )
@@ -38,116 +40,111 @@ class DropdownCheckboxTheme {
   /// Creates a checkbox theme configuration.
   const DropdownCheckboxTheme({
     this.activeColor,
-    this.fillColor,
     this.checkColor,
-    this.side,
+    this.inactiveColor,
+    this.borderColor,
+    this.borderWidth,
     this.shape,
-    this.materialTapTargetSize,
-    this.visualDensity,
+    this.borderRadius,
+    this.size,
+    this.checkStrokeWidth,
+    this.checkScale,
     this.mouseCursor,
   });
 
-  /// The fill of a **checked** box.
-  ///
-  /// A convenience for the common case: it is resolved into [fillColor] for the
-  /// selected state. The box is drawn with `onChanged: null`, which Flutter
-  /// treats as `disabled`; a plain `Checkbox.activeColor` is dropped in that
-  /// state, so this is routed through [fillColor] — which [Checkbox] consults
-  /// first — to make it survive. If [fillColor] is also given, that wins and
-  /// this is ignored.
+  /// The fill of a **checked** box. If null, defers to the ambient theme's
+  /// primary colour.
   final Color? activeColor;
 
-  /// The box's fill per [WidgetState], for full control.
-  ///
-  /// Takes precedence over [activeColor]. To colour the checked box, return a
-  /// colour for the `selected` state (it arrives alongside `disabled`, since the
-  /// box is non-interactive) and null otherwise, so an unchecked box keeps the
-  /// ambient default.
-  final WidgetStateProperty<Color?>? fillColor;
-
-  /// The colour of the checkmark. If null, the ambient [CheckboxThemeData]
-  /// decides.
+  /// The colour of the checkmark. If null, defers to white.
   final Color? checkColor;
 
+  /// The fill of an **unchecked** box. If null, transparent.
+  final Color? inactiveColor;
+
   /// The outline of an **unchecked** box. A checked box draws no outline — its
-  /// fill covers it. If null, the ambient [CheckboxThemeData] decides.
-  final BorderSide? side;
+  /// fill covers it. If null, defers to the ambient theme's outline colour.
+  final Color? borderColor;
 
-  /// The box's shape — rounded corners, say. If null, the ambient
-  /// [CheckboxThemeData] decides.
-  final OutlinedBorder? shape;
+  /// The width of the unchecked box's outline. If null, `2`.
+  final double? borderWidth;
 
-  /// The size class the box occupies. If null, the ambient [CheckboxThemeData]
-  /// decides.
-  final MaterialTapTargetSize? materialTapTargetSize;
+  /// The box's shape — [CheckboxShape.rectangle] (default) or
+  /// [CheckboxShape.circle]. If null, rectangle.
+  final CheckboxShape? shape;
 
-  /// The density adjustment applied to the box's size. If null, the ambient
-  /// [CheckboxThemeData] decides.
-  final VisualDensity? visualDensity;
+  /// The corner radius of a rectangle box. Ignored for a circle. If null, `4`.
+  final double? borderRadius;
+
+  /// The width and height of the box in logical pixels. If null, `24`.
+  final double? size;
+
+  /// The stroke width of the checkmark. If null, `2.5`.
+  final double? checkStrokeWidth;
+
+  /// A scale for the checkmark within the box, about its centre — `0.7` draws a
+  /// smaller tick with more padding. If null, `1.0`.
+  final double? checkScale;
 
   /// The cursor shown while a pointer is over the box.
   ///
-  /// The box's `MouseRegion` is installed regardless of its (non-)interactivity,
-  /// so this is honoured even though the box is drawn `onChanged: null`. The box
-  /// sits inside the row's ink well, which shows a click cursor; by default the
-  /// box's own cursor differs over its small area, so set this to
-  /// [SystemMouseCursors.click] to make the whole row read as one target. If
-  /// null, the ambient [CheckboxThemeData] decides.
+  /// The box's `MouseRegion` is installed even though it is drawn
+  /// `onChanged: null`. The box sits inside the row's ink well, which shows a
+  /// click cursor; set this to [SystemMouseCursors.click] to make the whole row
+  /// read as one target. If null, defers to [FlutterCheckbox]'s own default.
   final MouseCursor? mouseCursor;
 
   /// Creates a copy of this theme with the given fields replaced.
   DropdownCheckboxTheme copyWith({
     Color? activeColor,
-    WidgetStateProperty<Color?>? fillColor,
     Color? checkColor,
-    BorderSide? side,
-    OutlinedBorder? shape,
-    MaterialTapTargetSize? materialTapTargetSize,
-    VisualDensity? visualDensity,
+    Color? inactiveColor,
+    Color? borderColor,
+    double? borderWidth,
+    CheckboxShape? shape,
+    double? borderRadius,
+    double? size,
+    double? checkStrokeWidth,
+    double? checkScale,
     MouseCursor? mouseCursor,
   }) {
     return DropdownCheckboxTheme(
       activeColor: activeColor ?? this.activeColor,
-      fillColor: fillColor ?? this.fillColor,
       checkColor: checkColor ?? this.checkColor,
-      side: side ?? this.side,
+      inactiveColor: inactiveColor ?? this.inactiveColor,
+      borderColor: borderColor ?? this.borderColor,
+      borderWidth: borderWidth ?? this.borderWidth,
       shape: shape ?? this.shape,
-      materialTapTargetSize:
-          materialTapTargetSize ?? this.materialTapTargetSize,
-      visualDensity: visualDensity ?? this.visualDensity,
+      borderRadius: borderRadius ?? this.borderRadius,
+      size: size ?? this.size,
+      checkStrokeWidth: checkStrokeWidth ?? this.checkStrokeWidth,
+      checkScale: checkScale ?? this.checkScale,
       mouseCursor: mouseCursor ?? this.mouseCursor,
     );
   }
 
-  /// The checkbox as it should be drawn.
+  /// The box's style, in the shape [FlutterCheckbox] takes.
   ///
-  /// Pure — it reads no [BuildContext]. Its one job is turning the convenience
-  /// [activeColor] into a [fillColor] that answers for the selected state
-  /// whether or not `disabled` is also present, which is the state the box is
-  /// actually in. Every other field is passed straight through, and an unset
-  /// field stays null so the ambient [CheckboxThemeData] keeps control.
-  ResolvedCheckboxStyle resolve() {
-    return ResolvedCheckboxStyle(
-      fillColor: fillColor ?? _fillFromActiveColor(),
+  /// Pure — it reads no [BuildContext]. Each named field is set on the returned
+  /// [CheckboxStyle]; each unset field keeps [CheckboxStyle]'s own default, and
+  /// [FlutterCheckbox] resolves those defaults (and any null colour) against the
+  /// ambient [ThemeData] at build time. [mouseCursor] is not part of the style —
+  /// it is a constructor argument of [FlutterCheckbox] — so it is read directly.
+  CheckboxStyle resolve() {
+    return const CheckboxStyle().copyWith(
+      activeColor: activeColor,
       checkColor: checkColor,
-      side: side,
+      inactiveColor: inactiveColor,
+      borderColor: borderColor,
+      borderWidth: borderWidth,
       shape: shape,
-      materialTapTargetSize: materialTapTargetSize,
-      visualDensity: visualDensity,
-      mouseCursor: mouseCursor,
+      borderRadius: borderRadius,
+      size: size,
+      checkStrokeWidth: checkStrokeWidth,
+      checkScale: checkScale,
     );
   }
 
-  /// [activeColor] as a [fillColor]: the accent when the box is selected — with
-  /// or without `disabled` — and null (defer to ambient) when it is not.
-  WidgetStateProperty<Color?>? _fillFromActiveColor() {
-    final accent = activeColor;
-    if (accent == null) return null;
-    return WidgetStateProperty.resolveWith(
-      (states) => states.contains(WidgetState.selected) ? accent : null,
-    );
-  }
-
-  /// Default theme: every slot deferred to the ambient [CheckboxThemeData].
+  /// Default theme: every slot deferred to the ambient [ThemeData].
   static const DropdownCheckboxTheme defaultTheme = DropdownCheckboxTheme();
 }

--- a/lib/src/theme/resolved_dropdown_style.dart
+++ b/lib/src/theme/resolved_dropdown_style.dart
@@ -297,55 +297,6 @@ class ResolvedOverlayStyle {
   final EdgeInsets? padding;
 }
 
-/// The checklist checkbox's appearance, in the shape [Checkbox] takes.
-///
-/// Every field is handed straight to the [Checkbox] the multi-select menu
-/// draws. A slot the theme left unset stays **null**, which a [Checkbox] reads
-/// as "ask the ambient [CheckboxThemeData]" — writing a default in would
-/// silence an app-wide theme.
-///
-/// [fillColor] is the resolved form of the theme's convenience `activeColor`:
-/// the box is drawn with `onChanged: null`, so Flutter marks it `disabled` and
-/// drops a plain `activeColor` before reading it. Routing the accent through
-/// [fillColor] — which [Checkbox] consults first — is what makes it survive.
-class ResolvedCheckboxStyle {
-  /// Creates a resolved checkbox style.
-  const ResolvedCheckboxStyle({
-    this.fillColor,
-    this.checkColor,
-    this.side,
-    this.shape,
-    this.materialTapTargetSize,
-    this.visualDensity,
-    this.mouseCursor,
-  });
-
-  /// The box's fill per state. Null defers to the ambient [CheckboxThemeData].
-  final WidgetStateProperty<Color?>? fillColor;
-
-  /// The checkmark's colour. Null defers to the ambient theme.
-  final Color? checkColor;
-
-  /// The outline of an **unchecked** box. A checked box has none — its fill
-  /// covers it. Null defers to the ambient theme.
-  final BorderSide? side;
-
-  /// The box's shape. Null defers to the ambient theme.
-  final OutlinedBorder? shape;
-
-  /// The size class the box occupies. Null defers to the ambient theme.
-  final MaterialTapTargetSize? materialTapTargetSize;
-
-  /// The density adjustment applied to the box's size. Null defers to the
-  /// ambient theme.
-  final VisualDensity? visualDensity;
-
-  /// The cursor over the box. Honoured despite `onChanged: null` — the box's
-  /// `MouseRegion` is installed regardless of interactivity. Null defers to the
-  /// ambient theme.
-  final MouseCursor? mouseCursor;
-}
-
 /// One item row's appearance, with every slot filled in.
 class ResolvedItemStyle {
   /// Creates a resolved item style.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 3.3.0
+version: 4.0.0
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues
@@ -20,6 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_checkbox: ^0.3.1
 
 dev_dependencies:
   flutter_test:

--- a/test/bare_anchor_test.dart
+++ b/test/bare_anchor_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_checkbox/flutter_checkbox.dart';
 import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -222,13 +223,13 @@ void main() {
         ),
       );
 
-      expect(find.byType(Checkbox), findsNothing);
+      expect(find.byType(FlutterCheckbox), findsNothing);
 
       await tester.tap(find.text('BARE-ANCHOR'));
       await tester.pumpAndSettle();
 
       // The checklist opened: a box per row.
-      expect(find.byType(Checkbox), findsNWidgets(3));
+      expect(find.byType(FlutterCheckbox), findsNWidgets(3));
     });
 
     testWidgets('combining a button-box param with anchorBuilder asserts', (

--- a/test/multi_select_test.dart
+++ b/test/multi_select_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_checkbox/flutter_checkbox.dart';
 import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -132,7 +133,9 @@ void main() {
     await tester.tap(row('Apple').first);
     await tester.pumpAndSettle();
 
-    final boxes = tester.widgetList<Checkbox>(find.byType(Checkbox)).toList();
+    final boxes = tester
+        .widgetList<FlutterCheckbox>(find.byType(FlutterCheckbox))
+        .toList();
     expect(boxes.map((b) => b.value), [true, false, false]);
   });
 
@@ -164,7 +167,7 @@ void main() {
     await openMenu(tester);
 
     expect(find.text('ghost'), findsNothing);
-    expect(find.byType(Checkbox), findsOneWidget);
+    expect(find.byType(FlutterCheckbox), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -217,7 +220,7 @@ void main() {
 
     expect(find.byIcon(Icons.star), findsNWidgets(2), reason: 'one per row');
 
-    final box = tester.getTopLeft(find.byType(Checkbox).first).dx;
+    final box = tester.getTopLeft(find.byType(FlutterCheckbox).first).dx;
     final icon = tester.getTopLeft(find.byIcon(Icons.star).first).dx;
     final label = tester.getTopLeft(find.text('Apple')).dx;
     final count = tester.getTopLeft(find.text('12').first).dx;
@@ -230,12 +233,12 @@ void main() {
   testWidgets('closeAll shuts a checklist too', (tester) async {
     await tester.pumpWidget(const Harness());
     await openMenu(tester);
-    expect(find.byType(Checkbox), findsNWidgets(3));
+    expect(find.byType(FlutterCheckbox), findsNWidgets(3));
 
     FlutterMultiSelectDropdown.closeAll(animate: false);
     await tester.pumpAndSettle();
 
-    expect(find.byType(Checkbox), findsNothing);
+    expect(find.byType(FlutterCheckbox), findsNothing);
   });
 
   testWidgets('opening a plain dropdown closes an open checklist', (
@@ -271,7 +274,7 @@ void main() {
 
     await tester.tap(find.byType(FlutterMultiSelectDropdown<String>));
     await tester.pumpAndSettle();
-    expect(find.byType(Checkbox), findsNWidgets(2));
+    expect(find.byType(FlutterCheckbox), findsNWidgets(2));
 
     // The open menu covers the screen with a dismiss barrier, so reaching the
     // other button may take two taps. Either way, both must never be open.
@@ -286,7 +289,11 @@ void main() {
     }
 
     expect(find.text('One'), findsOneWidget, reason: 'the other one opened');
-    expect(find.byType(Checkbox), findsNothing, reason: 'the checklist closed');
+    expect(
+      find.byType(FlutterCheckbox),
+      findsNothing,
+      reason: 'the checklist closed',
+    );
   });
 
   testWidgets('reopening the menu does reset the query', (tester) async {
@@ -311,7 +318,8 @@ void main() {
   ) async {
     // End to end: the theme travels the whole path a consumer relies on —
     // DropdownStyleTheme → the widget → the shell → the presentation → the
-    // Checkbox drawn in the root Overlay, which a local Theme could not reach.
+    // FlutterCheckbox drawn in the root Overlay, which a local Theme could not
+    // reach.
     await tester.pumpWidget(
       const Harness(
         initial: {'Apple'},
@@ -319,20 +327,22 @@ void main() {
           checkbox: DropdownCheckboxTheme(
             activeColor: Color(0xFF00AA88),
             checkColor: Color(0xFFFFFFFF),
-            side: BorderSide(color: Color(0xFFDDDDDD), width: 2),
+            borderColor: Color(0xFFDDDDDD),
           ),
         ),
       ),
     );
     await openMenu(tester);
 
-    final box = tester.widget<Checkbox>(find.byType(Checkbox).first);
-    expect(box.checkColor, const Color(0xFFFFFFFF));
-    expect(box.side, const BorderSide(color: Color(0xFFDDDDDD), width: 2));
+    final box = tester.widget<FlutterCheckbox>(
+      find.byType(FlutterCheckbox).first,
+    );
+    expect(box.style.checkColor, const Color(0xFFFFFFFF));
+    expect(box.style.borderColor, const Color(0xFFDDDDDD));
     expect(
-      box.fillColor!.resolve({WidgetState.disabled, WidgetState.selected}),
+      box.style.activeColor,
       const Color(0xFF00AA88),
-      reason: 'the checked box fills with the accent even while disabled',
+      reason: 'the checked box fills with the accent, read straight through',
     );
   });
 }

--- a/test/presentation/multi_select_presentation_test.dart
+++ b/test/presentation/multi_select_presentation_test.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
+import 'package:flutter_checkbox/flutter_checkbox.dart';
 import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// A checklist row must announce that it is checked, and must not announce
 /// that it is disabled.
 ///
-/// A presentational `Checkbox` — one with `onChanged: null`, so the row's own
-/// `InkWell` owns the gesture — carries `isEnabled: false` into the semantics
-/// tree. `IgnorePointer` does not strip it; it suppresses hit-testing only.
-/// Nothing on screen differs, so this is invisible to a render test.
+/// The box is a presentational `FlutterCheckbox` — `onChanged: null`, so the
+/// row's own `InkWell` owns the gesture. Its own semantics node would merge into
+/// the row's, so it is wrapped in `ExcludeSemantics` and the checked state is
+/// re-attached to the row. `IgnorePointer` would not help; it suppresses
+/// hit-testing only. Nothing on screen differs, so this is invisible to a render
+/// test.
 ///
 /// `containsSemantics` is deprecated after Flutter 3.40 in favour of
 /// `isSemantics`, which does not exist on the 3.32 floor this package declares.
@@ -43,9 +46,9 @@ MultiSelectPresentation<T> multi<T>({
   );
 }
 
-/// The `Checkbox` a row was actually rendered with.
-Checkbox renderedBox(WidgetTester tester) =>
-    tester.widget<Checkbox>(find.byType(Checkbox).first);
+/// The `FlutterCheckbox` a row was actually rendered with.
+FlutterCheckbox renderedBox(WidgetTester tester) =>
+    tester.widget<FlutterCheckbox>(find.byType(FlutterCheckbox).first);
 
 /// The style the face was actually rendered with.
 TextStyle? faceStyle(WidgetTester tester) =>
@@ -93,9 +96,11 @@ void main() {
     });
 
     testWidgets('a row never announces that it is disabled', (tester) async {
-      // The regression test. A bare `Checkbox(onChanged: null)` — and one
-      // wrapped in `IgnorePointer` — both put `isEnabled: false` on the merged
-      // row, so a screen reader calls every row of the checklist dimmed.
+      // The contract guard. Material's `Checkbox(onChanged: null)` stamped
+      // `isEnabled: false` onto the merged row (a screen reader called every row
+      // dimmed) — the bug this test was born for. `FlutterCheckbox(onChanged:
+      // null)` stays `enabled`, so it no longer leaks that; the test now guards
+      // the contract against a regression to a box that does.
       final handle = tester.ensureSemantics();
       final presentation = multi<String>(selected: {'a'});
 
@@ -112,9 +117,9 @@ void main() {
   });
 
   group('hit testing', () {
-    // Guard, not a regression test. It pins the measurement that removed an
-    // `IgnorePointer` around the box: a `Checkbox` with `onChanged: null` has
-    // no gesture recognizer, so the tap reaches the row beneath it.
+    // Guard, not a regression test. It pins the measurement that there is no
+    // `IgnorePointer` around the box: a `FlutterCheckbox` with `onChanged: null`
+    // has no gesture recognizer, so the tap reaches the row beneath it.
     testWidgets('a tap on the box is a tap on the row', (tester) async {
       var taps = 0;
       final presentation = multi<String>(selected: const {});
@@ -135,7 +140,7 @@ void main() {
           ),
         ),
       );
-      await tester.tap(find.byType(Checkbox));
+      await tester.tap(find.byType(FlutterCheckbox));
       await tester.pumpAndSettle();
 
       expect(taps, 1);
@@ -159,7 +164,9 @@ void main() {
         ),
       );
 
-      final boxes = tester.widgetList<Checkbox>(find.byType(Checkbox)).toList();
+      final boxes = tester
+          .widgetList<FlutterCheckbox>(find.byType(FlutterCheckbox))
+          .toList();
       expect(boxes.map((b) => b.value), [true, false]);
     });
 
@@ -185,7 +192,7 @@ void main() {
         MaterialApp(home: Scaffold(body: presentation.buildItem('a', false))),
       );
 
-      expect(find.byType(Checkbox), findsOneWidget);
+      expect(find.byType(FlutterCheckbox), findsOneWidget);
       expect(find.text('a'), findsOneWidget);
     });
 
@@ -211,7 +218,7 @@ void main() {
         ),
       );
 
-      final box = tester.getTopLeft(find.byType(Checkbox)).dx;
+      final box = tester.getTopLeft(find.byType(FlutterCheckbox)).dx;
       final icon = tester.getTopLeft(find.byType(Icon)).dx;
       final label = tester.getTopLeft(find.text('a')).dx;
       final count = tester.getTopLeft(find.text('12')).dx;
@@ -233,34 +240,40 @@ void main() {
   });
 
   group('checkbox theme', () {
-    // Pump a row and read the Checkbox it built. The box is `onChanged: null`,
-    // so Flutter resolves its colours in the `disabled` state — asserting the
-    // widget's own `fillColor` against `{disabled, selected}` is what proves the
-    // accent survives, since a raw `activeColor` would be dropped there.
+    // Pump a row and read the FlutterCheckbox it built. The box is themed through
+    // its `style` (a CheckboxStyle) plus the `mouseCursor` argument.
     Future<void> pumpRow(WidgetTester tester, MultiSelectPresentation p) async {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: p.buildItem('a', true))),
       );
     }
 
-    testWidgets('an unthemed row leaves every checkbox slot null', (
+    testWidgets('the box is presentational but not greyed', (tester) async {
+      // The whole reason for FlutterCheckbox over Material: `onChanged: null`
+      // makes it non-interactive (tap falls through) while `enabled` stays true,
+      // so it is not dimmed and needs no activeColor→fillColor workaround.
+      await pumpRow(tester, multi<String>(selected: {'a'}));
+
+      final box = renderedBox(tester);
+      expect(box.onChanged, isNull, reason: 'the row owns the gesture');
+      expect(box.enabled, isTrue, reason: 'presentational, not disabled');
+      expect(box.value, isTrue);
+    });
+
+    testWidgets('an unthemed row leaves the style colours null', (
       tester,
     ) async {
       await pumpRow(tester, multi<String>(selected: {'a'}));
 
-      final box = renderedBox(tester);
-      expect(box.fillColor, isNull, reason: 'defer to ambient CheckboxTheme');
-      expect(box.checkColor, isNull);
-      expect(box.side, isNull);
-      expect(box.shape, isNull);
-      expect(box.materialTapTargetSize, isNull);
-      expect(box.visualDensity, isNull);
-      expect(box.mouseCursor, isNull);
+      final style = renderedBox(tester).style;
+      expect(style.activeColor, isNull, reason: 'defer to the ambient theme');
+      expect(style.checkColor, isNull);
+      expect(style.borderColor, isNull);
+      expect(style.inactiveColor, isNull);
+      expect(renderedBox(tester).mouseCursor, isNull);
     });
 
-    testWidgets('activeColor reaches the box and holds in the disabled state', (
-      tester,
-    ) async {
+    testWidgets('activeColor reaches the box directly', (tester) async {
       await pumpRow(
         tester,
         multi<String>(
@@ -271,38 +284,34 @@ void main() {
         ),
       );
 
-      final fill = renderedBox(tester).fillColor;
-      expect(fill, isNotNull);
       expect(
-        fill!.resolve({WidgetState.disabled, WidgetState.selected}),
+        renderedBox(tester).style.activeColor,
         const Color(0xFF00AA88),
-        reason: 'the state the presentational box is actually in',
+        reason: 'no disabled dance — FlutterCheckbox reads it straight',
       );
     });
 
-    testWidgets('checkColor, side and shape are handed to the box', (
+    testWidgets('checkColor, borderColor, shape and cursor are handed over', (
       tester,
     ) async {
-      const side = BorderSide(color: Color(0xFFDDDDDD), width: 2);
-      const shape = RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(6)),
-      );
       await pumpRow(
         tester,
         multi<String>(
           selected: {'a'},
           checkboxTheme: const DropdownCheckboxTheme(
             checkColor: Color(0xFFFFFFFF),
-            side: side,
-            shape: shape,
+            borderColor: Color(0xFFDDDDDD),
+            shape: CheckboxShape.circle,
+            mouseCursor: SystemMouseCursors.click,
           ),
         ),
       );
 
       final box = renderedBox(tester);
-      expect(box.checkColor, const Color(0xFFFFFFFF));
-      expect(box.side, side);
-      expect(box.shape, shape);
+      expect(box.style.checkColor, const Color(0xFFFFFFFF));
+      expect(box.style.borderColor, const Color(0xFFDDDDDD));
+      expect(box.style.shape, CheckboxShape.circle);
+      expect(box.mouseCursor, SystemMouseCursors.click);
     });
   });
 

--- a/test/theme/dropdown_checkbox_theme_test.dart
+++ b/test/theme/dropdown_checkbox_theme_test.dart
@@ -2,112 +2,78 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// The checklist checkbox is drawn with `onChanged: null`, so Flutter treats it
-/// as **disabled** and resolves its fill through the `disabled` state. A plain
-/// `activeColor` is dropped before it is ever read (`checkbox.dart:452`); only
-/// `fillColor` survives (`checkbox.dart:543`). So `resolve()` must turn a simple
-/// `activeColor` into a `fillColor` that answers for the selected state whether
-/// or not `disabled` is also present. These tests pin exactly that.
+/// The checklist box is a `FlutterCheckbox`, drawn `onChanged: null` but left
+/// `enabled: true` — presentational without being greyed, so no `activeColor` →
+/// `fillColor` workaround is needed (the accent shows on a checked box directly).
+/// `resolve()` builds the `CheckboxStyle` FlutterCheckbox takes: each named field
+/// is set, each unset field keeps CheckboxStyle's own default (which FlutterCheckbox
+/// later resolves against the ambient ThemeData), and a colour left null stays
+/// null so the app theme wins.
 void main() {
-  // The state sets Flutter's Checkbox actually asks `fillColor` about.
-  const selected = <WidgetState>{WidgetState.selected};
-  const disabledSelected = <WidgetState>{
-    WidgetState.disabled,
-    WidgetState.selected,
-  };
-  const unselected = <WidgetState>{};
-  const disabledUnselected = <WidgetState>{WidgetState.disabled};
+  group('resolve', () {
+    test(
+      'a default theme leaves colours null, keeps CheckboxStyle defaults',
+      () {
+        final r = const DropdownCheckboxTheme().resolve();
 
-  group('resolve — empty theme leaves every slot to Flutter', () {
-    test('a default theme resolves every field to null', () {
-      final r = const DropdownCheckboxTheme().resolve();
-
-      expect(
-        r.fillColor,
-        isNull,
-        reason: 'null defers to ambient CheckboxTheme',
-      );
-      expect(r.checkColor, isNull);
-      expect(r.side, isNull);
-      expect(r.shape, isNull);
-      expect(r.materialTapTargetSize, isNull);
-      expect(r.visualDensity, isNull);
-    });
-  });
-
-  group(
-    'resolve — activeColor routes into fillColor and survives disabled',
-    () {
-      test('the checked box takes activeColor even while disabled', () {
-        final r = const DropdownCheckboxTheme(
-          activeColor: Color(0xFF00AA88),
-        ).resolve();
-
-        expect(r.fillColor, isNotNull);
         expect(
-          r.fillColor!.resolve(selected),
-          const Color(0xFF00AA88),
-          reason: 'selected → the accent fills the box',
+          r.activeColor,
+          isNull,
+          reason: 'null defers to the ambient theme',
         );
-        expect(
-          r.fillColor!.resolve(disabledSelected),
-          const Color(0xFF00AA88),
-          reason:
-              'the whole point: onChanged:null adds `disabled`, and the '
-              'accent must still win — a raw activeColor is dropped here',
-        );
-      });
+        expect(r.checkColor, isNull);
+        expect(r.borderColor, isNull);
+        expect(r.inactiveColor, isNull);
+        // CheckboxStyle's own non-null defaults survive an unset theme.
+        expect(r.shape, CheckboxShape.rectangle);
+        expect(r.size, 24);
+        expect(r.borderWidth, 2);
+        expect(r.borderRadius, 4);
+        expect(r.checkStrokeWidth, 2.5);
+        expect(r.checkScale, 1.0);
+      },
+    );
 
-      test('the unchecked box keeps the ambient default fill', () {
-        final r = const DropdownCheckboxTheme(
-          activeColor: Color(0xFF00AA88),
-        ).resolve();
-
-        expect(r.fillColor!.resolve(unselected), isNull);
-        expect(r.fillColor!.resolve(disabledUnselected), isNull);
-      });
-    },
-  );
-
-  group('resolve — fillColor is the escape hatch and wins', () {
-    test('an explicit fillColor is used verbatim over activeColor', () {
-      final explicit = WidgetStateProperty.resolveWith<Color?>(
-        (states) => states.contains(WidgetState.selected)
-            ? const Color(0xFF112233)
-            : const Color(0xFF445566),
-      );
-      final r = DropdownCheckboxTheme(
-        activeColor: const Color(0xFF00AA88),
-        fillColor: explicit,
-      ).resolve();
-
-      expect(identical(r.fillColor, explicit), isTrue);
-      expect(r.fillColor!.resolve(selected), const Color(0xFF112233));
-      expect(r.fillColor!.resolve(unselected), const Color(0xFF445566));
-    });
-  });
-
-  group('resolve — the remaining fields pass straight through', () {
-    test('checkColor, side, shape, tapTarget, density and cursor pass', () {
-      const side = BorderSide(color: Color(0xFFDDDDDD), width: 2);
-      const shape = RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(Radius.circular(6)),
-      );
+    test('activeColor reaches the style directly — no disabled dance', () {
       final r = const DropdownCheckboxTheme(
-        checkColor: Color(0xFFFFFFFF),
-        side: side,
-        shape: shape,
-        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        visualDensity: VisualDensity.compact,
-        mouseCursor: SystemMouseCursors.click,
+        activeColor: Color(0xFF00AA88),
       ).resolve();
 
+      expect(r.activeColor, const Color(0xFF00AA88));
+    });
+
+    test('every named field passes into the CheckboxStyle', () {
+      final r = const DropdownCheckboxTheme(
+        activeColor: Color(0xFF00AA88),
+        checkColor: Color(0xFFFFFFFF),
+        inactiveColor: Color(0xFFEEEEEE),
+        borderColor: Color(0xFFDDDDDD),
+        borderWidth: 3,
+        shape: CheckboxShape.circle,
+        borderRadius: 6,
+        size: 20,
+        checkStrokeWidth: 3.5,
+        checkScale: 0.8,
+      ).resolve();
+
+      expect(r.activeColor, const Color(0xFF00AA88));
       expect(r.checkColor, const Color(0xFFFFFFFF));
-      expect(r.side, side);
-      expect(r.shape, shape);
-      expect(r.materialTapTargetSize, MaterialTapTargetSize.shrinkWrap);
-      expect(r.visualDensity, VisualDensity.compact);
-      expect(r.mouseCursor, SystemMouseCursors.click);
+      expect(r.inactiveColor, const Color(0xFFEEEEEE));
+      expect(r.borderColor, const Color(0xFFDDDDDD));
+      expect(r.borderWidth, 3);
+      expect(r.shape, CheckboxShape.circle);
+      expect(r.borderRadius, 6);
+      expect(r.size, 20);
+      expect(r.checkStrokeWidth, 3.5);
+      expect(r.checkScale, 0.8);
+    });
+
+    test('mouseCursor is not part of the style — it is read off the theme', () {
+      const theme = DropdownCheckboxTheme(
+        mouseCursor: SystemMouseCursors.click,
+      );
+
+      expect(theme.mouseCursor, SystemMouseCursors.click);
     });
   });
 
@@ -125,28 +91,32 @@ void main() {
     });
 
     test('an unnamed field falls back to the original', () {
-      // Exercises the fallback branch of every field: nothing is passed, so
-      // each `x ?? this.x` must take `this.x`.
-      const side = BorderSide(width: 3);
-      const shape = CircleBorder();
+      // Exercises both branches of every field's `x ?? this.x`: the first
+      // copyWith sets each (the non-null branch), the empty one keeps each.
       final full = base.copyWith(
         activeColor: const Color(0xFF010101),
-        fillColor: WidgetStateProperty.all(const Color(0xFF020202)),
-        side: side,
-        shape: shape,
-        materialTapTargetSize: MaterialTapTargetSize.padded,
-        visualDensity: VisualDensity.standard,
+        inactiveColor: const Color(0xFF020202),
+        borderColor: const Color(0xFF030303),
+        borderWidth: 3,
+        shape: CheckboxShape.circle,
+        borderRadius: 6,
+        size: 20,
+        checkStrokeWidth: 3.5,
+        checkScale: 0.8,
         mouseCursor: SystemMouseCursors.click,
       );
       final unchanged = full.copyWith();
 
       expect(unchanged.activeColor, const Color(0xFF010101));
       expect(unchanged.checkColor, const Color(0xFF000000));
-      expect(unchanged.fillColor, full.fillColor);
-      expect(unchanged.side, side);
-      expect(unchanged.shape, shape);
-      expect(unchanged.materialTapTargetSize, MaterialTapTargetSize.padded);
-      expect(unchanged.visualDensity, VisualDensity.standard);
+      expect(unchanged.inactiveColor, const Color(0xFF020202));
+      expect(unchanged.borderColor, const Color(0xFF030303));
+      expect(unchanged.borderWidth, 3);
+      expect(unchanged.shape, CheckboxShape.circle);
+      expect(unchanged.borderRadius, 6);
+      expect(unchanged.size, 20);
+      expect(unchanged.checkStrokeWidth, 3.5);
+      expect(unchanged.checkScale, 0.8);
       expect(unchanged.mouseCursor, SystemMouseCursors.click);
     });
   });


### PR DESCRIPTION
Closes #81.

## What

The multi-select checklist now draws its boxes with [`flutter_checkbox`](https://pub.dev/packages/flutter_checkbox) `^0.3.1`'s `FlutterCheckbox` instead of Flutter's built-in `Checkbox`, and `DropdownCheckboxTheme` is redesigned around its `CheckboxStyle`. This is the **4.0.0** major.

**The SDK floor is unchanged** (`>=3.32.0`): `flutter_checkbox` 0.3.1 requires only Flutter 3.27 (0.3.0 over-declared 3.35; 0.3.1 corrected it). So the dependency drops in with no `environment` bump — the release is breaking for one reason only: the theme API redesign.

## Breaking

- `DropdownCheckboxTheme` rebuilt around `CheckboxStyle`. **Removed** (Material-only): `fillColor`, `side`, `shape: OutlinedBorder`, `materialTapTargetSize`, `visualDensity`. **Kept**: `activeColor`, `checkColor`, `mouseCursor`. **Added**: `inactiveColor`, `borderColor`, `borderWidth`, `borderRadius`, `size`, `checkStrokeWidth`, `checkScale`, and `shape` retyped to the `CheckboxShape` enum. `resolve()` now returns a `CheckboxStyle`; `ResolvedCheckboxStyle` is removed. `CheckboxShape`/`CheckboxStyle` re-exported from the barrel.
- `CustomItemPresentation.items` removed — deprecated in 3.1.0, its promised 4.0.0 removal honoured here.

## Why it's cleaner

`FlutterCheckbox(onChanged: null, enabled: true)` is presentational (tap falls through to the row) **without** being greyed. Material forced an `onChanged: null` box into its disabled state and dropped a plain `activeColor` — the reason 3.2.0 routed the accent through `fillColor`. That whole workaround is deleted; `activeColor` is read straight.

## Verification

- 280 tests, **100% line coverage** (1085 lines).
- Semantics contract held at the semantics tree (row `checked`, never *disabled*); discrimination check revealed `FlutterCheckbox(onChanged: null)` emits `enabled: true` (unlike Material) — `ExcludeSemantics` kept to drop the box's redundant `checked` node and for 0.x robustness (recorded in `lessons.md`).
- Box asserted presentational-but-not-greyed; accent reaches `style.activeColor` directly.
- `flutter analyze` (package + example) clean; `dart format` clean; `pub publish --dry-run` clean bar the uncommitted-git warning.
- Docs swept: README, api_reference, theming, migration (field map), CHANGELOG (4.0.0), example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
