### PR TITLE
feat: position the menu against an external box via positioningKey (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.1.0
+
+The second half of the embedded-field pattern 4.0.0's bare anchor opened. `anchorBuilder` decoupled what the anchor *renders*; a menu embedded inside a wider field still positioned and sized against the compact anchor's own box, so it dropped from mid-field and left-aligned to the little `[All ▾]` segment. `positioningKey` decouples what the menu *positions against*.
+
+* **FEAT**: `positioningKey` — an optional `GlobalKey` on `FlutterDropdownButton` (both constructors) and `FlutterMultiSelectDropdown`. Wrap the whole field in a widget carrying the key and pass it here; the menu then measures *that* box instead of the anchor — dropping below it, left-aligning to it, and defaulting to its width — while the anchor keeps drawing and toggling where it sits. `menuAlignment`, `minMenuWidth` and `maxMenuWidth` measure against the box too
+* **FEAT**: additive and orthogonal. It is a parameter on the shared `DropdownMenuShell`, not a new constructor, so it composes with text mode, custom mode, the checklist and the bare anchor alike — and with a normal chromed button, unrestricted (no assert). The placement engine is untouched: only which `RenderBox` is measured changes, and the existing width/alignment/flip logic yields the field-relative result for free
+* **CHANGE**: the box is measured on every menu build, not tracked per frame — a box that moves *while the menu is open* is not followed, the same contract the anchor already held. It must live in the same `Overlay` coordinate space as the anchor
+* **TEST**: placement is asserted at the overlay's `Positioned` — the menu's width, left and top measure the outer field, not the compact anchor — with control tests pinning the anchor-relative default, a runtime-toggle test proving the key is honoured mutably, and the checklist composition. Discriminating power confirmed by reverting the measure-key swap (the field-relative tests go red, the controls stay green)
+
 ## 4.0.0
 
 Breaking on two axes, plus one long-promised removal. The multi-select checklist now draws its boxes with the [`flutter_checkbox`](https://pub.dev/packages/flutter_checkbox) package instead of Flutter's built-in `Checkbox` (`DropdownCheckboxTheme` redesigned around it), and the monolithic `DropdownTheme` is split into three surface sub-themes. The **SDK floor is unchanged** (`>=3.32.0`): `flutter_checkbox` `0.3.1` needs only Flutter 3.27. This release also folds in the bare-anchor feature, which was never published on its own.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^4.0.0
+  flutter_dropdown_button: ^4.1.0
 ```
 
 Import the package:

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -65,6 +65,38 @@ Only the button *face* becomes yours. The anchored menu — its theming, keyboar
 - **Set `minMenuWidth` — the menu inherits the anchor's width.** A bare anchor is compact by design, and the menu takes its width from it, so an `[All ▾]` anchor yields an `[All ▾]`-wide menu its rows overflow. `minMenuWidth` (and `maxMenuWidth`) are *menu* widths, not the button-box `width`/`minWidth`/`maxWidth`, so they are allowed in bare mode and are the way to give the menu a usable width of its own.
 - **The anchor is still announced as a button.** The dropped ink well's role is restored with `Semantics(button: true)`, so a screen reader reads your widget as the control it is.
 
+### Positioning against an outer box
+
+```dart
+GlobalKey? positioningKey
+```
+
+By default the menu measures the anchor: it drops below it, left-aligns to it, and defaults to its width. An embedded `[All ▾]` anchor is therefore a trap — the menu drops from the middle of the field and left-aligns to the little segment, not to the field around it.
+
+Wrap the whole field in a widget carrying a `GlobalKey`, pass that key as `positioningKey`, and the menu measures **that box** instead. It drops below the whole field, left-aligns to it, and defaults to its width — while the anchor keeps drawing and toggling where it sits. This is the second half of the embedded-field pattern `anchorBuilder` opens: `anchorBuilder` decouples what the anchor *renders*, `positioningKey` decouples what the menu *positions against*. `FlutterMultiSelectDropdown` takes the same parameter.
+
+```dart
+final fieldKey = GlobalKey();
+
+Container(
+  key: fieldKey, // the whole search box
+  child: Row(children: [
+    FlutterDropdownButton<String>.text(
+      items: fields,
+      value: field,
+      onChanged: onField,
+      anchorBuilder: (context, isOpen) => const Text('All ▾'),
+      positioningKey: fieldKey, // menu drops below the whole box
+    ),
+    const Expanded(child: TextField(/* search… */)),
+  ]),
+)
+```
+
+- **`menuAlignment`, `minMenuWidth` and `maxMenuWidth` all measure against the box too.** When `positioningKey` is set, "the button" every width-and-alignment rule refers to is the outer box, not the anchor. With the menu already defaulting to the field's width, `minMenuWidth` is usually unnecessary here — the reverse of bare mode without a `positioningKey`.
+- **The box is measured on every menu build, not tracked per frame.** A box that moves *while the menu is open* is not followed — the same as the anchor. It must live in the same `Overlay` coordinate space the anchor does.
+- **Not restricted to bare mode.** It composes with a normal chromed button too, if you want the menu to align to a container the button sits inside; there is no assert against it.
+
 ## FlutterMultiSelectDropdown\<T\>
 
 A checklist. Several items may be chosen, the menu stays open while they are, and `onChanged` fires the moment a box is ticked — no confirm button. Anchored rather than modal: no scrim, dismissed by an outside tap.
@@ -313,6 +345,7 @@ A working example lives in `example/lib/pages/domain_type_page.dart`.
 | Member | Description |
 |--------|-------------|
 | `buttonKey` | Attach to the button so the controller can measure it |
+| `positioningKey` | A `GlobalKey` on an outer box to measure the menu against instead of `buttonKey`. Mutable; null measures the button. See [Positioning against an outer box](#positioning-against-an-outer-box) |
 | `isOpen` | Whether the menu is showing |
 | `animation` | Runs forward as the menu opens. Drive your own transitions from it — a rotating trailing icon, say |
 | `open(context)` | Shows the menu, closing whichever menu is open in the same `Overlay` |

--- a/example/lib/pages/bare_anchor_page.dart
+++ b/example/lib/pages/bare_anchor_page.dart
@@ -10,6 +10,11 @@ import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
 /// outer field owns the border and background and the selector contributes only
 /// its label and chevron. The chevron turns off `isOpen`, the one thing the
 /// builder cannot read for itself.
+///
+/// `positioningKey` completes the pattern (#86): a `GlobalKey` on the outer
+/// field, so the menu drops below the *whole* field and matches its width,
+/// instead of hanging off the tiny anchor. That is what makes `minMenuWidth`
+/// unnecessary here — the menu already inherits the field's width.
 class BareAnchorPage extends StatefulWidget {
   const BareAnchorPage({super.key});
 
@@ -23,6 +28,11 @@ class _BareAnchorPageState extends State<BareAnchorPage> {
   String _field = 'All';
   Set<String> _tags = {};
   final _searchController = TextEditingController();
+
+  // One key per field, attached to the outer box and handed to its selector as
+  // `positioningKey` so the menu positions against the whole field.
+  final _singleFieldKey = GlobalKey();
+  final _multiFieldKey = GlobalKey();
 
   @override
   void dispose() {
@@ -48,16 +58,17 @@ class _BareAnchorPageState extends State<BareAnchorPage> {
                 Text('Single-select scope', style: theme.textTheme.labelLarge),
                 const SizedBox(height: 8),
                 _SearchField(
+                  fieldKey: _singleFieldKey,
                   // The scope selector — no border, no background, no width.
                   scope: FlutterDropdownButton<String>.text(
                     items: _fields,
                     value: _field,
                     onChanged: (f) => setState(() => _field = f!),
-                    // The anchor is tiny by design, and the menu takes its
-                    // width from the anchor. `minMenuWidth` gives the menu a
-                    // usable width of its own — it is a *menu* width, so it is
-                    // allowed in bare mode where the button-box `width` is not.
-                    minMenuWidth: 200,
+                    // The menu positions against the whole field, not the tiny
+                    // anchor: it drops below the field and matches its width. No
+                    // `minMenuWidth` needed — that lever is only for a bare
+                    // anchor left to size the menu itself.
+                    positioningKey: _singleFieldKey,
                     anchorBuilder: (context, isOpen) =>
                         _AnchorFace(label: _field, isOpen: isOpen),
                   ),
@@ -67,14 +78,15 @@ class _BareAnchorPageState extends State<BareAnchorPage> {
                 Text('Multi-select scope', style: theme.textTheme.labelLarge),
                 const SizedBox(height: 8),
                 _SearchField(
+                  fieldKey: _multiFieldKey,
                   scope: FlutterMultiSelectDropdown<String>(
                     items: const ['Title', 'Body', 'Author', 'Tags'],
                     selected: _tags,
                     onChanged: (next) => setState(() => _tags = next),
-                    // Without this the checklist rows would collapse to the
-                    // tiny anchor's width and overflow. See the single-select
+                    // The checklist menu positions against the whole field too,
+                    // so its rows get the field's width. See the single-select
                     // note above.
-                    minMenuWidth: 200,
+                    positioningKey: _multiFieldKey,
                     labelBuilder: (s) => switch (s.length) {
                       0 => 'All',
                       1 => s.first,
@@ -129,9 +141,17 @@ class _AnchorFace extends StatelessWidget {
 /// The outer field that owns the border and background. The [scope] anchor sits
 /// at its head, then a divider, then the text field.
 class _SearchField extends StatelessWidget {
-  const _SearchField({required this.scope, this.controller});
+  const _SearchField({
+    required this.scope,
+    required this.fieldKey,
+    this.controller,
+  });
 
   final Widget scope;
+
+  /// Attached to the outer box and handed to [scope] as its `positioningKey`,
+  /// so the selector's menu drops below the whole field.
+  final GlobalKey fieldKey;
   final TextEditingController? controller;
 
   @override
@@ -139,6 +159,7 @@ class _SearchField extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Container(
+      key: fieldKey,
       decoration: BoxDecoration(
         border: Border.all(color: theme.dividerColor),
         borderRadius: BorderRadius.circular(10),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -82,6 +82,7 @@ class FlutterDropdownButton<T> extends StatefulWidget {
     this.searchFilter,
     this.emptyBuilder,
     this.anchorBuilder,
+    this.positioningKey,
   }) : hintText = null,
        label = null,
        config = null,
@@ -146,6 +147,7 @@ class FlutterDropdownButton<T> extends StatefulWidget {
     this.searchFilter,
     this.emptyBuilder,
     this.anchorBuilder,
+    this.positioningKey,
   }) : hintText = hint,
        hintWidget = null,
        itemBuilder = null,
@@ -389,6 +391,43 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   /// [expand] and [trailing] — must be left unset; combining them asserts.
   final Widget Function(BuildContext context, bool isOpen)? anchorBuilder;
 
+  /// An outer box to position the menu against, instead of the anchor.
+  ///
+  /// By default the menu drops below the anchor, left-aligns to it, and defaults
+  /// to its width. Wrap some enclosing box in a widget carrying a [GlobalKey],
+  /// pass that key here, and the menu measures *that* box instead: it drops
+  /// below, left-aligns to, and defaults to the width of the enclosing box,
+  /// while the anchor keeps drawing and toggling where it sits. [menuAlignment],
+  /// [minMenuWidth] and [maxMenuWidth] all measure against the box too.
+  ///
+  /// This is the second half of the embedded-field pattern [anchorBuilder]
+  /// opens: [anchorBuilder] decouples what the anchor *renders*, this decouples
+  /// what the menu *positions against*. A compact `[All ▾]` selector at the head
+  /// of a search box drops its menu below the whole box, not the little segment.
+  ///
+  /// ```dart
+  /// final fieldKey = GlobalKey();
+  ///
+  /// Container(
+  ///   key: fieldKey, // the whole search box
+  ///   child: Row(children: [
+  ///     FlutterDropdownButton<String>.text(
+  ///       items: fields,
+  ///       value: field,
+  ///       onChanged: onField,
+  ///       anchorBuilder: (context, isOpen) => const Text('All ▾'),
+  ///       positioningKey: fieldKey, // menu drops below the whole box
+  ///     ),
+  ///     const Expanded(child: TextField(/* search… */)),
+  ///   ]),
+  /// )
+  /// ```
+  ///
+  /// The box must live in the same [Overlay] the anchor does. It is measured on
+  /// every menu build, not tracked per frame — a box that moves *while the menu
+  /// is open* is not followed, the same as the anchor.
+  final GlobalKey? positioningKey;
+
   /// Whether this dropdown was built by [FlutterDropdownButton.text].
   ///
   /// Informational. Nothing inside the widget branches on this: rendering is
@@ -540,6 +579,7 @@ class _FlutterDropdownButtonState<T> extends State<FlutterDropdownButton<T>> {
       searchFilter: widget.searchFilter,
       emptyBuilder: widget.emptyBuilder,
       anchorBuilder: widget.anchorBuilder,
+      positioningKey: widget.positioningKey,
     );
   }
 }

--- a/lib/src/flutter_multi_select_dropdown.dart
+++ b/lib/src/flutter_multi_select_dropdown.dart
@@ -71,6 +71,7 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
     this.searchFilter,
     this.emptyBuilder,
     this.anchorBuilder,
+    this.positioningKey,
   }) : assert(
          anchorBuilder == null ||
              (width == null &&
@@ -204,6 +205,25 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
   /// ```
   final Widget Function(BuildContext context, bool isOpen)? anchorBuilder;
 
+  /// An outer box to position the menu against, instead of the anchor.
+  ///
+  /// By default the menu drops below the anchor, left-aligns to it, and defaults
+  /// to its width. Wrap some enclosing box in a widget carrying a [GlobalKey],
+  /// pass that key here, and the menu measures *that* box instead: it drops
+  /// below, left-aligns to, and defaults to the width of the enclosing box,
+  /// while the anchor keeps drawing and toggling where it sits. [menuAlignment],
+  /// [minMenuWidth] and [maxMenuWidth] all measure against the box too.
+  ///
+  /// The second half of the embedded-field pattern [anchorBuilder] opens:
+  /// [anchorBuilder] decouples what the anchor *renders*, this decouples what the
+  /// menu *positions against*. A compact checklist selector at the head of a
+  /// search box drops its menu below the whole box, not the little segment.
+  ///
+  /// The box must live in the same [Overlay] the anchor does. It is measured on
+  /// every menu build, not tracked per frame — a box that moves *while the menu
+  /// is open* is not followed, the same as the anchor.
+  final GlobalKey? positioningKey;
+
   /// Closes every open dropdown overlay, of either kind.
   ///
   /// Single-open coordination lives in a registry keyed by `Overlay`, so this
@@ -259,6 +279,7 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
       searchFilter: searchFilter,
       emptyBuilder: emptyBuilder,
       anchorBuilder: anchorBuilder,
+      positioningKey: positioningKey,
     );
   }
 }

--- a/lib/src/overlay/dropdown_overlay_controller.dart
+++ b/lib/src/overlay/dropdown_overlay_controller.dart
@@ -115,6 +115,22 @@ class DropdownOverlayController {
   /// Attach this to the button so the controller can measure it.
   final GlobalKey buttonKey = GlobalKey();
 
+  /// An outer box to position the menu against, instead of [buttonKey].
+  ///
+  /// Null — the default — measures the anchor itself: the menu drops below it,
+  /// left-aligns to it, and defaults to its width. Set to a [GlobalKey] on some
+  /// enclosing box and the menu measures *that* box instead — it drops below,
+  /// left-aligns to, and defaults to the width of the enclosing box, while the
+  /// anchor keeps drawing and toggling where it is. The reference for a compact
+  /// dropdown embedded at the head of a wider field.
+  ///
+  /// The box is measured on every overlay build, not tracked per frame: a box
+  /// that moves *while the menu is open* is not followed, the same as the anchor.
+  /// It must live in the same [Overlay] coordinate space the anchor does.
+  ///
+  /// Mutable: the owning widget reassigns it as its own parameter changes.
+  GlobalKey? positioningKey;
+
   /// Describes the menu as it should be drawn right now.
   final DropdownOverlaySpecBuilder spec;
 
@@ -242,7 +258,11 @@ class DropdownOverlayController {
     final context = _context;
     if (context == null || !context.mounted) return null;
 
-    final button = buttonKey.currentContext?.findRenderObject() as RenderBox?;
+    // The menu positions against [positioningKey]'s box when one is given, else
+    // the anchor's own. Only which RenderBox is read changes; the offset and
+    // size it yields feed the same pure placement resolve() unchanged.
+    final measureKey = positioningKey ?? buttonKey;
+    final button = measureKey.currentContext?.findRenderObject() as RenderBox?;
     if (button == null || !button.attached || !button.hasSize) return null;
 
     // The menu is positioned inside the Overlay's Stack, so the button must be

--- a/lib/src/shell/dropdown_menu_shell.dart
+++ b/lib/src/shell/dropdown_menu_shell.dart
@@ -53,6 +53,7 @@ class DropdownMenuShell<T> extends StatefulWidget {
     this.maxWidth,
     this.minMenuWidth,
     this.maxMenuWidth,
+    this.positioningKey,
   });
 
   /// Everything the menu may show, before the query narrows it.
@@ -148,6 +149,15 @@ class DropdownMenuShell<T> extends StatefulWidget {
 
   /// The menu's maximum width.
   final double? maxMenuWidth;
+
+  /// An outer box to position the menu against, instead of the anchor.
+  ///
+  /// A [GlobalKey] on some enclosing box the caller wraps around the whole
+  /// field. When given, the menu drops below, left-aligns to, and defaults to
+  /// the width of *that* box — [menuAlignment], [minMenuWidth] and [maxMenuWidth]
+  /// all measure against it too — while the anchor keeps drawing and toggling
+  /// where it is. See [DropdownOverlayController.positioningKey].
+  final GlobalKey? positioningKey;
 
   @override
   State<DropdownMenuShell<T>> createState() => _DropdownMenuShellState<T>();
@@ -336,6 +346,12 @@ class _DropdownMenuShellState<T> extends State<DropdownMenuShell<T>>
 
   @override
   Widget build(BuildContext context) {
+    // Kept current here rather than at construction: the caller may swap the key
+    // (or toggle it on and off), and build runs after didUpdateWidget and before
+    // the overlay re-measures. Mutating the controller in build is safe — it is
+    // a plain field assignment, not a rebuild.
+    _menu.positioningKey = widget.positioningKey;
+
     final anchorBuilder = widget.anchorBuilder;
     if (anchorBuilder != null) return _buildBareAnchor(context, anchorBuilder);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 4.0.0
+version: 4.1.0
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues

--- a/test/positioning_key_test.dart
+++ b/test/positioning_key_test.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// positioningKey (#86): the menu measures against an outer box the caller
+/// wraps around the whole field, instead of the interactive anchor.
+///
+/// A compact `[All ▾]` anchor lives at the head of a 300-wide field. With no
+/// positioningKey the menu measures the anchor (its small width, its own left).
+/// With positioningKey pointed at the field the same menu drops below the whole
+/// field, left-aligns to it, and defaults to its width — with no change to the
+/// pure placement engine, only to which RenderBox is measured.
+
+/// The whole field: a 300-wide keyed box holding a compact anchor at its head.
+///
+/// Pinned to a known origin (top-left + 100 padding) so placement can be
+/// asserted against the field's own rect.
+class FieldHost extends StatelessWidget {
+  const FieldHost({
+    super.key,
+    required this.fieldKey,
+    required this.usePositioningKey,
+    this.multiSelect = false,
+  });
+
+  final GlobalKey fieldKey;
+  final bool usePositioningKey;
+  final bool multiSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final key = usePositioningKey ? fieldKey : null;
+
+    final Widget dropdown = multiSelect
+        ? FlutterMultiSelectDropdown<String>(
+            items: const ['Apple', 'Banana', 'Cherry'],
+            selected: const {'Apple'},
+            onChanged: (_) {},
+            labelBuilder: (s) => s.isEmpty ? 'All' : '${s.length}',
+            anchorBuilder: (context, isOpen) => const Text('All ▾'),
+            positioningKey: key,
+          )
+        : FlutterDropdownButton<String>.text(
+            items: const ['Apple', 'Banana', 'Cherry'],
+            value: 'Apple',
+            onChanged: (_) {},
+            anchorBuilder: (context, isOpen) => const Text('All ▾'),
+            positioningKey: key,
+          );
+
+    return MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: Padding(
+            padding: const EdgeInsets.all(100),
+            child: SizedBox(
+              key: fieldKey,
+              width: 300,
+              height: 60,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  dropdown,
+                  const Expanded(child: SizedBox()),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The single Positioned the menu is drawn into, inside the overlay.
+Positioned menuPositioned(WidgetTester tester) => tester.widget<Positioned>(
+  find.descendant(of: find.byType(Overlay), matching: find.byType(Positioned)),
+);
+
+void main() {
+  testWidgets(
+    'CONTROL: without positioningKey the menu measures the compact anchor',
+    (tester) async {
+      final fieldKey = GlobalKey();
+      await tester.pumpWidget(
+        FieldHost(fieldKey: fieldKey, usePositioningKey: false),
+      );
+      await tester.tap(find.text('All ▾'));
+      await tester.pumpAndSettle();
+
+      final anchorWidth = tester.getSize(find.text('All ▾')).width;
+      final p = menuPositioned(tester);
+
+      expect(
+        p.width,
+        anchorWidth,
+        reason: 'menu takes the compact anchor width, not the field width',
+      );
+      expect(
+        p.width,
+        lessThan(300),
+        reason: 'and it is far short of the field',
+      );
+    },
+  );
+
+  testWidgets(
+    'positioningKey positions and sizes the menu to the whole field',
+    (tester) async {
+      final fieldKey = GlobalKey();
+      await tester.pumpWidget(
+        FieldHost(fieldKey: fieldKey, usePositioningKey: true),
+      );
+      await tester.tap(find.text('All ▾'));
+      await tester.pumpAndSettle();
+
+      final field = tester.getRect(find.byKey(fieldKey));
+      final p = menuPositioned(tester);
+
+      expect(
+        p.width,
+        field.width,
+        reason: 'menu matches the field width (300)',
+      );
+      expect(p.left, field.left, reason: 'menu left-aligns to the field');
+      expect(
+        p.top,
+        field.bottom + 4,
+        reason: 'menu drops below the whole field (buttonGap 4)',
+      );
+    },
+  );
+
+  testWidgets('the anchor still measures below itself, not the field', (
+    tester,
+  ) async {
+    // The control's menu drops below the anchor's own bottom, which — because
+    // the anchor is centred in a taller field — sits above the field bottom.
+    // This is the exact difference positioningKey erases.
+    final fieldKey = GlobalKey();
+    await tester.pumpWidget(
+      FieldHost(fieldKey: fieldKey, usePositioningKey: false),
+    );
+    await tester.tap(find.text('All ▾'));
+    await tester.pumpAndSettle();
+
+    final field = tester.getRect(find.byKey(fieldKey));
+    final p = menuPositioned(tester);
+
+    expect(
+      p.top,
+      lessThan(field.bottom + 4),
+      reason: 'without the key the menu hangs off the anchor, mid-field',
+    );
+  });
+
+  testWidgets('positioningKey is honoured when toggled on at runtime', (
+    tester,
+  ) async {
+    // Proves the controller's positioningKey is mutable: the same shell State
+    // (and its controller) is reused across the rebuild, and build() reassigns
+    // the key. Were it fixed at construction, the second open would still
+    // measure the anchor.
+    final fieldKey = GlobalKey();
+
+    await tester.pumpWidget(
+      FieldHost(fieldKey: fieldKey, usePositioningKey: false),
+    );
+    await tester.tap(find.text('All ▾'));
+    await tester.pumpAndSettle();
+    expect(menuPositioned(tester).width, lessThan(300), reason: 'anchor first');
+
+    // Close, then rebuild the same tree with the key switched on.
+    await tester.tap(find.text('All ▾'));
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(
+      FieldHost(fieldKey: fieldKey, usePositioningKey: true),
+    );
+
+    await tester.tap(find.text('All ▾'));
+    await tester.pumpAndSettle();
+    final field = tester.getRect(find.byKey(fieldKey));
+    expect(
+      menuPositioned(tester).width,
+      field.width,
+      reason: 'the reassigned key now drives placement',
+    );
+  });
+
+  testWidgets('positioningKey composes with the multi-select checklist', (
+    tester,
+  ) async {
+    final fieldKey = GlobalKey();
+    await tester.pumpWidget(
+      FieldHost(fieldKey: fieldKey, usePositioningKey: true, multiSelect: true),
+    );
+    await tester.tap(find.text('All ▾'));
+    await tester.pumpAndSettle();
+
+    final field = tester.getRect(find.byKey(fieldKey));
+    expect(
+      menuPositioned(tester).width,
+      field.width,
+      reason: 'the checklist menu also measures the field',
+    );
+  });
+}


### PR DESCRIPTION
## What

Adds an optional **`positioningKey`** (a `GlobalKey`) to `FlutterDropdownButton` (both constructors), `FlutterMultiSelectDropdown`, and the shared `DropdownMenuShell` / `DropdownOverlayController`. When set, the menu positions and sizes against the box that key is attached to — the outer field — instead of the interactive anchor.

The second half of the embedded-field pattern #75's bare anchor opened: `anchorBuilder` decoupled what the anchor *renders*; `positioningKey` decouples what the menu *positions against*. A compact `[All ▾]` selector at the head of a search box now drops its menu below the whole box and matches its width, instead of hanging off the little segment.

## How

`DropdownOverlayController.measurePlacement()` measures `positioningKey ?? buttonKey`. **The pure placement engine (`DropdownPlacement`) is untouched** — because width defaults to the measured box's width and left/alignment are computed relative to it, swapping the box yields the field-relative result with no new placement params.

- Mutable on the controller, reassigned from the shell's `build()` → a caller may toggle/swap the key at runtime.
- Composes with every mode and with a normal chromed button; no assert restricts it (per the repo's "cardinality is a type, not a flag" stance).
- `menuAlignment` / `minMenuWidth` / `maxMenuWidth` measure against the box too.
- **Not tracked per frame** — a box that moves while the menu is open is not followed, the same contract the anchor already held. `LayerLink` was rejected for exactly this: it fights the measurement-based placement engine. Full design rationale + spike in the [issue comment](https://github.com/kihyun1998/flutter_dropdown_button/issues/86#issuecomment-4969010303).

## Ships as 4.1.0

Additive, non-breaking (4.0.0 is published, so this opens a new minor). Publishing is the maintainer's step.

## Tests / gates

- Placement asserted at the overlay's `Positioned` (width / left / top measure the outer field); control tests pin the anchor-relative default; a runtime-toggle test proves the key is honoured **mutably**; checklist composition covered.
- **Discriminating power** confirmed by reverting the measure-key swap — the field-relative tests go red, the controls stay green.
- **Adversarial completeness (theflow Step 5) skipped by judgement**: this is a closed mechanical surface (one RenderBox swap, pure engine untouched) exhaustively covered by the round-trip widget tests — not a hidden-state/domain change.
- Gates green locally: `flutter analyze` clean · 290 tests pass · coverage **100%** (1106/1106) · `dart format` clean · example analyze clean · `pub publish --dry-run` clean but for the pre-commit uncommitted-files warning.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)