### PR TITLE
fix: announce the trigger's role and the chosen row's state (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.2.0
+
+What is on screen reached everyone except the people who cannot see it. The trigger announced its current value and nothing about being a control; the chosen row was distinguished from its neighbours by `DropdownItemTheme.selectedColor` and by nothing else. The checklist had been doing this correctly since 3.1.0 — `Semantics(checked:)` on the row — and the single-select path simply never got the same treatment.
+
+* **FIX**: the trigger announces `button` and its enabled state. Measured before: `flags=[isFocusable] actions=[tap, focus]` — no role at all, and a *disabled* dropdown emitted `flags=[] actions=[]`, indistinguishable from something decorative. It is one `Semantics` on the node the `InkWell` already annotates, so the merged `semanticsLabel` contract is unchanged. Both widgets get it; they share the shell
+* **FIX**: a single-select row announces `selected`. Before, the three rows of an open menu were byte-identical in the semantics tree whichever one was the value. It is attached in the presentation, not the shell — the shell does not know what selection is, so it cannot know whether "chosen" means `selected` or `checked`; that word is the presentation's, one per cardinality
+* **FIX**: `anchorBuilder`'s bare anchor was already announcing the role, and the reported direction had it backwards — it was the chromed path that was silent. The dartdoc and `documentation/api_reference.md` both credited the role to the ink well being "restored"; an `InkWell` announces no role in either path (`material/ink_well.dart` declares only `onTap`/`onLongPress`). What it does contribute is focusability, which the bare path lacks
+* **CHANGE**: if your `itemBuilder` declares `selected` itself — a hand-rolled workaround for this bug — **delete it**. Two `Semantics` in one merge group cannot both set the same field, so the caller's now becomes a node of its own: measured, the row keeps `selected` and its tap action but loses its *label*, while the labelled node loses its actions. Any other property a caller declares (a label, a hint) merges as before
+* **TEST**: asserted at the semantics tree, never the render tree — every assertion here passes under `find.text` while the tree says nothing. `containsSemantics`, matching `multi_select_presentation_test.dart`'s existing choice: an exhaustive matcher pins the host platform, because `Focus` emits its focus action only off-iOS. Discriminating power confirmed by reverting `lib/` — six of eight go red, and the two that stay green are the two labelled guards
+
 ## 4.1.0
 
 The second half of the embedded-field pattern 4.0.0's bare anchor opened. `anchorBuilder` decoupled what the anchor *renders*; a menu embedded inside a wider field still positioned and sized against the compact anchor's own box, so it dropped from mid-field and left-aligned to the little `[All ▾]` segment. `positioningKey` decouples what the menu *positions against*.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flutter_dropdown_button: ^4.1.0
+  flutter_dropdown_button: ^4.2.0
 ```
 
 Import the package:

--- a/docs/adr/0001-accessibility-semantics-are-attached-by-hand.md
+++ b/docs/adr/0001-accessibility-semantics-are-attached-by-hand.md
@@ -1,0 +1,136 @@
+# 0001 — Accessibility semantics are attached by hand, and the word for a state is the presentation's
+
+**Status:** Accepted — 2026-08-09. Promoted out of the adversarial completeness
+pass on [#88](https://github.com/kihyun1998/flutter_dropdown_button/issues/88).
+This is the first decision record in this repository; `docs/adr/` did not exist
+before it.
+
+## Why a record rather than another issue
+
+Four issues have now been filed against the same mechanism — #37, #64, #81, #88
+— and each was found the way the last one was: someone opened a semantics tree
+and looked. An issue holds one decision. It cannot hold a rule that spans
+decisions, which is why the fifth of these would have been decided from scratch
+too.
+
+Two of theflow's promotion triggers fired in #88's pass, which is the bar:
+
+- **The reference cannot arbitrate — it contradicts itself across its own call
+  sites.** `material/dropdown.dart:246` wraps a dropdown row in
+  `Semantics(role: SemanticsRole.menuItem)` and never emits `selected` at all;
+  `material/list_tile.dart:997` emits `Semantics(selected: selected)` for the
+  same kind of row. Asking "what does Material do for a selected row" has two
+  answers.
+- **Two artifacts inside this repo required opposite things.**
+  `test/presentation/multi_select_presentation_test.dart` reasoned its way to
+  `containsSemantics` because an exhaustive matcher breaks when an `InkWell`
+  gains a flag; `test/semantics_role_state_test.dart` reasoned its way to
+  `matchesSemantics` for the opposite reason, on the same surface, and was
+  measurably wrong — see rule 4. Neither file knew the other had decided.
+
+## The root
+
+**This package builds its interactive surfaces itself, and they announce
+nothing.** `material/ink_well.dart:1401` declares only `onTap` and
+`onLongPress`: an `InkWell` contributes a tap action and — through its `Focus` —
+focusability, and no role, no enabled state, no relation. A bare
+`GestureDetector` contributes less still. That is a direct consequence of
+[the overlay-rendering identity](../../CLAUDE.md): a package that used Flutter's
+menu machinery would inherit its semantics, and this one does not use it.
+
+So nothing arrives for free, and **nothing reports the absence.** A missing flag
+compiles, analyzes clean, renders correctly, passes `find.text`, and holds a 100%
+coverage floor. Measured on 4.1.0: the trigger of a *disabled* dropdown emitted
+`flags=[] actions=[]` — a screen reader could not distinguish it from decoration
+— while every gate in this repo was green.
+
+## The rules
+
+1. **An interactive surface declares its role and its enabled state.** Absence
+   is not a default; it is a defect. This covers widget-level identity
+   (`button`, `textField`), not structural relations — see the exclusions.
+2. **A stateful surface declares its state, and the word is the presentation's
+   — one per cardinality.** A single-select row is `selected`; a checklist row
+   is `checked`. The shell must not choose between them: it knows what
+   `isChosen` answered, never what it *means*. This is "cardinality is a type,
+   not a flag" reaching the semantics tree, and it is why the announcement lives
+   in `DropdownItemPresentation.buildItem` and not in the shell's row wrapper.
+3. **A semantics node is complete or it is absent** — the same rule the themes
+   hold for resolved styles. Half a node is worse than none: a role with no
+   enabled state reads as a control that cannot be broken, and a state with no
+   role reads as decoration.
+4. **Assertions are made at the semantics tree, and assert *this package's*
+   contract — not Flutter's contributions to the node.** Every claim in this
+   record was found by dumping the tree and none of them by reading the render
+   tree. Exhaustive matchers are forbidden here: they pin the host platform,
+   because `widgets/focus_scope.dart:723` emits the focus action only off-iOS,
+   so a node matched flag-for-flag on the test host goes red under
+   `TargetPlatform.iOS`. Partial matching, with the negative assertions carrying
+   the weight — an unchosen row states `selected: false` rather than staying
+   silent.
+5. **Both anchor paths carry the same contract.** `anchorBuilder` changes what
+   the anchor *looks like*, not what it *is*. A caller who draws their own
+   anchor is not asking for a different control.
+
+## What these derive
+
+The rules were written to reproduce decisions already taken, not to list them.
+Each of these was decided separately and falls out of the rules above:
+
+| Already decided | Now derived from |
+|---|---|
+| #37 — `semanticsLabel` describes the control, so it goes on the control, and the merged string is the contract | rule 4 (the tree is the seam; the render tree passed while the announcement was wrong) |
+| #64 / #81 — the checklist box is excluded and `checked` is re-attached to the row | rules 2 and 3 (one complete node per interactive surface, in the checklist's vocabulary) |
+| #88 — the trigger announces `button`/`enabled`, the single-select row announces `selected` | rules 1, 2, 3 |
+| #88 — the reported direction was backwards: the *bare* path already announced the role | rule 5 |
+
+## What these contradict
+
+Adjudicated, not quietly flipped. Each is a conformance gap under this record
+and is filed as such rather than fixed inside the change that found it:
+
+- **Rule 5 vs. the bare anchor's focusability.** The bare path is a plain
+  `GestureDetector`: measured `actions=[tap]` with no `isFocusable` and no focus
+  action, where the chromed path has both from its `InkWell`. It is also not
+  keyboard-operable, while `documentation/api_reference.md:60`,
+  `documentation/use_cases.md:525` and `CHANGELOG.md:34` all advertise "keyboard
+  navigation".
+- **Rules 1 and 3 vs. the dismiss barrier.** Measured with a query matching
+  nothing: one node, `Rect(0, 0, 800, 600)` on an 800×600 screen,
+  `label="No results found" actions=[tap]`. The overlay's barrier declares a tap
+  and no role, and the empty state merges into it, so the whole screen becomes a
+  single target named after the empty state whose activation dismisses the menu.
+- **Rule 3 vs. the trigger's open state.** Neither anchor path announces
+  expanded or collapsed, so a node that now correctly says "button, enabled" is
+  still not a complete description of a control whose whole job is to toggle.
+
+## What this record does not cover
+
+Named so the next pass does not read them as decided:
+
+- **Structural roles** (`SemanticsRole.menu`, `SemanticsRole.menuItem`). Rule 1
+  is deliberately about widget-level identity. Adopting Flutter's menu
+  *vocabulary* while deliberately not using its menu *machinery* is a design
+  question this record does not settle — and neither `matchesSemantics` nor
+  `containsSemantics` has a `role` parameter at the 3.32 floor or at 3.44, so it
+  would be a rule with no way to assert it.
+- **Keyboard operation** — arrow keys, Escape, type-ahead. This record governs
+  what is *declared*, not the interaction model. `lib/` currently contains no
+  `Shortcuts`, `Actions`, `LogicalKeyboardKey` or `FocusTraversal` at all.
+- **Announcement timing** — live regions, whether opening the menu moves
+  accessibility focus, whether anything is spoken on open.
+- **Anything a caller's own `Semantics` does.** Rule 2 puts a `selected` on the
+  row; a caller who declares `selected` inside `itemBuilder` collides with it
+  and splits the row in two (measured: the row keeps the state and the action,
+  the caller's node keeps the label). Documented on `buildItem`, not governed
+  here.
+
+## Consequences
+
+- `documentation/api_reference.md`'s `DropdownItemPresentation` table now states
+  rule 2 as part of the interface contract, because the interface is exported
+  and a third-party implementation is bound by it.
+- The three contradictions above are filed as conformance items under this
+  record.
+- A future presentation — a third cardinality, a grouped menu — inherits rules
+  1-5 by construction instead of rediscovering them with a semantics dump.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -11,7 +11,14 @@ This is a **single-context** repo.
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
 
-Neither `CONTEXT.md` nor `docs/adr/` exists yet in this repo. That is expected.
+`CONTEXT.md` does not exist yet in this repo. That is expected.
+
+`docs/adr/` does, as of #88, and holds one record:
+
+- **[0001 — Accessibility semantics are attached by hand, and the word for a
+  state is the presentation's](../adr/0001-accessibility-semantics-are-attached-by-hand.md)**
+  — read it before touching anything that emits `Semantics`, and file work in
+  that area as a conformance item under it rather than as a fresh decision.
 
 ## File structure
 

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -63,7 +63,7 @@ Only the button *face* becomes yours. The anchored menu — its theming, keyboar
 - **`isOpen` flips true the moment the menu opens and false once it has finished closing** — the close animation runs while it is still true, so a chevron animated off it settles back after the menu is gone.
 - **The button-box params it replaces must be left unset.** `width`, `minWidth`, `maxWidth`, `expand` and `trailing` describe the box you no longer have; combining any with `anchorBuilder` asserts in debug.
 - **Set `minMenuWidth` — the menu inherits the anchor's width.** A bare anchor is compact by design, and the menu takes its width from it, so an `[All ▾]` anchor yields an `[All ▾]`-wide menu its rows overflow. `minMenuWidth` (and `maxMenuWidth`) are *menu* widths, not the button-box `width`/`minWidth`/`maxWidth`, so they are allowed in bare mode and are the way to give the menu a usable width of its own.
-- **The anchor is still announced as a button.** The dropped ink well's role is restored with `Semantics(button: true)`, so a screen reader reads your widget as the control it is.
+- **The anchor is still announced as a button.** `Semantics(button: true)` wraps it, the same as the chromed path, so a screen reader reads your widget as the control it is. (It is not the ink well's role being restored — an `InkWell` announces no role in either path; it contributes the focusability that a bare anchor, being a plain gesture detector, does not have.)
 
 ### Positioning against an outer box
 
@@ -391,8 +391,8 @@ How items and the button's face are drawn. One implementation per rendering mode
 |--------|------|-------------|
 | `contentAlignment` | `Alignment` | Where the button's face and each item row sit horizontally |
 | `defaultSearchFilter` | `DropdownSearchFilter<T>?` | The filter used when the caller supplies none. Null means this mode has none to offer |
-| `buildItem(item, isSelected)` | `Widget` | One row of the open menu |
-| `buildSelected()` | `Widget` | The button's face: the selected item, or the hint |
+| `buildItem(item, isSelected)` | `Widget` | One row of the open menu. An implementation must also **announce** `isSelected` on the row, in its cardinality's vocabulary — `selected` for a single-select row, `checked` for a checklist one. The shell cannot do it for you: it does not know what selection is, only what `isChosen` answered |
+| `buildSelected()` | `Widget` | The button's face: the selected item, or the hint. Deliberately *not* routed through `buildItem` — the face is not a selected row |
 
 ### TextItemPresentation\<T\>
 

--- a/documentation/text_configuration.md
+++ b/documentation/text_configuration.md
@@ -281,7 +281,9 @@ TextDropdownConfig(
 
 `semanticsLabel` describes the **button**. A screen reader announces it alongside
 the selected value — `"Fruit selection dropdown, Banana"` — not in place of it.
-Menu items are unaffected: each announces its own text.
+Menu items do not take the label — each announces its own text, plus whether it
+is the chosen one (`selected`), which is the only place that state exists for a
+screen reader: on screen it is a colour.
 
 ### Locale-specific Rendering
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.1.0"
+    version: "4.2.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -142,10 +142,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -224,5 +224,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.32.0"

--- a/lib/src/presentation/item_presentation.dart
+++ b/lib/src/presentation/item_presentation.dart
@@ -29,6 +29,14 @@ abstract interface class DropdownItemPresentation<T> {
   DropdownSearchFilter<T>? get defaultSearchFilter;
 
   /// One row of the open menu.
+  ///
+  /// [isSelected] is not only a styling hint: an implementation **announces it**
+  /// on the row, in the vocabulary its cardinality calls for — a single-select
+  /// row is `selected`, a checklist row is `checked`. The shell cannot do this
+  /// on the row's behalf, because it does not know what selection is; it only
+  /// knows the answer `isChosen` gave. On screen the distinction is a colour
+  /// ([DropdownItemTheme.selectedColor]), and a colour reaches nobody using a
+  /// screen reader.
   Widget buildItem(T item, bool isSelected);
 
   /// The button's face: the selected item, or the hint when nothing is chosen.
@@ -167,7 +175,11 @@ class TextItemPresentation<T> implements DropdownItemPresentation<T> {
     // semantics label *replaces* the announced string, so applying one label to
     // every row made a screen reader read the same phrase for all of them.
     // It describes the dropdown, and it is applied in [buildSelected].
-    return _withLeading(text, leading);
+    //
+    // `selected` rather than `checked`: one value is chosen, so the row is not
+    // a box that is on or off. The row's `InkWell` is the interactive node and
+    // this merges into it.
+    return Semantics(selected: isSelected, child: _withLeading(text, leading));
   }
 
   @override
@@ -247,8 +259,23 @@ class CustomItemPresentation<T> implements DropdownItemPresentation<T> {
   @override
   DropdownSearchFilter<T>? get defaultSearchFilter => null;
 
+  /// The caller's widget, told whether it is the chosen one — and the row says
+  /// so in the tree as well.
+  ///
+  /// **A caller who also declares `selected` inside [itemBuilder] now splits the
+  /// row in two.** Two `Semantics` in one merge group cannot both set the same
+  /// field, so the caller's becomes its own node: measured, the row keeps
+  /// `selected` and the actions but loses its *label*, and the labelled node
+  /// loses its actions — a screen reader then meets an unnamed tappable row.
+  /// Any *other* property a caller declares (a label, a hint) merges as before.
+  /// The remedy is to delete the hand-rolled `selected`, which this makes
+  /// redundant; that is the workaround this change exists to retire.
+  ///
+  /// [buildSelected] deliberately does not go through here — the button's face
+  /// is not a selected row.
   @override
-  Widget buildItem(T item, bool isSelected) => itemBuilder(item, isSelected);
+  Widget buildItem(T item, bool isSelected) =>
+      Semantics(selected: isSelected, child: itemBuilder(item, isSelected));
 
   @override
   Widget buildSelected() {

--- a/lib/src/shell/dropdown_menu_shell.dart
+++ b/lib/src/shell/dropdown_menu_shell.dart
@@ -357,24 +357,34 @@ class _DropdownMenuShellState<T> extends State<DropdownMenuShell<T>>
 
     final style = _buttonStyle;
 
-    Widget button = Container(
-      key: _menu.buttonKey,
-      width: widget.width,
-      decoration: style.decoration,
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: widget.enabled ? _toggleDropdown : null,
-          mouseCursor: widget.enabled
-              ? SystemMouseCursors.click
-              : SystemMouseCursors.forbidden,
-          borderRadius: BorderRadius.circular(style.borderRadius),
-          splashColor: style.splashColor,
-          highlightColor: style.highlightColor,
-          hoverColor: style.hoverColor,
-          child: Padding(
-            padding: style.padding,
-            child: _buildButtonContent(style),
+    // The role and the enabled state, on the same node the `InkWell` annotates
+    // with `tap`/`focus` — an `InkWell` contributes neither (it declares only
+    // `onTap`/`onLongPress`, `material/ink_well.dart:1401`), so without this the
+    // trigger reads as an unlabelled focusable thing. `container: false` is the
+    // default, so this merges into that node rather than splitting it, which is
+    // what keeps the merged `semanticsLabel` of #37 intact.
+    Widget button = Semantics(
+      button: true,
+      enabled: widget.enabled,
+      child: Container(
+        key: _menu.buttonKey,
+        width: widget.width,
+        decoration: style.decoration,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: widget.enabled ? _toggleDropdown : null,
+            mouseCursor: widget.enabled
+                ? SystemMouseCursors.click
+                : SystemMouseCursors.forbidden,
+            borderRadius: BorderRadius.circular(style.borderRadius),
+            splashColor: style.splashColor,
+            highlightColor: style.highlightColor,
+            hoverColor: style.hoverColor,
+            child: Padding(
+              padding: style.padding,
+              child: _buildButtonContent(style),
+            ),
           ),
         ),
       ),
@@ -389,10 +399,14 @@ class _DropdownMenuShellState<T> extends State<DropdownMenuShell<T>>
   /// icon — the button-box params the widgets assert away in this mode. The
   /// only things the shell must still own wrap the caller's widget: the
   /// [DropdownOverlayController.buttonKey] the overlay measures to place the
-  /// menu, and the tap that toggles it. `Semantics(button: …)` restores the
-  /// role the dropped `InkWell` would have announced; the key rides on it
-  /// because a `Semantics` is a render box that takes its child's size, which
-  /// is what [DropdownOverlayController.measurePlacement] reads.
+  /// menu, and the tap that toggles it. `Semantics(button: …)` is the same role
+  /// and enabled state the chrome path announces — the caller draws the anchor,
+  /// not what it *is*, and dropping the chrome does not make it stop being the
+  /// control that opens the menu. (It is not the `InkWell`'s doing in either
+  /// path: an `InkWell` declares only `onTap`/`onLongPress`,
+  /// `material/ink_well.dart:1401`.) The key rides on the `Semantics` because it
+  /// is a render box that takes its child's size, which is what
+  /// [DropdownOverlayController.measurePlacement] reads.
   Widget _buildBareAnchor(
     BuildContext context,
     Widget Function(BuildContext context, bool isOpen) anchorBuilder,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 4.1.0
+version: 4.2.0
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues

--- a/test/presentation/item_presentation_test.dart
+++ b/test/presentation/item_presentation_test.dart
@@ -144,8 +144,23 @@ void main() {
     test('an item row is drawn unselected unless it is the value', () {
       final presentation = custom<String>(value: 'a');
 
-      expect((presentation.buildItem('a', true) as Text).data, 'a/true');
-      expect((presentation.buildItem('b', false) as Text).data, 'b/false');
+      // The row is the caller's widget wrapped in the announcement of whether
+      // it is chosen — `itemBuilder`'s result is handed through untouched, and
+      // `selected` carries the same answer the styling did (#88).
+      final chosen = presentation.buildItem('a', true) as Semantics;
+      final other = presentation.buildItem('b', false) as Semantics;
+
+      expect((chosen.child as Text).data, 'a/true');
+      expect(chosen.properties.selected, isTrue);
+
+      expect((other.child as Text).data, 'b/false');
+      expect(
+        other.properties.selected,
+        isFalse,
+        reason:
+            'an unchosen row says so rather than staying silent — the '
+            'absence of a flag is not a state a screen reader can read',
+      );
     });
   });
 }

--- a/test/semantics_role_state_test.dart
+++ b/test/semantics_role_state_test.dart
@@ -1,0 +1,343 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Observed at the semantics tree, not the widget tree — a screen reader reads
+/// the former. Every assertion in this file passes under `find.text` while the
+/// tree says nothing (#37 is the precedent).
+///
+/// Two contracts live here:
+///
+/// * the trigger is a **control that opens a list**, so it announces the button
+///   role and whether it is enabled;
+/// * a row that is **chosen** says so. Which word it uses is the presentation's
+///   call — a checklist row is `checked`, a single-select row is `selected` —
+///   because the shell does not know what selection is.
+///
+/// `containsSemantics`, deliberately ignored — the same choice and the same
+/// reasoning as `presentation/multi_select_presentation_test.dart`, which worked
+/// this out first. `isSemantics` does not exist on the 3.32 floor; `hasFlag` and
+/// `flagsCollection` are mirror problems. `matchesSemantics` compiles on both
+/// ends but insists on describing *every* flag, which is not a stronger bar
+/// here — it is a trap: `Focus` emits its focus action only off-iOS
+/// (`widgets/focus_scope.dart:723`), so an exhaustive matcher pins the host
+/// default and goes red under `TargetPlatform.iOS`. Measured, not guessed.
+/// Drop the ignores when the floor moves past `isSemantics`.
+///
+/// What is asserted here is therefore *this package's* contract, not Flutter's
+/// contributions to the node. The negative assertions carry the weight: an
+/// unchosen row states `isSelected: false` rather than staying silent, so a bug
+/// that marked every row selected cannot pass.
+
+class Role {
+  const Role(this.name);
+  final String name;
+}
+
+const owner = Role('Owner');
+const member = Role('Member');
+const viewer = Role('Viewer');
+const roles = [owner, member, viewer];
+
+/// Custom mode. The face is built by [selectedBuilder] so its text differs from
+/// the rows' — otherwise `find.text('Member')` matches both the trigger and its
+/// row, and the finder, not the tree, decides what is asserted.
+Future<void> pumpCustom(WidgetTester tester, {bool enabled = true}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: FlutterDropdownButton<Role>(
+            width: 200,
+            items: roles,
+            value: member,
+            enabled: enabled,
+            itemBuilder: (role, isSelected) => Text(role.name),
+            selectedBuilder: (role) => Text('Face ${role.name}'),
+            onChanged: (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> pumpText(WidgetTester tester, {String? semanticsLabel}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: FlutterDropdownButton<Role>.text(
+            width: 200,
+            items: roles,
+            value: member,
+            label: (role) => role.name,
+            config: TextDropdownConfig(semanticsLabel: semanticsLabel),
+            onChanged: (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> pumpMulti(WidgetTester tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: FlutterMultiSelectDropdown<Role>(
+            width: 200,
+            items: roles,
+            selected: const {member},
+            label: (role) => role.name,
+            labelBuilder: (selected) => '${selected.length} selected',
+            onChanged: (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('the trigger carries its role', () {
+    testWidgets('an enabled dropdown announces the button role', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await pumpCustom(tester);
+
+      expect(
+        tester.getSemantics(find.text('Face Member')),
+        // ignore: deprecated_member_use
+        containsSemantics(
+          label: 'Face Member',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+        ),
+      );
+
+      semantics.dispose();
+    });
+
+    testWidgets(
+      'a disabled dropdown announces the role and the disabled state',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+        await pumpCustom(tester, enabled: false);
+
+        // No tap or focus action, and no `isEnabled` — but the node must still
+        // say it *has* an enabled state, or a screen reader cannot tell a
+        // disabled control from a decorative one.
+        expect(
+          tester.getSemantics(find.text('Face Member')),
+          // ignore: deprecated_member_use
+          containsSemantics(
+            label: 'Face Member',
+            isButton: true,
+            hasEnabledState: true,
+            isEnabled: false,
+          ),
+        );
+
+        semantics.dispose();
+      },
+    );
+
+    testWidgets(
+      'the multi-select trigger carries it too — one shell, one fix',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+        await pumpMulti(tester);
+
+        expect(
+          tester.getSemantics(find.text('1 selected')),
+          // ignore: deprecated_member_use
+          containsSemantics(
+            label: '1 selected',
+            isButton: true,
+            hasEnabledState: true,
+            isEnabled: true,
+          ),
+        );
+
+        semantics.dispose();
+      },
+    );
+  });
+
+  group('a chosen row says so', () {
+    testWidgets('custom mode — only the chosen row is selected', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await pumpCustom(tester);
+      await tester.tap(find.byType(FlutterDropdownButton<Role>));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.text('Member')),
+        // ignore: deprecated_member_use
+        containsSemantics(
+          label: 'Member',
+          hasSelectedState: true,
+          isSelected: true,
+          hasTapAction: true,
+        ),
+        reason: 'the chosen row',
+      );
+
+      // The side conditions. A lone positive assertion would also pass if every
+      // row were marked selected — which is a bug that looks identical from the
+      // chosen row alone.
+      for (final unchosen in ['Owner', 'Viewer']) {
+        expect(
+          tester.getSemantics(find.text(unchosen)),
+          // ignore: deprecated_member_use
+          containsSemantics(
+            label: unchosen,
+            hasSelectedState: true,
+            isSelected: false,
+            hasTapAction: true,
+          ),
+          reason: '$unchosen is not chosen',
+        );
+      }
+
+      semantics.dispose();
+    });
+
+    testWidgets('text mode — only the chosen row is selected', (tester) async {
+      final semantics = tester.ensureSemantics();
+      await pumpText(tester);
+      await tester.tap(find.byType(FlutterDropdownButton<Role>));
+      await tester.pumpAndSettle();
+
+      // The trigger shows 'Member' too, so scope the finder to the menu. `Ink`
+      // is the row's own surface and appears nowhere else — the menu is not
+      // always a `ListView` (three rows fit, so they are laid out in a Column).
+      Finder row(String name) =>
+          find.descendant(of: find.byType(Ink), matching: find.text(name));
+
+      expect(
+        tester.getSemantics(row('Member')),
+        // ignore: deprecated_member_use
+        containsSemantics(
+          label: 'Member',
+          hasSelectedState: true,
+          isSelected: true,
+          hasTapAction: true,
+        ),
+      );
+      expect(
+        tester.getSemantics(row('Owner')),
+        // ignore: deprecated_member_use
+        containsSemantics(
+          label: 'Owner',
+          hasSelectedState: true,
+          isSelected: false,
+          hasTapAction: true,
+        ),
+      );
+
+      semantics.dispose();
+    });
+
+    testWidgets(
+      'a checklist row stays checked and does not also claim to be selected',
+      (tester) async {
+        // Guard, not a regression test: `checked` is already emitted (#64/#81).
+        // What this pins is that the single-select word did not leak into the
+        // checklist — one vocabulary per cardinality.
+        final semantics = tester.ensureSemantics();
+        await pumpMulti(tester);
+        await tester.tap(find.byType(FlutterMultiSelectDropdown<Role>));
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getSemantics(find.text('Member')),
+          // ignore: deprecated_member_use
+          containsSemantics(
+            label: 'Member',
+            hasCheckedState: true,
+            isChecked: true,
+            isSelected: false,
+            hasTapAction: true,
+          ),
+        );
+
+        semantics.dispose();
+      },
+    );
+  });
+
+  group('what was already right stays right', () {
+    testWidgets('the bare anchor keeps the role it already announced', (
+      tester,
+    ) async {
+      // Guard. The bare path has carried `button`/`enabled` since #75; the
+      // issue proposed excluding it, which would have deleted working
+      // behaviour.
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: FlutterDropdownButton<Role>(
+                items: roles,
+                value: member,
+                minMenuWidth: 200,
+                itemBuilder: (role, isSelected) => Text(role.name),
+                anchorBuilder: (context, isOpen) => const Text('Anchor'),
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.text('Anchor')),
+        // ignore: deprecated_member_use
+        containsSemantics(
+          label: 'Anchor',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+          hasTapAction: true,
+        ),
+      );
+
+      semantics.dispose();
+    });
+
+    testWidgets('the merged trigger label survives the added role', (
+      tester,
+    ) async {
+      // Guard for #37: the announced string is the merge of the dropdown's
+      // `semanticsLabel` and the current value. Adding a role to that node must
+      // not split the node or replace the string.
+      final semantics = tester.ensureSemantics();
+      await pumpText(tester, semanticsLabel: 'Role picker');
+
+      expect(
+        tester.getSemantics(find.text('Member')),
+        // ignore: deprecated_member_use
+        containsSemantics(
+          label: 'Role picker\nMember',
+          isButton: true,
+          hasEnabledState: true,
+          isEnabled: true,
+        ),
+      );
+
+      semantics.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Closes #88.

The single-select path put neither role nor chosen-state into the semantics tree. The checklist had been doing it correctly since 3.1.0 — `Semantics(checked:)` on the row — and the same treatment simply never reached the other two presentations.

## Measured first, with a probe

Custom mode, three items, value = the 2nd. Before:

```
trigger (enabled)   label="Member"  flags=[isFocusable]  actions=[tap, focus]
trigger (disabled)  label="Member"  flags=[]             actions=[]
rows                all three       flags=[isFocusable]  actions=[tap, focus]
```

So the trigger claimed no role; a **disabled** dropdown was indistinguishable from decoration; and the three rows were byte-identical whichever one was the value — a distinction that existed only as `DropdownItemTheme.selectedColor`, i.e. only as a colour.

Text mode measured the same, which the issue had not checked.

## The issue's proposal was backwards, and its rationale was false

#88 suggested **excluding** the bare anchor. The bare path has announced `button`/`enabled` since #75; it was the chromed path that was silent. Its dartdoc credited the role to the ink well being "restored" — false in both paths: `material/ink_well.dart:1401` declares only `onTap`/`onLongPress`. What an `InkWell` *does* contribute is focusability, which the bare path lacks (filed as #91).

`documentation/api_reference.md` carried the same false sentence and is corrected here.

## Where each half goes, and why

- **The role is the shell's.** The anchor is the shell's own widget in the chromed path, and the shell wraps the caller's in the bare one.
- **The row's state is the presentation's.** The shell knows what `isChosen` answered but not what it *means*, so it cannot choose between `selected` and `checked` without knowing the cardinality — which is exactly what `CLAUDE.md` says it must not know. `buildItem`'s interface dartdoc now states the obligation, and `documentation/api_reference.md`'s interface table does too, since the interface is exported.

## Behaviour change

A caller who declares `selected` inside `itemBuilder` — a hand-rolled workaround for this bug — now **splits the row in two**. Measured: the row keeps `selected` and its tap action but loses its *label*, while the caller's node keeps the label and loses its actions. Any other property they declare (a label, a hint) merges as before. The remedy is to delete the workaround this makes redundant. In the CHANGELOG as a `CHANGE`.

## Tests

At the semantics tree, never the render tree — every assertion here passes under `find.text` while the tree says nothing (#37 is the precedent).

`containsSemantics`, matching the choice `multi_select_presentation_test.dart` had already reasoned out. An exhaustive matcher pins the host platform: `widgets/focus_scope.dart:723` emits the focus action only off-iOS, so the first version of this file went red under `TargetPlatform.iOS` — measured, after the adversarial pass caught it. Two files on one surface had reached opposite answers to the same question with opposite reasons; they now agree.

**Discriminating power:** reverting `lib/` takes six of eight red. The two that stay green are the two labelled guards (the bare anchor, and the checklist row proving `selected` did not leak into the checklist's vocabulary).

## ADR-0001

Second commit. #88 is the fourth issue against this one mechanism (#37, #64, #81), and two of theflow's promotion triggers fired in its pass — the reference contradicts itself across its own call sites (`dropdown.dart:246` gives a row `menuItem` and never `selected`; `list_tile.dart:997` emits `selected`), and two artifacts in this repo required opposite things. So the rule is written down instead of decided a fifth time. `docs/` is pubignored; none of it reaches the archive.

Three contradictions are adjudicated in the record rather than quietly fixed, and filed as conformance items under it: **#89** (a disabled dropdown still accepts a selection — a functional bug this change only makes *audible*), **#90** (the dismiss barrier is a full-screen unnamed tap node that the empty state names), **#91** (the trigger's contract is not one contract).

## Version

4.2.0 — new behaviour, no public member added or removed.

## Gates

`flutter analyze` 0 · `example/` analyze 0 · `dart format` 0 · **298 tests** · coverage **100.00% (1108/1108)** · `pub publish --dry-run` clean but for the dirty-tree warning.

## Downstream

`mobile_init_project` pins `^4.1.0` and holds **two tripwire tests** that pinned the absence of these flags on purpose, so they go red by design when this ships. Its `#26` is waiting on exactly this. That loop runs after release, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)