### PR TITLE
docs: the two controller members that fail silently (#95, #103)

### DIFF
--- a/documentation/api_reference.md
+++ b/documentation/api_reference.md
@@ -385,19 +385,39 @@ class _MyDropdownState extends State<MyDropdown>
   );
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Keeps the scroll dismissal alive across a theme or devicePixelRatio
+    // change, which rebuilds the surrounding Scrollable's position.
+    _menu.refreshScrollables(context);
+  }
+
+  @override
   void dispose() {
     _menu.dispose();
     super.dispose();
   }
 
   @override
-  Widget build(BuildContext context) => InkWell(
-        key: _menu.buttonKey,
-        onTap: () => _menu.toggle(context),
-        child: ...,
-      );
+  Widget build(BuildContext context) {
+    // Read by another dropdown's barrier, so it can tell an anchor that would
+    // act on a tap from one that would not.
+    _menu.triggerEnabled = widget.enabled;
+    return InkWell(
+      key: _menu.buttonKey,
+      onTap: widget.enabled ? () => _menu.toggle(context) : null,
+      child: ...,
+    );
+  }
 }
 ```
+
+Both of the additions above are optional in the sense that nothing throws
+without them — and both fail silently, which is why they are in the example
+rather than in a footnote. Skip `refreshScrollables` and the scroll dismissal
+dies the first time the theme changes; skip `triggerEnabled` and a neighbouring
+menu stands down over your disabled anchor, leaving its own menu open under a
+tap that did nothing.
 
 A working example lives in `example/lib/pages/domain_type_page.dart`.
 
@@ -418,12 +438,14 @@ A working example lives in `example/lib/pages/domain_type_page.dart`.
 |--------|-------------|
 | `buttonKey` | Attach to the button so the controller can measure it |
 | `positioningKey` | A `GlobalKey` on an outer box to measure the menu against instead of `buttonKey`. Mutable; null measures the button. See [Positioning against an outer box](#positioning-against-an-outer-box) |
+| `triggerEnabled` | Whether your anchor currently accepts a tap. Mutable, set it from your own `build`. Another dropdown's dismiss barrier reads it to decide whether to stand down over your anchor, and must not stand down over one that would do nothing with the tap. Defaults to true, so a controller that never sets it behaves as an enabled anchor |
 | `isOpen` | Whether the menu is showing — true for the whole close animation too, since the entry is still mounted. `open()` accounts for that itself |
 | `animation` | Runs forward as the menu opens. Drive your own transitions from it — a rotating trailing icon, say |
 | `open(context)` | Shows the menu, closing whichever menu is open in the same `Overlay`. Called while this menu is closing it takes the close back, so `closeAll()` then `open()` shows the menu |
 | `close({animate = true})` | Hides the menu. Pass `animate: false` to tear it down at once. The menu goes away either way — the animation is decoration, not the mechanism, so a disabled `TickerMode` (anything under a pushed route) cannot strand the entry |
 | `toggle(context)` | Opens if closed, closes if open |
 | `rebuild()` | Rebuilds and re-measures the menu in place. Not legal during a build — defer to a post-frame callback |
+| `refreshScrollables(context)` | Re-reads the scrollables your anchor sits in, so the scroll dismissal keeps working. Call it from your `State.didChangeDependencies`: a `Scrollable` rebuilds its position from its own, disposing the old one, and an open menu would be left listening to a dead object with no leak or exception to show for it. A no-op while closed |
 | `dispose()` | Releases the animation and removes the overlay |
 | `closeAll({animate = true})` (static) | Closes every open menu, in every `Overlay` |
 

--- a/example/lib/pages/domain_type_page.dart
+++ b/example/lib/pages/domain_type_page.dart
@@ -131,6 +131,16 @@ class _ColourMenuButtonState extends State<_ColourMenuButton>
   );
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // A surrounding Scrollable rebuilds its scroll position from its own
+    // didChangeDependencies — a theme change is enough — and an open menu would
+    // be left listening to the disposed one, its scroll dismissal silently
+    // dead. Nothing throws without this line; it just stops working.
+    _menu.refreshScrollables(context);
+  }
+
+  @override
   void dispose() {
     _menu.dispose();
     super.dispose();

--- a/lib/src/overlay/dropdown_overlay_controller.dart
+++ b/lib/src/overlay/dropdown_overlay_controller.dart
@@ -108,7 +108,19 @@ typedef DropdownOverlaySpecBuilder = DropdownOverlaySpec Function();
 ///   decorationBuilder: () => null,
 ///   onOpenStateChanged: (_) => setState(() {}),
 /// );
+///
+/// @override
+/// void didChangeDependencies() {
+///   super.didChangeDependencies();
+///   _menu.refreshScrollables(context);
+/// }
 /// ```
+///
+/// Two members fail *silently* if an owner skips them, which is why they are in
+/// the sketch above rather than only in the member list: without
+/// [refreshScrollables] the scroll dismissal dies the first time the theme
+/// changes, and without [triggerEnabled] a neighbouring menu stands down over a
+/// disabled anchor and stays open under a tap that did nothing.
 class DropdownOverlayController {
   /// Creates a controller. Call [dispose] from the owner's `dispose`.
   DropdownOverlayController({


### PR DESCRIPTION
`triggerEnabled` (#95) and `refreshScrollables` (#103) were added to an **exported** class that `README.md:29` advertises as *"Build Your Own"* — and neither reached the member table in `documentation/api_reference.md`. A third party driving their own `DropdownOverlayController` had no way to discover either.

## Why they get the worked example, not a footnote

Both **fail silently**, which is the whole reason this is worth a PR rather than two table rows:

| Skipped | What happens |
|---|---|
| `refreshScrollables` | the scroll dismissal dies the first time the theme changes — no leak, no exception, because removing a listener from a disposed notifier is legal |
| `triggerEnabled` | a neighbouring menu stands down over your disabled anchor and stays open under a tap that did nothing |

Neither is discoverable by watching for a crash. So they go in the code you copy.

## Surfaces

- the `### Members` table
- the `### Usage` sketch
- the **class dartdoc**, which ships verbatim to pub.dev
- `example/lib/pages/domain_type_page.dart` — which `api_reference.md` cites as *"a working example"*, so it has to actually demonstrate what it is cited for

## Checked and clean, rather than assumed

`theming.md`, `text_configuration.md`, `migration.md` and `use_cases.md` say nothing about dismissal or the controller's members. `README.md` carries only the one-line pointer. The `environment` floor is untouched — nothing here is newer than the 3.32.0 promise. `.pubignore` is unaffected.

No behavior change and no `CHANGELOG.md` entry: both members are already named in the 4.2.0 entries that introduced them.

Gates: analyze clean · `example/` analyze clean · 362 tests · format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)