### PR TITLE
chore: keep the test suite out of the published archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ What is on screen reached everyone except the people who cannot see it. The trig
 * **CHANGE**: a disabled row now carries `enabled: false` in the semantics tree rather than merely losing its tap action. Dropping the action alone left a node still announcing a chosen state while saying nothing about being unavailable — half a node, which `docs/adr/0001` rule 3 exists to forbid. It stays focusable, unlike the trigger; rule 1's other half, that the row carries no role, is still open
 * **TEST**: asserted at `onChanged`, not at the tree — this is a functional contract, and the tree was only where it first became audible.
 
+### Packaging
+
+* **CHANGE**: the test suite is no longer in the published archive — `test/.pubignore`, the same treatment `docs/` and `tool/` already had. It is how the package is developed, not how it is used, and no consumer runs it. Archive: 526 KB → 475 KB compressed. `CLAUDE.md` deliberately stays: excluding a root file needs a root `.pubignore`, which disables `.gitignore`-based listing for the root directory, and this repo has already shipped `coverage/lcov.info` once with zero dry-run warnings
+
 ### One trigger, one contract (#91)
 
 * **FIX**: the trigger now announces whether its menu is **open**. Both anchor paths carry it. `isOpen` was already handed to `anchorBuilder` as "the one thing a caller cannot read for itself" — a screen-reader user is exactly that caller. It tracks the overlay entry, so it stays true for the close animation, which is deliberate: the menu is still on screen and the chevron a caller draws from the same flag is still turned

--- a/test/.pubignore
+++ b/test/.pubignore
@@ -1,0 +1,10 @@
+# The test suite is how this package is developed, not how it is used. It is a
+# third of the published archive and no consumer runs it — the same reasoning
+# that keeps `docs/` and `tool/` out.
+#
+# `CLAUDE.md` stays in, deliberately. Excluding a root file needs a root
+# `.pubignore`, and that disables `.gitignore`-based listing for the root
+# directory — every pattern in it would have to be restated by hand, and this
+# repo has already shipped `coverage/lcov.info` with zero dry-run warnings once.
+# Three kilobytes is not worth that trade.
+*


### PR DESCRIPTION
Found while looking at the archive one last time before publishing 4.2.0 — publishing is what makes an archive permanent, so this is the moment it is worth looking.

## Measured

`test/` was a third of what shipped, and no consumer runs it. `test/.pubignore` with `*`, matching what `docs/` and `tool/` already have.

| | |
|---|---|
| archive before | 526 KB compressed |
| archive after | **475 KB** |
| dry-run | 0 warnings, before and after |
| `test` as a top-level archive entry | gone |

## `CLAUDE.md` stays, on purpose

It is the same category — repo tooling with no value to an installer — but not the same cost. Excluding a **root** file needs a **root** `.pubignore`, and that disables `.gitignore`-based listing for the root directory: every pattern in the root `.gitignore` would have to be restated by hand or start shipping. `docs/agents/lessons.md` already records this repo shipping `coverage/lcov.info` with zero dry-run warnings, so "the dry run is clean" is not evidence here.

Three kilobytes does not buy that risk. The reasoning is written into `test/.pubignore` itself rather than only into this PR, so the next person considering it does not re-derive it — and finds the trap named before they trip it.

## Gates

`flutter analyze` 0 · `dart format` 0 · **325 tests** · `pub publish --dry-run` 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)