### PR TITLE
feat: custom mode passes the knobs the page already drew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       # Same rule as the floor above, and for the same reason: raise it when the
       # number rises, never lower it to make a red build green.
       - name: API coverage floor
-        run: dart run tool/check_api_coverage.dart --min 75.9 --report
+        run: dart run tool/check_api_coverage.dart --min 79.3 --report
 
       # Three steps rather than one `run: |` block, on purpose. A block's exit
       # status depends on the runner's shell flags to stop at the first failure;

--- a/example/lib/pages/playground_page.dart
+++ b/example/lib/pages/playground_page.dart
@@ -57,6 +57,7 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
   double _itemHeight = 48;
   bool _enabled = true;
   bool _scrollToSelected = true;
+  int _scrollToSelectedMs = 300;
   int _animationMs = 200;
   bool _useCustomTrailing = false;
   double _trailingSize = 20;
@@ -601,6 +602,16 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
           'scrollToSelectedItem',
           _scrollToSelected,
           (v) => setState(() => _scrollToSelected = v),
+        ),
+        // The duration is meaningless without the flag above, so it sits with
+        // it rather than in the geometry section.
+        _sliderRow(
+          'scrollToSelectedDuration (ms)',
+          _scrollToSelectedMs.toDouble(),
+          0,
+          1000,
+          (v) => setState(() => _scrollToSelectedMs = v.round()),
+          divisions: 20,
         ),
         _switchRow(
           'searchable',
@@ -1744,6 +1755,7 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
           itemHeight: _itemHeight,
           enabled: _enabled,
           scrollToSelectedItem: _scrollToSelected,
+          scrollToSelectedDuration: Duration(milliseconds: _scrollToSelectedMs),
           animationDuration: Duration(milliseconds: _animationMs),
           theme: theme,
           config: config,
@@ -1769,6 +1781,23 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
           items: _items,
           value: _selectedValue,
           hintWidget: const Text('Select an option'),
+          // The six below were already drawn by this page and read by the text
+          // branch only. Nothing was missing from the UI; the arguments simply
+          // were not passed — and the check counts per constructor because the
+          // two constructors make different promises.
+          width: _fixedWidth,
+          minWidth: _minWidth,
+          maxWidth: _maxWidth,
+          expand: _expand,
+          disableWhenSingleItem: _disableWhenSingleItem,
+          hideIconWhenSingleItem: _hideIconWhenSingleItem,
+          scrollToSelectedDuration: Duration(milliseconds: _scrollToSelectedMs),
+          emptyBuilder: (query) => Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              query.isEmpty ? 'No items' : 'Nothing matching "$query"',
+            ),
+          ),
           height: _height,
           itemHeight: _itemHeight,
           enabled: _enabled,


### PR DESCRIPTION
Slice 5 of 6 from [the map](https://github.com/kihyun1998/flutter_dropdown_button/issues/122), and the smallest of them.

**Six of the seven missing parameters already had a control on screen.** Compare the two branches of `_buildDropdown`: the text branch read `width`, `minWidth`, `maxWidth`, `expand`, `disableWhenSingleItem` and `hideIconWhenSingleItem`; the custom branch did not. Nothing was missing from the UI — the arguments simply were not passed, and a reader moving those sliders in custom mode watched nothing happen.

That is the case for **counting per constructor** rather than per concept. Merged counting would have called all six covered from the text branch and left this exactly as it was: knobs on screen, inert.

The two that needed real work are `emptyBuilder` and `scrollToSelectedDuration` — the latter gaining a slider beside the flag it is meaningless without, rather than in the geometry section. The text branch takes it too.

`anchorBuilder` and `positioningKey` are deliberately absent: an assert forbids `anchorBuilder` coexisting with the geometry this mode passes, so that combination lives in the bare-anchor recipe or nowhere.

## Coverage

**All three widget constructors are complete** — 28/28, 31/31, 26/26.

**154/203 → 161/203 (79.3%)**. Everything remaining is a theme class: slice 6.

## Gates

All nine bare. `dart format` red on `test/search/dropdown_search_controller_test.dart`, which `main` fails identically (#120).

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuRC5vXeddLybiNXXkbJto