### PR TITLE
docs: say that the dismissing tap is consumed (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A highly customizable dropdown package for Flutter with overlay-based rendering,
 - **Overlay-based Rendering**: Better positioning and visual effects than Flutter's built-in DropdownButton
 - **Smart Positioning**: Automatically opens up/down based on available space
 - **Smooth Animations**: Scale and fade effects with configurable timing
-- **Outside-tap Dismissal**: Automatic closure when tapping outside
+- **Outside-tap Dismissal**: Automatic closure when tapping outside — the tap is consumed by the dismissal, so it does not also reach what is behind the menu (as in Material's `DropdownButton`)
 - **Reaches a Screen Reader**: The trigger announces its role, whether it is enabled and whether the menu is open; a chosen row says so (`selected`, or `checked` on the checklist). Keyboard-activatable in both chromed and bare mode
 - **Flexible Width**: Fixed, min/max constraints, content-based, or flex expansion
 - **Bare Anchor**: Drop the button chrome with `anchorBuilder` and embed the menu inside another field, `[All ▾] │ search…`
@@ -262,7 +262,8 @@ Give the user a way to clear it.
 
 A checklist. Several items may be chosen, the menu stays open while they are,
 and `onChanged` fires the moment a box is ticked. Anchored rather than modal:
-no scrim, dismissed by an outside tap.
+no scrim, dismissed by an outside tap — a tap the dismissal consumes, so it
+does not also reach what is behind the menu.
 
 Rows render as text, so `T` must be a `String` or `label` must say how to make
 one. `T` must implement `==` **and** `hashCode` consistently — a `Set` needs

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -35,6 +35,10 @@ FlutterDropdownButton<T>.text({
 
 Full parameter tables live in `README.md`. The two constructors share every layout, theming and search parameter; only the rendering parameters differ.
 
+### Outside-tap dismissal
+
+A tap outside an open menu closes it. **That tap is consumed by the dismissal and does not reach what is behind the menu** — activating a widget behind an open menu takes a second tap. Material's own `DropdownButton` behaves the same way: its `PopupRoute` mounts a dismissible, fully transparent `ModalBarrier`. This package follows it deliberately; the tap is not lost by accident.
+
 ### Statics
 
 | Member | Description |
@@ -133,7 +137,7 @@ Container(
 
 ## FlutterMultiSelectDropdown\<T\>
 
-A checklist. Several items may be chosen, the menu stays open while they are, and `onChanged` fires the moment a box is ticked — no confirm button. Anchored rather than modal: no scrim, dismissed by an outside tap.
+A checklist. Several items may be chosen, the menu stays open while they are, and `onChanged` fires the moment a box is ticked — no confirm button. Anchored rather than modal: no scrim, dismissed by an outside tap — a tap the dismissal consumes, so it does not also reach what is behind the menu.
 
 ```dart
 FlutterMultiSelectDropdown<T>({

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -22,7 +22,7 @@ import 'theme/tooltip_theme.dart';
 /// Features:
 /// - Smart positioning (opens up/down based on available space)
 /// - Smooth scale and opacity animations
-/// - Outside-tap dismissal
+/// - Outside-tap dismissal (the tap is consumed, not passed through)
 /// - Custom scrollbar theming
 /// - Scroll gradient indicators
 /// - Single-item mode (auto-disable when only one option)

--- a/lib/src/flutter_multi_select_dropdown.dart
+++ b/lib/src/flutter_multi_select_dropdown.dart
@@ -14,7 +14,8 @@ import 'theme/tooltip_theme.dart';
 ///
 /// Anchored rather than modal. There is no scrim and no confirm button — a tap
 /// on a row calls [onChanged] at once with a **new** `Set`, and an outside tap
-/// dismisses the menu.
+/// dismisses the menu. The dismissing tap is consumed, so it does not also
+/// reach what is behind the menu.
 ///
 /// ```dart
 /// FlutterMultiSelectDropdown<String>(


### PR DESCRIPTION
Four surfaces describe outside-tap dismissal. All four were silent on the fact
that the dismissing tap is **consumed** — it does not reach what is behind the
menu. This adds that fact; no behavior changes.

## Why this, and not a rewrite

#95 read `"anchored rather than modal, no scrim"` as a broken hit-test promise.
Opening the actual sentences shows it is not one — it sits in the multi-select
description and refers to UX (no dimming scrim, no confirm button, the menu
stays open while boxes are ticked). All three are true today. The issue's line
numbers had also drifted (`api_reference.md:102` → 136, `README.md:262` → 264).

The real defect was an **omission**, so the fix is additive.

## Measured

A throwaway widget test compared this package against Material's own
`DropdownButton` under identical conditions (Flutter 3.41.9, 800×600):

| | tap 1 | tap 2 |
|---|---|---|
| this package | menu closes, `behind=0` | `behind=1` |
| Material `DropdownButton` | route closes, `behind=0` | `behind=1` |

Identical. Material's `_DropdownRoute` is a `PopupRoute` with
`barrierDismissible = true` and `barrierColor => null` — a dismissible,
fully transparent `ModalBarrier`. Consuming the tap is the Material contract,
not an oversight here, so it is documented rather than "fixed".

## Scope

Only that one fact is documented. #95's two remaining symptoms — switching
between dropdowns costing two taps, and the menu not following its anchor while
open — are deliberately **not** written down, because both are live defects on
that issue and putting them in the contract would make fixing them breaking.

`CHANGELOG.md` is untouched: behavior did not change, so there is no `FIX`
entry to make. Two `lib/` files are touched, but only dartdoc — a pub.dev
surface, not behavior.

Refs #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
