### PR TITLE
docs: retract a 4.2.0 headnote claim that ADR 0002 falsified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Two contracts on `DropdownOverlayController` also rested on the same wrong idea 
 
 And the empty state kept a smaller half-truth of its own: `emptyBuilder`, documented as the builder for when the menu has nothing to show, was reachable only through a search that matched nothing — the emptiest menu of all, an empty source list, called nothing and opened as a chrome-only sliver (#96).
 
-Two of this release's fixes come from the same wrong idea about the barrier and the menu it covers: that placing a menu once is the end of the story. Scrolling the page behind an open menu left it floating over whatever had moved underneath it, anchored to nothing, in every configuration measured — finger and mouse wheel alike (#103).
+A menu also turned out to be placed once and then forgotten. Scroll the page behind an open one and the content moved while the menu stayed — floating over whatever had slid underneath it, anchored to nothing, on a finger and a mouse wheel alike. That one *looked* like a barrier problem and was not: the fix touches neither the barrier nor hit-testing, and the obvious barrier-shaped remedy would have stopped the background scrolling altogether (#103).
 
 The dismiss barrier turns out to have been charging for something the package advertises. Putting several dropdowns on a page and having only one open at a time is a documented feature, but swapping between them cost two taps, because the barrier joined the gesture arena ahead of the trigger the user was aiming at. Two of this release's tests had a retry branch written around exactly that (#95).
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ A checklist. Several items may be chosen, the menu stays open while they are,
 and `onChanged` fires the moment a box is ticked. Anchored rather than modal:
 no scrim, dismissed by an outside tap — a tap the dismissal consumes, so it
 does not also reach what is behind the menu. Another dropdown's trigger is the
-one exception, and swaps the two menus in a single tap.
+one exception, and swaps the two menus in a single tap. Scrolling the content
+around the menu dismisses it too, rather than leaving it at coordinates its
+anchor has scrolled away from.
 
 Rows render as text, so `T` must be a `String` or `label` must say how to make
 one. `T` must implement `==` **and** `hashCode` consistently — a `Set` needs


### PR DESCRIPTION
The 4.2.0 headnote claimed two of this release's fixes *"come from the same wrong idea about the barrier and the menu it covers: that placing a menu once is the end of the story."* **Both halves are false**, and the record that falsified them was written after the sentence.

- **#103's root is not the barrier.** The fix touches neither it nor hit-testing, and the obvious barrier-shaped remedy — a drag recognizer on the barrier — would have been *actively wrong*: it wins the arena first and stops the background scrolling altogether.
- **#95's root is not "placing once."** It is the barrier's ordering in the gesture arena.

ADR 0002 records exactly this as the spine hypothesis it falsifies. Leaving the headnote would have shipped release notes teaching the idea the decision record exists to retire.

`CHANGELOG.md` is snapshotted at publish and 4.2.0 is unpublished, so this corrects an open entry rather than rewriting a shipped one.

Also fills a `README.md` gap: the multi-select section restates the dismissal contract and listed the sibling-trigger exception but **not** the scroll dismissal, while the widget's own dartdoc carried both.

No behavior change. Gates: analyze clean · 362 tests · format clean · `pub publish --dry-run` 0 warnings once committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)