### PR TITLE
docs: the search field follows enabled, not the item count (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The unified dropdown widget. Use the default constructor for custom widget rende
 | `maxMenuWidth` | `double?` | `null` | Maximum width of dropdown menu |
 | `menuAlignment` | `MenuAlignment` | `.left` | Menu alignment when wider than button |
 | `theme` | `DropdownStyleTheme?` | `null` | Theme configuration |
-| `searchable` | `bool` | `false` | Enable search/filter field in dropdown |
+| `searchable` | `bool` | `false` | Enable search/filter field in dropdown — the field follows `enabled`, not the item count, so it stays live over an empty list |
 | `searchFilter` | `bool Function(T, String)?` | `null` | Custom filter function (required for custom mode) |
 | `emptyBuilder` | `Widget Function(String)?` | `null` | Builder for the empty state — empty item list, or no search matches (the query is `""` when the list itself is empty) |
 | `anchorBuilder` | `Widget Function(BuildContext, bool isOpen)?` | `null` | Draw the anchor yourself, dropping the button chrome (**bare** mode) — see below |

--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -80,6 +80,15 @@ What is **not** here: the open menu is not navigated by arrow keys, Escape does
 not close it, and there is no type-ahead. The anchor is keyboard-activatable;
 the menu is not keyboard-driven.
 
+### The search field
+
+`searchable: true` puts a text field at the top of the menu. **Its enabled state follows the control's, never the item count.** It goes dead when `enabled` is false — the field is part of the control, and before that it stayed focused and accepted typing for the whole close animation, leaving a soft keyboard over a disabled dropdown. It stays live on an empty list.
+
+So a menu opened over `items: []` shows a working search field above "No items", and one whose query matches nothing keeps the field that got it there. Both are deliberate. Emptiness is not a reason to disable, for two reasons:
+
+- **A list can be empty in transit.** A caller loading items asynchronously has `items: []` for the first frames. A field that disabled itself there would drop the focus mid-keystroke and dismiss the soft keyboard, and nothing would give either back when the items arrived — the field is focused on open, and an open menu never re-focuses it.
+- **The empty state already says it.** "There is nothing to search" is the job of `emptyBuilder`, or of the default "No items", which carries a semantics node of its own so a screen reader announces it apart from the field. A disabled field would say only that search is unavailable, and not why.
+
 ### A value that is not in `items`
 
 The button draws `value` whether or not `items` still offers it. A list refresh can drop the chosen row's data while `value` still names it; the button keeps showing it, the menu draws no row for it, and nothing throws.

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -330,6 +330,10 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   ///
   /// The search field appearance can be customized via [DropdownStyleTheme.search].
   ///
+  /// The field follows [enabled], not the item count: it stays live over an
+  /// empty list, so a caller loading items asynchronously does not lose the
+  /// focus and the soft keyboard while they arrive.
+  ///
   /// Defaults to false.
   final bool searchable;
 

--- a/lib/src/flutter_multi_select_dropdown.dart
+++ b/lib/src/flutter_multi_select_dropdown.dart
@@ -172,6 +172,10 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
   ///
   /// The query survives a tick: the menu does not close, and only opening and
   /// closing reset it.
+  ///
+  /// The field follows [enabled], not the item count: it stays live over an
+  /// empty list, so a caller loading items asynchronously does not lose the
+  /// focus and the soft keyboard while they arrive.
   final bool searchable;
 
   /// Overrides the default case-insensitive `contains` over each item's label.


### PR DESCRIPTION
Documents a behavior that was written down nowhere, and records the decision behind it. **No behavior change** — `lib/` gains dartdoc only.

## Why

`#112` asked whether the search field should disable itself over an empty list. It came out of #96's Step 5 completeness pass, which found a live `TextField` semantics node (`label="Search..."`, full action set) above an empty menu and could not adjudicate it from the sources — because no source said anything. The field's enabled state is `enabled: widget.enabled` in the shell with a measured rationale in a code comment, and **no public surface mentioned it, or that the item count is not an input.**

## The decision: it stays enabled

- **A list is empty in transit.** A caller loading items asynchronously has `items: []` for the first frames. A field that disabled itself there would drop the focus mid-keystroke and dismiss the soft keyboard, and nothing would give either back — the field is focused in `_openDropdown()`, and an open menu never re-focuses it.
- **The empty state already says it.** Since #96 the empty state carries a semantics node of its own, so a screen reader announces "No items" apart from the field. A disabled field would say only that search is unavailable, and not why.
- **The same branch serves both emptinesses.** `items.isEmpty` in the shell covers an empty source list *and* a query that matched nothing. Disabling on it would trap a user behind their own query with no way to backspace out.

## Surfaces

| Surface | Change |
|---|---|
| `documentation/api_reference.md` | new `### The search field` section — the home for the contract and its reasons |
| `lib/src/flutter_dropdown_button.dart` | `searchable` dartdoc (pub.dev surface) |
| `lib/src/flutter_multi_select_dropdown.dart` | same |
| `README.md` | `searchable` parameter row |

No `CHANGELOG.md` entry and no version bump: nothing about the package's behavior is different, and none of the TYPEs fit a documentation-only addition.

## Gates

`flutter analyze` clean · `flutter test` 344 passed · `dart format` clean on both touched Dart files · `pub publish --dry-run` warns only about the (then) uncommitted tree.

Refs #112 — closed separately as a decision, not as a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)