### PR TITLE
fix: close() completes without a running ticker, open() survives a close in flight (#106, #107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 What is on screen reached everyone except the people who cannot see it. The trigger announced its current value and nothing about being a control; the chosen row was distinguished from its neighbours by `DropdownItemTheme.selectedColor` and by nothing else. The checklist had been doing this correctly since 3.1.0 — `Semantics(checked:)` on the row — and the single-select path simply never got the same treatment.
 
+Two contracts on `DropdownOverlayController` also rested on the same wrong idea — that the overlay entry's lifetime is the same thing as the menu being open. It is not: the entry outlives the close by exactly one animation, and that animation is not guaranteed to run. Both bugs are invisible through `FlutterDropdownButton` and `FlutterMultiSelectDropdown`, because the dismiss barrier keeps the pointer away from the trigger (#95); they surface on the third-party controller path the README advertises as "Build Your Own".
+
+### `close()` finishes without a running ticker (#106)
+
+* **FIX**: an open menu no longer strands itself over a pushed route. `close()` gated teardown on `_animation.reverse().then(…)`, and `ModalRoute` disables the `TickerMode` of the route below it — so the reverse started and never advanced. Measured: `anim=reverse v=1.00` unchanged after two seconds, the entry still mounted *above the new page*, and `page2Taps=0` on three consecutive taps. The page was dead until the user navigated back. Reproduced with no `Navigator` in the tree at all — a plain `TickerMode(enabled: false)` is the whole condition, so any caller who disables ticking hit it
+* **FIX**: `onOpenStateChanged(false)` now arrives in that case. It rode on the same teardown, so an owner drawing its trigger from the callback stayed drawn as open
+* **CHANGE**: the close animation is decoration, not the mechanism. A timer settles the teardown at `animationDuration` whichever way the ticker goes, and whichever of the two arrives first wins. Querying the tree instead was not available: `TickerMode.of` is deprecated after 3.35 and this repo's `flutter analyze` gate exits 1 on a single info, while `TickerMode.valuesOf` does not exist at the `>=3.32.0` floor — both CI jobs close that door from opposite sides
+
+### `open()` is no longer dropped mid-close (#107)
+
+* **FIX**: `closeAll()` immediately followed by `open()` shows the menu. `open()`'s guard is `if (isOpen) return`, and `isOpen` is `_entry != null`, which stays true for the whole close animation — so the call was a silent no-op and the close then completed. The caller asked for a menu and got none. A close in flight is now taken back instead
+* **TEST**: `overlay_close_contract_test.dart` pins both, including the route case end to end. Discriminating power confirmed by reverting `lib/`: five of six go red, and the one that stays green is the guard against "fixing" this by never closing at all
+
 ### The trigger and the chosen row reach the semantics tree (#88)
 
 * **FIX**: the trigger announces `button` and its enabled state. Measured before: `flags=[isFocusable] actions=[tap, focus]` — no role at all, and a *disabled* dropdown emitted `flags=[] actions=[]`, indistinguishable from something decorative. It is one `Semantics` on the node the `InkWell` already annotates, so the merged `semanticsLabel` contract is unchanged. Both widgets get it; they share the shell

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -37,7 +37,9 @@ Full parameter tables live in `README.md`. The two constructors share every layo
 
 ### Outside-tap dismissal
 
-A tap outside an open menu closes it. **That tap is consumed by the dismissal and does not reach what is behind the menu** — activating a widget behind an open menu takes a second tap. Material's own `DropdownButton` behaves the same way: its `PopupRoute` mounts a dismissible, fully transparent `ModalBarrier`. This package follows it deliberately; the tap is not lost by accident.
+A tap outside an open menu closes it. **That tap is consumed by the dismissal and does not reach what is behind the menu** — activating a widget behind an open menu takes a second tap. Material's own `DropdownButton` produces the same tap count, through a `PopupRoute` whose `ModalBarrier` is dismissible and fully transparent.
+
+The two are not the same mechanism, and the difference is observable. Material's barrier is `HitTestBehavior.opaque`, so nothing behind it is hit-tested at all. This package's is `translucent` and simply wins the gesture arena, so a widget behind an open menu **does** still receive the pointer — a `Listener` behind one fires its `onPointerDown` and `onPointerUp`; what it does not get is the tap.
 
 ### Statics
 
@@ -385,10 +387,10 @@ A working example lives in `example/lib/pages/domain_type_page.dart`.
 |--------|-------------|
 | `buttonKey` | Attach to the button so the controller can measure it |
 | `positioningKey` | A `GlobalKey` on an outer box to measure the menu against instead of `buttonKey`. Mutable; null measures the button. See [Positioning against an outer box](#positioning-against-an-outer-box) |
-| `isOpen` | Whether the menu is showing |
+| `isOpen` | Whether the menu is showing — true for the whole close animation too, since the entry is still mounted. `open()` accounts for that itself |
 | `animation` | Runs forward as the menu opens. Drive your own transitions from it — a rotating trailing icon, say |
-| `open(context)` | Shows the menu, closing whichever menu is open in the same `Overlay` |
-| `close({animate = true})` | Hides the menu. Pass `animate: false` to tear it down at once |
+| `open(context)` | Shows the menu, closing whichever menu is open in the same `Overlay`. Called while this menu is closing it takes the close back, so `closeAll()` then `open()` shows the menu |
+| `close({animate = true})` | Hides the menu. Pass `animate: false` to tear it down at once. The menu goes away either way — the animation is decoration, not the mechanism, so a disabled `TickerMode` (anything under a pushed route) cannot strand the entry |
 | `toggle(context)` | Opens if closed, closes if open |
 | `rebuild()` | Rebuilds and re-measures the menu in place. Not legal during a build — defer to a post-frame callback |
 | `dispose()` | Releases the animation and removes the overlay |

--- a/lib/src/overlay/dropdown_overlay_controller.dart
+++ b/lib/src/overlay/dropdown_overlay_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../buttons/menu_alignment.dart';
@@ -148,6 +150,16 @@ class DropdownOverlayController {
   BuildContext? _context;
   bool _disposed = false;
 
+  /// Whether a close is in flight.
+  ///
+  /// [isOpen] cannot answer this — it is `_entry != null`, and the entry lives
+  /// for the whole close animation. Kept separate so [open] can tell a menu
+  /// that is open from one that is on its way out.
+  bool _closing = false;
+
+  /// Settles a close whose animation never ticks. See [close].
+  Timer? _closeFallback;
+
   /// The open menu in each [Overlay], so opening one closes its neighbour.
   ///
   /// Keyed by Overlay rather than held in a single static field: two menus in
@@ -156,6 +168,11 @@ class DropdownOverlayController {
       {};
 
   /// Whether the menu is showing.
+  ///
+  /// True for the whole close animation as well — the entry is still mounted
+  /// and still painting. [open] accounts for that itself, so a call that lands
+  /// mid-close reopens rather than being dropped; a caller reading this to
+  /// decide whether to open does not have to.
   bool get isOpen => _entry != null;
 
   /// Runs forward as the menu opens and backward as it closes.
@@ -175,8 +192,23 @@ class DropdownOverlayController {
   ).animate(CurvedAnimation(parent: _animation, curve: Curves.easeOut));
 
   /// Shows the menu, closing whichever menu is open in the same [Overlay].
+  ///
+  /// Called while this menu is closing, it takes the close back and the menu
+  /// stays up — so `closeAll()` immediately followed by `open()` shows the
+  /// menu rather than silently doing nothing.
   void open(BuildContext context) {
-    if (isOpen) return;
+    if (isOpen) {
+      // A close in flight still counts as open, so without this the call is
+      // dropped and the menu the caller just asked for finishes closing
+      // instead. `closeAll()` immediately followed by `open()` — the obvious
+      // "close everything, then show mine" — is exactly that sequence.
+      if (!_closing) return;
+      _cancelClose();
+      _context = context;
+      _animation.forward();
+      rebuild();
+      return;
+    }
 
     final overlay = Overlay.of(context);
     _openPerOverlay[overlay]?.close();
@@ -195,6 +227,11 @@ class DropdownOverlayController {
   /// With [animate] true the close animation plays first, so the trailing icon
   /// rotates back. Pass false to tear the overlay down at once — the owner may
   /// be disposed before an animation could finish.
+  ///
+  /// The menu goes away either way. The animation is decoration, not the
+  /// mechanism: an owner whose `TickerMode` is disabled — anything under a
+  /// route that has been pushed over — would otherwise keep the entry mounted
+  /// forever, over the new page, swallowing every tap.
   void close({bool animate = true}) {
     if (!isOpen) return;
 
@@ -204,10 +241,36 @@ class DropdownOverlayController {
       return;
     }
 
+    _closing = true;
     _animation.reverse().then((_) {
       // The owner may have been disposed while the animation ran.
-      if (!_disposed && isOpen) _teardown();
+      if (!_disposed && _closing) _teardown();
     });
+
+    // The reverse only advances while the owner's `TickerMode` is enabled, and
+    // a route pushed over an open menu mutes it. Without this the entry stayed
+    // mounted *above the new page*, swallowing every tap, until the user
+    // navigated back — measured `page2Taps=0` three taps running (#106).
+    //
+    // Asking the tree whether the ticker runs is not open to us: `TickerMode.of`
+    // is deprecated after 3.35, and this repo's analyze gate exits 1 on a single
+    // info, while `TickerMode.valuesOf` does not exist at our 3.32 floor. Both
+    // CI jobs close that door from opposite sides. A timer is not ticker-gated,
+    // so it settles the teardown either way; whichever arrives first wins and
+    // `_cancelClose` makes the loser a no-op.
+    _closeFallback?.cancel();
+    _closeFallback = Timer(_animation.duration ?? Duration.zero, () {
+      if (!_disposed && _closing) {
+        _animation.reset();
+        _teardown();
+      }
+    });
+  }
+
+  void _cancelClose() {
+    _closing = false;
+    _closeFallback?.cancel();
+    _closeFallback = null;
   }
 
   /// Opens the menu if closed, closes it if open.
@@ -223,6 +286,7 @@ class DropdownOverlayController {
   /// Releases the animation and removes the overlay without animating.
   void dispose() {
     _disposed = true;
+    _cancelClose();
     // Silent: the owner is being torn down and must not be asked to rebuild.
     if (isOpen) _teardown(notify: false);
     _animation.dispose();
@@ -236,6 +300,7 @@ class DropdownOverlayController {
   }
 
   void _teardown({bool notify = true}) {
+    _cancelClose();
     try {
       _entry?.remove();
     } catch (_) {

--- a/test/overlay_close_contract_test.dart
+++ b/test/overlay_close_contract_test.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The controller's two lifetime contracts, both invisible through the widgets
+/// because the dismiss barrier keeps the pointer away from the trigger (#95).
+///
+/// - #106: `close()` promises to hide the menu. It gated teardown on an
+///   animation that need not tick, so a muted `TickerMode` — a pushed route is
+///   the common one — left the entry mounted forever.
+/// - #107: `isOpen` is `_entry != null`, which stays true for the whole close
+///   animation, so `open()` was a silent no-op while a close was in flight.
+
+class Bare extends StatefulWidget {
+  const Bare({super.key});
+
+  @override
+  State<Bare> createState() => BareState();
+}
+
+class BareState extends State<Bare> with SingleTickerProviderStateMixin {
+  late final DropdownOverlayController menu = DropdownOverlayController(
+    vsync: this,
+    spec: () => const DropdownOverlaySpec(
+      itemCount: 2,
+      actualItemHeight: 40,
+      maxDropdownHeight: 200,
+    ),
+    contentBuilder: (height) => const Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [Text('MENU-ROW'), Text('two')],
+    ),
+    decorationBuilder: () => null,
+  );
+
+  @override
+  void dispose() {
+    menu.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      key: menu.buttonKey,
+      onTap: () => menu.toggle(context),
+      child: const SizedBox(width: 120, height: 40, child: Text('open me')),
+    );
+  }
+}
+
+Finder menuRow() => find.text('MENU-ROW');
+
+void main() {
+  group('#106 — close() completes without a running ticker', () {
+    testWidgets('a muted TickerMode still tears the menu down', (tester) async {
+      var enabled = true;
+      late StateSetter setOuter;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                setOuter = setState;
+                return TickerMode(
+                  enabled: enabled,
+                  child: const Center(child: Bare()),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      final state = tester.state<BareState>(find.byType(Bare));
+
+      await tester.tap(find.text('open me'));
+      await tester.pumpAndSettle();
+      expect(menuRow(), findsOneWidget);
+
+      // No Navigator involved: muting the ticker is the whole condition.
+      setOuter(() => enabled = false);
+      await tester.pump();
+
+      state.menu.close();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(menuRow(), findsNothing, reason: 'the entry must be gone');
+      expect(state.menu.isOpen, isFalse);
+    });
+
+    testWidgets('the owner is told the menu closed', (tester) async {
+      // The state change is what a caller rebuilds on; a teardown that does
+      // not announce itself leaves the trigger drawn as if still open.
+      var closes = 0;
+      var enabled = true;
+      late StateSetter setOuter;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                setOuter = setState;
+                return TickerMode(
+                  enabled: enabled,
+                  child: Center(child: _Counting(onClosed: () => closes++)),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      final state = tester.state<_CountingState>(find.byType(_Counting));
+
+      await tester.tap(find.text('open me'));
+      await tester.pumpAndSettle();
+
+      setOuter(() => enabled = false);
+      await tester.pump();
+
+      state.menu.close();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(closes, 1);
+    });
+
+    testWidgets('a route pushed over an open menu does not lock the page', (
+      tester,
+    ) async {
+      var page2Taps = 0;
+      final navKey = GlobalKey<NavigatorState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navKey,
+          home: Scaffold(
+            body: Center(
+              child: FlutterDropdownButton<String>.text(
+                width: 150,
+                items: const ['Alpha 1', 'Alpha 2'],
+                hint: 'Alpha',
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      expect(find.text('Alpha 2'), findsOneWidget);
+
+      navKey.currentState!.push(
+        MaterialPageRoute<void>(
+          builder: (_) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => page2Taps++,
+                child: const Text('PAGE2'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The first tap may still be spent dismissing the menu — that is #95,
+      // not this contract. What must not happen is the page staying dead.
+      await tester.tap(find.text('PAGE2'), warnIfMissed: false);
+      // Not `pumpAndSettle`: the route mutes the ticker, so the close animation
+      // schedules no frame and a settle would return without moving the clock.
+      // The fallback timer is what has to fire here, and it needs real time.
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('Alpha 2'), findsNothing, reason: 'menu must be gone');
+
+      await tester.tap(find.text('PAGE2'));
+      await tester.pumpAndSettle();
+
+      expect(page2Taps, greaterThan(0), reason: 'the new page must be usable');
+    });
+  });
+
+  group('#107 — isOpen distinguishes open from closing', () {
+    testWidgets('open() during the close animation keeps the menu', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: Center(child: Bare())),
+        ),
+      );
+      final state = tester.state<BareState>(find.byType(Bare));
+
+      await tester.tap(find.text('open me'));
+      await tester.pumpAndSettle();
+
+      state.menu.close();
+      await tester.pump(const Duration(milliseconds: 100)); // mid-reverse
+
+      state.menu.open(tester.element(find.text('open me')));
+      await tester.pumpAndSettle();
+
+      expect(state.menu.isOpen, isTrue);
+      expect(menuRow(), findsOneWidget, reason: 'open() must not be dropped');
+    });
+
+    testWidgets('closeAll() then open() shows the menu', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: Center(child: Bare())),
+        ),
+      );
+      final state = tester.state<BareState>(find.byType(Bare));
+
+      await tester.tap(find.text('open me'));
+      await tester.pumpAndSettle();
+
+      // The documented "close everything, then show mine" idiom.
+      DropdownOverlayController.closeAll();
+      state.menu.open(tester.element(find.text('open me')));
+      await tester.pumpAndSettle();
+
+      expect(state.menu.isOpen, isTrue);
+      expect(menuRow(), findsOneWidget);
+    });
+
+    testWidgets('an ordinary close still closes', (tester) async {
+      // The guard against fixing #107 by never closing at all.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: Center(child: Bare())),
+        ),
+      );
+      final state = tester.state<BareState>(find.byType(Bare));
+
+      await tester.tap(find.text('open me'));
+      await tester.pumpAndSettle();
+      expect(menuRow(), findsOneWidget);
+
+      state.menu.close();
+      await tester.pumpAndSettle();
+
+      expect(state.menu.isOpen, isFalse);
+      expect(menuRow(), findsNothing);
+    });
+  });
+}
+
+class _Counting extends StatefulWidget {
+  const _Counting({required this.onClosed});
+
+  final VoidCallback onClosed;
+
+  @override
+  State<_Counting> createState() => _CountingState();
+}
+
+class _CountingState extends State<_Counting>
+    with SingleTickerProviderStateMixin {
+  late final DropdownOverlayController menu = DropdownOverlayController(
+    vsync: this,
+    spec: () => const DropdownOverlaySpec(
+      itemCount: 2,
+      actualItemHeight: 40,
+      maxDropdownHeight: 200,
+    ),
+    contentBuilder: (height) => const Text('MENU-ROW'),
+    decorationBuilder: () => null,
+    onOpenStateChanged: (isOpen) {
+      if (!isOpen) widget.onClosed();
+    },
+  );
+
+  @override
+  void dispose() {
+    menu.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      key: menu.buttonKey,
+      onTap: () => menu.toggle(context),
+      child: const SizedBox(width: 120, height: 40, child: Text('open me')),
+    );
+  }
+}


### PR DESCRIPTION
Two contracts on `DropdownOverlayController` rested on the same wrong idea: that
the overlay entry's lifetime is the same thing as the menu being open. It is not
— the entry outlives the close by exactly one animation, and that animation is
not guaranteed to run.

Closes #106. Closes #107.

## #106 — `close()` finishes without a running ticker

`close()` gated teardown on `_animation.reverse().then(…)`. `ModalRoute` disables
the `TickerMode` of the route below it, so a route pushed over an open menu left
the reverse started and never advancing:

```
after push   menuMounted=true page2Found=true tickerMuted=true
tap PAGE2    page2Taps=0  anim=reverse v=1.00
+2s          page2Taps=0  anim=reverse v=1.00  menuRowFound=true
```

The entry stayed mounted **above the new page** and swallowed every tap. The page
was dead until the user navigated back.

**No `Navigator` is required.** A plain `TickerMode(enabled: false)` reproduces it
exactly, which is what makes the regression test cheap and the root honest:
`close()` promises to hide the menu, and with a muted ticker it did not.

The fix races the teardown against a timer, which is not ticker-gated; whichever
arrives first wins and `_cancelClose` makes the loser a no-op. The animation
stays exactly what it was — decoration.

**Asking the tree instead was not available, and that is measured, not assumed.**
`TickerMode.of` is deprecated after 3.35 and this repo's analyze gate exits 1 on
a single info — verified by running the gate while a probe still used it:

```
info - 'of' is deprecated ... Use TickerMode.valuesOf ... deprecated_member_use
1 issue found.        exit=1
```

and `TickerMode.valuesOf` does not exist at the `>=3.32.0` floor. Both CI jobs
close that door from opposite sides.

## #107 — `open()` is no longer dropped mid-close

`open()`'s guard is `if (isOpen) return`, and `isOpen` is `_entry != null`, true
for the whole close animation. So `closeAll()` immediately followed by `open()`
— the obvious "close everything, then show mine" — was a silent no-op, and the
close then completed. The caller asked for a menu and got none.

```
midClose        isOpen=true
rightAfterOpen  isOpen=true      ← the call was dropped
settled         isOpen=false visible=false
```

A close in flight is now taken back. `isOpen`'s public meaning is unchanged, so
this is not breaking; the dartdoc now says what it covers.

## Why neither showed up before

Both are invisible through `FlutterDropdownButton` and
`FlutterMultiSelectDropdown`: the dismiss barrier keeps the pointer away from the
trigger (#95), so the sequences that reach them cannot be typed by a user. They
surface on the third-party controller path the README advertises as "Build Your
Own" — the class `docs/agents/theflow.md` marks as sacred precisely because its
blast radius is the consumer's whole app.

## Proof

`test/overlay_close_contract_test.dart`, six tests. Discriminating power
confirmed by `git stash push -- lib/` **before** committing (a stash after a
commit is silently empty — `lessons.md`): five of six go red, and the one that
stays green is the guard against "fixing" #107 by never closing at all.

Gates, each run bare: `flutter analyze` 0 · 331 tests pass · coverage
100.00% (1149/1149) · `example/` analyze 0 · `dart format --set-exit-if-changed`
0 · `flutter pub publish --dry-run` **0 warnings**.

## Version

Folded into the **unreleased 4.2.0** entry rather than opening 4.2.1. The
registry is the authority and it says the latest published version is `4.1.0`:

```
$ curl -s https://pub.dev/api/packages/flutter_dropdown_button
latest published: 4.1.0
all versions: 3.0.1, 3.0.2, 3.1.0, 3.2.0, 4.0.0, 4.1.0
```

so 4.2.0's notes were never snapshotted and are still open to edit. Opening 4.2.1
would have made pub.dev jump 4.1.0 → 4.2.1 and orphan the 4.2.0 notes. The
`publish --dry-run` hint is what surfaced this.

## Not in scope

#95 (switching dropdowns costs two taps) and #103 (the menu does not follow its
anchor) are untouched; so is the open question on spine #105 about whether the
barrier should consume the tap at all. #106 was fixed first on purpose — the
barrier's consumption was *masking* the lockup, so changing consumption first
would have mixed the two effects and cost the regression test its discriminating
power.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
