### PR TITLE
docs: an outside tap is scoped to the hosting Overlay, and pin it

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A highly customizable dropdown package for Flutter with overlay-based rendering,
 - **Overlay-based Rendering**: Better positioning and visual effects than Flutter's built-in DropdownButton
 - **Smart Positioning**: Automatically opens up/down based on available space
 - **Smooth Animations**: Scale and fade effects with configurable timing
-- **Outside-tap Dismissal**: Automatic closure when tapping outside — the tap is consumed by the dismissal, so it does not also reach what is behind the menu (as in Material's `DropdownButton`)
+- **Outside-tap Dismissal**: Automatic closure when tapping outside the menu, anywhere inside its `Overlay` — the tap is consumed by the dismissal, so it does not also reach what is behind the menu (as in Material's `DropdownButton`)
 - **Reaches a Screen Reader**: The trigger announces its role, whether it is enabled and whether the menu is open; a chosen row says so (`selected`, or `checked` on the checklist). Keyboard-activatable in both chromed and bare mode
 - **Flexible Width**: Fixed, min/max constraints, content-based, or flex expansion
 - **Bare Anchor**: Drop the button chrome with `anchorBuilder` and embed the menu inside another field, `[All ▾] │ search…`

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -41,6 +41,8 @@ A tap outside an open menu closes it. **That tap is consumed by the dismissal an
 
 The two are not the same mechanism, and the difference is observable. Material's barrier is `HitTestBehavior.opaque`, so nothing behind it is hit-tested at all. This package's is `translucent` and simply wins the gesture arena, so a widget behind an open menu **does** still receive the pointer — a `Listener` behind one fires its `onPointerDown` and `onPointerUp`; what it does not get is the tap.
 
+**"Outside" means outside the menu but inside its `Overlay`.** The dismissing region is the size of the `Overlay` the menu was inserted into, not the size of the screen — so in a layout that nests an `Overlay` inside part of the screen (a side panel that owns its own), a tap landing *beyond that panel* does not dismiss. Measured on a 400×600 panel offset to `left: 400`: a tap at (100, 300) leaves the menu open, one at (600, 300) closes it. Everywhere the menu itself can be seen, an outside tap dismisses; the gap is only the region the hosting `Overlay` never covered. `DropdownOverlayController.closeAll()` is the way to dismiss from outside that region — it reaches every `Overlay`.
+
 ### Statics
 
 | Member | Description |

--- a/test/overlay_bounds_test.dart
+++ b/test/overlay_bounds_test.dart
@@ -101,4 +101,93 @@ void main() {
     );
     expect(menu.left, greaterThanOrEqualTo(0));
   });
+
+  testWidgets('"outside" is scoped to the hosting Overlay', (tester) async {
+    // Characterisation, not a defect: the dismiss barrier is `SizedBox.expand`
+    // inside the entry, so it fills the theatre of whatever `Overlay.of` gave
+    // it — a nested one covers only its own box. `documentation/api_reference.md`
+    // states this, and these are the numbers it quotes.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                left: 400,
+                top: 0,
+                width: 400,
+                height: 600,
+                child: Overlay(
+                  initialEntries: [
+                    OverlayEntry(
+                      builder: (_) => Align(
+                        alignment: Alignment.topLeft,
+                        child: dropdown(),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await openAndMeasureMenu(tester);
+    expect(find.byType(ListView), findsOneWidget);
+
+    // Beyond the hosting Overlay: the barrier was never there to be tapped.
+    await tester.tapAt(const Offset(100, 300));
+    await tester.pumpAndSettle();
+    expect(
+      find.byType(ListView),
+      findsOneWidget,
+      reason: 'a tap outside the hosting Overlay does not reach the barrier',
+    );
+
+    // Inside it, outside the menu: dismisses, as documented.
+    await tester.tapAt(const Offset(600, 300));
+    await tester.pumpAndSettle();
+    expect(find.byType(ListView), findsNothing);
+  });
+
+  testWidgets('closeAll reaches a menu the outside tap cannot', (tester) async {
+    // The documented way out of the gap the previous test pins.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                left: 400,
+                top: 0,
+                width: 400,
+                height: 600,
+                child: Overlay(
+                  initialEntries: [
+                    OverlayEntry(
+                      builder: (_) => Align(
+                        alignment: Alignment.topLeft,
+                        child: dropdown(),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await openAndMeasureMenu(tester);
+    await tester.tapAt(const Offset(100, 300));
+    await tester.pumpAndSettle();
+    expect(find.byType(ListView), findsOneWidget);
+
+    DropdownOverlayController.closeAll();
+    await tester.pumpAndSettle();
+    expect(find.byType(ListView), findsNothing);
+  });
 }


### PR DESCRIPTION
`README.md:17` and `documentation/api_reference.md` promise that a tap outside an
open menu dismisses it. In a layout that nests an `Overlay` inside part of the
screen — a side panel that owns its own, which
`test/overlay_bounds_test.dart` already covers as a supported host — that is not
true beyond the panel.

## Measured

400×600 panel offset to `left: 400`:

```
opened                                  = true
tap OUTSIDE the hosting Overlay (100,300) -> menu open   = true
tap INSIDE  the hosting Overlay (600,300) -> menu open   = false
```

The dismiss barrier is `SizedBox.expand` **inside the overlay entry**
(`dropdown_overlay_controller.dart:325`), so it fills the theatre of whatever
`Overlay.of(context)` returned at open time — a nested `Overlay` covers only its
own box. Beyond it there is no barrier to tap.

## The code is right; the sentence was

Nothing in `lib/` changes. This is the same shape as #59: the broken invariant
was the documentation, not the implementation. The gap is only the region the
hosting `Overlay` never covered, and everywhere the menu itself can be seen an
outside tap still dismisses — so the behaviour is defensible, it just was not
written down.

`README.md` gains four words. `api_reference.md` gains a paragraph with the
numbers above and points at `DropdownOverlayController.closeAll()`, which reaches
every `Overlay` and is the way out of that region.

## Pinned

Two characterisation tests in `test/overlay_bounds_test.dart` — the file that
already owns the nested-`Overlay` harness. One asserts the documented asymmetry
with the exact coordinates the docs quote; the other asserts `closeAll()` closes
a menu the outside tap cannot reach, so the documented escape hatch cannot rot
silently.

They are characterisation, not regression: they pin behaviour that was always
there and is now described. Reverting `lib/` would not turn them red, and that is
the point — there is no defect under them.

## Provenance

Found while reproducing the residual candidates from #95's Step 5 completeness
pass. Verified pre-existing by re-running the probe against `86932b2` (the commit
before #108): byte-identical output, so none of it came from that fix. The full
residual list, including the four candidates that turned out **not** to be
defects, is recorded on spine #105.

No `CHANGELOG.md` entry: behaviour did not change, and the sentence being
corrected belongs to the still-unreleased 4.2.0 section.

Refs #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
