### PR TITLE
feat: the playground gains a multi-select mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       # Same rule as the floor above, and for the same reason: raise it when the
       # number rises, never lower it to make a red build green.
       - name: API coverage floor
-        run: dart run tool/check_api_coverage.dart --min 70.0 --report
+        run: dart run tool/check_api_coverage.dart --min 75.9 --report
 
       # Three steps rather than one `run: |` block, on purpose. A block's exit
       # status depends on the runner's shell flags to stop at the first failure;

--- a/example/lib/pages/playground_page.dart
+++ b/example/lib/pages/playground_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
 
-enum DropdownType { text, custom }
+enum DropdownType { text, custom, multi }
 
 class PlaygroundPage extends StatefulWidget {
   const PlaygroundPage({super.key});
@@ -13,6 +13,10 @@ class PlaygroundPage extends StatefulWidget {
 class _PlaygroundPageState extends State<PlaygroundPage> {
   // ── Dropdown type ───────────────────────────────────────────────────────
   DropdownType _type = DropdownType.text;
+
+  /// The checklist mode holds a set rather than a value, and the page holds
+  /// it — `selected` is the caller's in this package, playground included.
+  Set<String> _multiSelected = {};
 
   // ── Items ───────────────────────────────────────────────────────────────
   List<String> _items = ['Option 1', 'Option 2', 'Option 3', 'Option 4'];
@@ -554,11 +558,16 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
                       value: DropdownType.custom,
                       label: Text('custom'),
                     ),
+                    ButtonSegment(
+                      value: DropdownType.multi,
+                      label: Text('multi'),
+                    ),
                   ],
                   selected: {_type},
                   onSelectionChanged: (v) => setState(() {
                     _type = v.first;
                     _selectedValue = null;
+                    _multiSelected = {};
                   }),
                 ),
               ),
@@ -1775,6 +1784,45 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
               item.toLowerCase().contains(query.toLowerCase()),
           itemBuilder: (item, isSelected) => Text(item),
           onChanged: (v) => setState(() => _selectedValue = v),
+        );
+
+      case DropdownType.multi:
+        // Every knob the other two modes read, read here too. The check counts
+        // per constructor, and it is right to: `.text()` gains overflow
+        // handling, a tooltip and a default filter that this one cannot offer,
+        // so a `width` proven on that constructor says nothing about this one.
+        return FlutterMultiSelectDropdown<String>(
+          items: _items,
+          selected: _multiSelected,
+          labelBuilder: (chosen) => switch (chosen.length) {
+            0 => _hint,
+            1 => chosen.first,
+            final n => '$n selected',
+          },
+          width: _fixedWidth,
+          minWidth: _minWidth,
+          maxWidth: _maxWidth,
+          height: _height,
+          itemHeight: _itemHeight,
+          enabled: _enabled,
+          expand: _expand,
+          animationDuration: Duration(milliseconds: _animationMs),
+          theme: theme,
+          config: config,
+          trailing: trailing,
+          minMenuWidth: _minMenuWidth,
+          maxMenuWidth: _maxMenuWidth,
+          menuAlignment: _menuAlignment,
+          searchable: _searchable,
+          searchFilter: (item, query) =>
+              item.toLowerCase().contains(query.toLowerCase()),
+          emptyBuilder: (query) => Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              query.isEmpty ? 'No items' : 'Nothing matching "$query"',
+            ),
+          ),
+          onChanged: (next) => setState(() => _multiSelected = next),
         );
     }
   }


### PR DESCRIPTION
Slice 4 of 6 from [the map](https://github.com/kihyun1998/flutter_dropdown_button/issues/122).

`FlutterMultiSelectDropdown` was the worst-covered constructor at **12/26** — not because the widget is neglected, but because the only surface with knobs had two modes and neither was a checklist. Thirteen of its parameters had zero uses anywhere.

A third `DropdownType` value rather than a second page: the settings panel is reused whole, and a separate multi-select playground would fork ~2000 lines of knob wiring into two places that drift.

**The mode reads every knob the other two do**, which is not redundancy. The check counts per constructor and is right to — `.text()` gains overflow handling, a tooltip and a default filter this one structurally cannot offer, so a `width` proven there says nothing about this one.

## Coverage

**142/203 → 154/203 (75.9%)**. `.text()` is now **31/31** and `FlutterMultiSelectDropdown` **26/26**. The seven that remain are all on the default constructor — slice 5.

## The gate caught me

The floor was first written as `76.0`, read off a rounded report. The real number is 75.86%, and the gate rejected it immediately — the rounding fix from slice 1 working in the other direction.

## Gates

All nine bare. `dart format` red on `test/search/dropdown_search_controller_test.dart`, which `main` fails identically (#120).

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuRC5vXeddLybiNXXkbJto