### PR TITLE
docs: expand is main-axis and width is a request, not a promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.2.1
+
+Documentation only. No statement in `lib/` changed — every edited line is a comment, and the diff is six removed one-liners. It is released for the reason 3.0.2 was: pub.dev renders the dartdoc of the version it was published from, so a reader of 4.2.0's API page is told the opposite of what the code does.
+
+Both corrected fields describe the button box, and both were found the same way — by an example recipe written against the comment rather than against the behaviour, which then rendered as a grey block through a green build (#143).
+
+* **CHANGE**: `expand` said "the button fills its parent's **cross-axis** space". It is an `Expanded`, so it fills the **main** axis — horizontal in a `Row`, vertical in a `Column`, where the button became 402 logical pixels tall for a control that is otherwise 50. The corrected wording also names the half that is easy to miss: `expand` puts the button's content in a filled row, so it takes the offered cross-axis width *as well*, and inside a `Column` the result is a box filling both directions. And the three conditions the flag cannot check — a `Flex` parent is required, a second `Expanded` around the widget is `Competing ParentDataWidgets`, and an unbounded-height `Column` throws *RenderFlex children have non-zero flex but incoming height constraints are unbounded*
+* **CHANGE**: `width` said "a fixed button width". It is applied as a box constraint, and `BoxConstraints.enforce` gives an incoming **tight** constraint the last word — so a dropdown placed directly in a `ListView`, whose cross axis is tight, is drawn at the list's full width and the value is ignored without a word. Measured: `width: 260` rendered at 1392. Now documented as *requested*, with the remedy that makes it arrive — wrap it in an `Align`, or any parent that loosens the constraint
+* **CHANGE**: `FlutterDropdownButton.expand`'s own wording was not wrong ("fill available flex space") but named neither the axis nor the requirement. It now carries the same text as its twin, as does the internal `DropdownMenuShell`, which is where both had been copied from
+* **TEST**: `button_box_contract_test.dart`, five tests, holding each corrected claim so the comment cannot drift back to the field name and a guess. Discriminating power confirmed by making the old wording true: implementing `expand` as a cross-axis fill reddens both expand tests, and making the widget loosen its own constraints reddens the width ones. The "a tight parent overrules it" assertion is deliberately taken on the **painted** box rather than the outer widget — a render box cannot be narrower than a tight incoming constraint, so asserting on the outer one would have been a claim about Flutter that no implementation here could falsify
+
 ## 4.2.0
 
 What is on screen reached everyone except the people who cannot see it. The trigger announced its current value and nothing about being a control; the chosen row was distinguished from its neighbours by `DropdownItemTheme.selectedColor` and by nothing else. The checklist had been doing this correctly since 3.1.0 — `Semantics(checked:)` on the row — and the single-select path simply never got the same treatment.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.2.0"
+    version: "4.2.1"
   flutter_example_template:
     dependency: "direct main"
     description:

--- a/lib/src/flutter_dropdown_button.dart
+++ b/lib/src/flutter_dropdown_button.dart
@@ -251,7 +251,16 @@ class FlutterDropdownButton<T> extends StatefulWidget {
 
   // --- Common fields ---
 
-  /// Fixed width of the button. If null, sizes to content.
+  /// A requested button width. If null, the button sizes to its content.
+  ///
+  /// Requested, not guaranteed: it is applied as a box constraint, and
+  /// `BoxConstraints.enforce` gives an incoming **tight** constraint the last
+  /// word. A dropdown placed directly in a [ListView] is the common case — a
+  /// list gives its children a tight cross-axis constraint, so the button is
+  /// drawn at the list's full width and this value is silently ignored.
+  ///
+  /// Wrap it in an [Align] (or any parent that loosens the constraint) for the
+  /// width to arrive.
   final double? width;
 
   /// Minimum width constraint when [width] is null.
@@ -290,7 +299,32 @@ class FlutterDropdownButton<T> extends StatefulWidget {
   /// Duration for scroll-to-selected animation. If null, jumps instantly.
   final Duration? scrollToSelectedDuration;
 
-  /// Whether to expand to fill available flex space. Defaults to false.
+  /// Whether the button fills the space its parent offers.
+  ///
+  /// Two things at once, and the second is easy to miss:
+  ///
+  ///  * it is an [Expanded], so it fills the **main** axis of the enclosing
+  ///    [Flex] — horizontal inside a [Row], **vertical inside a [Column]**;
+  ///  * it also lays the button's content out as a filled row, so the button
+  ///    takes all the **cross**-axis width on offer as well.
+  ///
+  /// Inside a [Row] that reads as "fills the width", which is the intended
+  /// use. Inside a [Column] it is a box filling both directions, with the
+  /// content floating in the middle of it.
+  ///
+  /// Three conditions come with it, none of which this flag can check:
+  ///
+  ///  * the parent must be a [Flex]. In a [ListView], or any other non-flex
+  ///    parent, there is no `FlexParentData` to write and the framework
+  ///    asserts. Give the button a [width] instead — inside an [Align], so the
+  ///    incoming constraint is loose enough for it to take (see [width]).
+  ///  * do not also wrap this widget in an [Expanded]. That is a second one on
+  ///    the same render object, which is `Competing ParentDataWidgets`.
+  ///  * the [Column] must have a bounded height. Inside a scrollable it does
+  ///    not, and the result is *RenderFlex children have non-zero flex but
+  ///    incoming height constraints are unbounded*.
+  ///
+  /// Defaults to false.
   final bool expand;
 
   /// Custom trailing widget replacing the default arrow icon.

--- a/lib/src/flutter_multi_select_dropdown.dart
+++ b/lib/src/flutter_multi_select_dropdown.dart
@@ -130,7 +130,16 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
   /// row checkboxes ([DropdownStyleTheme.checkbox]).
   final DropdownStyleTheme? theme;
 
-  /// A fixed button width.
+  /// A requested button width. If null, the button sizes to its content.
+  ///
+  /// Requested, not guaranteed: it is applied as a box constraint, and
+  /// `BoxConstraints.enforce` gives an incoming **tight** constraint the last
+  /// word. A dropdown placed directly in a [ListView] is the common case — a
+  /// list gives its children a tight cross-axis constraint, so the button is
+  /// drawn at the list's full width and this value is silently ignored.
+  ///
+  /// Wrap it in an [Align] (or any parent that loosens the constraint) for the
+  /// width to arrive.
   final double? width;
 
   /// The button's minimum width, when [width] is null.
@@ -156,7 +165,32 @@ class FlutterMultiSelectDropdown<T> extends StatelessWidget {
   /// open one stayed fully operable for as long as it was on screen.
   final bool enabled;
 
-  /// Whether the button fills its parent's cross-axis space.
+  /// Whether the button fills the space its parent offers.
+  ///
+  /// Two things at once, and the second is easy to miss:
+  ///
+  ///  * it is an [Expanded], so it fills the **main** axis of the enclosing
+  ///    [Flex] — horizontal inside a [Row], **vertical inside a [Column]**;
+  ///  * it also lays the button's content out as a filled row, so the button
+  ///    takes all the **cross**-axis width on offer as well.
+  ///
+  /// Inside a [Row] that reads as "fills the width", which is the intended
+  /// use. Inside a [Column] it is a box filling both directions, with the
+  /// content floating in the middle of it.
+  ///
+  /// Three conditions come with it, none of which this flag can check:
+  ///
+  ///  * the parent must be a [Flex]. In a [ListView], or any other non-flex
+  ///    parent, there is no `FlexParentData` to write and the framework
+  ///    asserts. Give the button a [width] instead — inside an [Align], so the
+  ///    incoming constraint is loose enough for it to take (see [width]).
+  ///  * do not also wrap this widget in an [Expanded]. That is a second one on
+  ///    the same render object, which is `Competing ParentDataWidgets`.
+  ///  * the [Column] must have a bounded height. Inside a scrollable it does
+  ///    not, and the result is *RenderFlex children have non-zero flex but
+  ///    incoming height constraints are unbounded*.
+  ///
+  /// Defaults to false.
   final bool expand;
 
   /// Replaces the trailing icon.

--- a/lib/src/shell/dropdown_menu_shell.dart
+++ b/lib/src/shell/dropdown_menu_shell.dart
@@ -99,7 +99,32 @@ class DropdownMenuShell<T> extends StatefulWidget {
   /// How long the open and close animation takes.
   final Duration animationDuration;
 
-  /// Whether the button fills its parent's cross-axis space.
+  /// Whether the button fills the space its parent offers.
+  ///
+  /// Two things at once, and the second is easy to miss:
+  ///
+  ///  * it is an [Expanded], so it fills the **main** axis of the enclosing
+  ///    [Flex] — horizontal inside a [Row], **vertical inside a [Column]**;
+  ///  * it also lays the button's content out as a filled row, so the button
+  ///    takes all the **cross**-axis width on offer as well.
+  ///
+  /// Inside a [Row] that reads as "fills the width", which is the intended
+  /// use. Inside a [Column] it is a box filling both directions, with the
+  /// content floating in the middle of it.
+  ///
+  /// Three conditions come with it, none of which this flag can check:
+  ///
+  ///  * the parent must be a [Flex]. In a [ListView], or any other non-flex
+  ///    parent, there is no `FlexParentData` to write and the framework
+  ///    asserts. Give the button a [width] instead — inside an [Align], so the
+  ///    incoming constraint is loose enough for it to take (see [width]).
+  ///  * do not also wrap this widget in an [Expanded]. That is a second one on
+  ///    the same render object, which is `Competing ParentDataWidgets`.
+  ///  * the [Column] must have a bounded height. Inside a scrollable it does
+  ///    not, and the result is *RenderFlex children have non-zero flex but
+  ///    incoming height constraints are unbounded*.
+  ///
+  /// Defaults to false.
   final bool expand;
 
   /// Which edge of the button the menu lines up with.
@@ -136,7 +161,16 @@ class DropdownMenuShell<T> extends StatefulWidget {
   /// tooltip theming still apply — only the button face is the caller's now.
   final Widget Function(BuildContext context, bool isOpen)? anchorBuilder;
 
-  /// A fixed button width.
+  /// A requested button width. If null, the button sizes to its content.
+  ///
+  /// Requested, not guaranteed: it is applied as a box constraint, and
+  /// `BoxConstraints.enforce` gives an incoming **tight** constraint the last
+  /// word. A dropdown placed directly in a [ListView] is the common case — a
+  /// list gives its children a tight cross-axis constraint, so the button is
+  /// drawn at the list's full width and this value is silently ignored.
+  ///
+  /// Wrap it in an [Align] (or any parent that loosens the constraint) for the
+  /// width to arrive.
   final double? width;
 
   /// The button's minimum width, when [width] is null.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropdown_button
 description: "A highly customizable dropdown widget with overlay-based rendering, smart positioning, search, tooltips, and full control over appearance."
-version: 4.2.0
+version: 4.2.1
 homepage: https://github.com/kihyun1998/flutter_dropdown_button
 repository: https://github.com/kihyun1998/flutter_dropdown_button
 issue_tracker: https://github.com/kihyun1998/flutter_dropdown_button/issues

--- a/test/button_box_contract_test.dart
+++ b/test/button_box_contract_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dropdown_button/flutter_dropdown_button.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// What the button box actually promises — and what it does not.
+///
+/// Nothing here is a regression: `expand` and `width` behave the way any
+/// Flutter widget does, and no statement in `lib/` changed to make these pass.
+/// They exist because the **dartdoc** was wrong (#145), and a corrected comment
+/// with nothing holding it drifts back the first time somebody reads the field
+/// name and guesses.
+///
+/// Each test fails if the old wording is ever made true again: if `expand` is
+/// changed to fill the cross axis, or if `width` is changed to win against the
+/// parent that contains it.
+
+const items = ['Alpha', 'Bravo', 'Charlie'];
+
+Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+Finder get button => find.byType(FlutterDropdownButton<String>);
+
+/// The `Container` carrying the decoration and the requested width.
+Finder get decoratedBox => find.descendant(
+  of: button,
+  matching: find.byWidgetPredicate(
+    (w) => w is Container && w.decoration != null,
+  ),
+);
+
+void main() {
+  group('expand fills the main axis, and the width on offer', () {
+    testWidgets('in a Row it takes the width and stays one row tall', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          const Row(
+            children: [
+              FlutterDropdownButton<String>.text(
+                items: items,
+                expand: true,
+                hint: 'Pick',
+                onChanged: _ignore,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final size = tester.getSize(button);
+      expect(size.width, 800.0, reason: 'the Row is the whole surface');
+      expect(
+        size.height,
+        lessThan(120.0),
+        reason: 'the cross axis of a Row is the height, and it is not filled',
+      );
+    });
+
+    testWidgets('in a bounded Column it takes the height', (tester) async {
+      // This is the assertion the old wording contradicted. A button that
+      // filled its parent's *cross*-axis space would be 400 wide and one row
+      // tall here; it is the other way round, and that is the whole of #143.
+      await tester.pumpWidget(
+        wrap(
+          const SizedBox(
+            width: 400,
+            height: 600,
+            child: Column(
+              children: [
+                FlutterDropdownButton<String>.text(
+                  items: items,
+                  expand: true,
+                  hint: 'Pick',
+                  onChanged: _ignore,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final size = tester.getSize(button);
+      expect(
+        size.height,
+        600.0,
+        reason: 'a Column\'s main axis is vertical, and expand fills it',
+      );
+      // And the width too, which is the half that is easy to miss: `expand`
+      // also puts the button's content row in `MainAxisSize.max`, so it takes
+      // the cross axis on offer as well. In a Column the result is a box
+      // filling both directions — "far taller *and wider* than asked for",
+      // which is exactly how #143 was first described.
+      expect(
+        size.width,
+        400.0,
+        reason: 'expand fills the offered width as well as the main axis',
+      );
+    });
+  });
+
+  group('width is requested, not fixed', () {
+    testWidgets('a tight parent overrules it', (tester) async {
+      // A `ListView` hands its children a tight cross-axis constraint, and
+      // `BoxConstraints.enforce` gives a tight parent the last word. The old
+      // wording — "a fixed button width" — promised the opposite.
+      await tester.pumpWidget(
+        wrap(
+          ListView(
+            children: const [
+              FlutterDropdownButton<String>.text(
+                items: items,
+                width: 260,
+                hint: 'Pick',
+                onChanged: _ignore,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      // Measured on the **decorated box** — the `Container` that carries the
+      // width and the border — not on the outer widget. The outer one cannot
+      // be anything but 800: a render box must satisfy a tight incoming
+      // constraint, so asserting on it would be a claim about Flutter that no
+      // implementation of this widget could falsify.
+      //
+      // The box that is painted can differ, and that is the real question: a
+      // widget that loosened its own constraints internally would draw a
+      // 260-wide button inside a full-width slot, and the advice below would
+      // be unnecessary. It does not, so the value is ignored outright.
+      expect(
+        tester.getSize(decoratedBox).width,
+        800.0,
+        reason: 'the width never reaches the painted button either',
+      );
+    });
+
+    testWidgets('inside an Align it arrives', (tester) async {
+      // The remedy the corrected dartdoc names. Asserted so that the advice
+      // cannot go stale separately from the claim above it.
+      await tester.pumpWidget(
+        wrap(
+          ListView(
+            children: const [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: FlutterDropdownButton<String>.text(
+                  items: items,
+                  width: 260,
+                  hint: 'Pick',
+                  onChanged: _ignore,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(button).width,
+        260.0,
+        reason: 'Align lays its child out under constraints.loosen()',
+      );
+    });
+
+    testWidgets('a loose parent lets the multi-select keep it too', (
+      tester,
+    ) async {
+      // The same claim is documented on the other widget, so it is held on the
+      // other widget. A fix applied to one dartdoc and not the other is the
+      // ordinary way half a correction ships.
+      await tester.pumpWidget(
+        wrap(
+          const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              FlutterMultiSelectDropdown<String>(
+                items: items,
+                selected: <String>{},
+                labelBuilder: _label,
+                width: 318,
+                onChanged: _ignoreSet,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byType(FlutterMultiSelectDropdown<String>)).width,
+        318.0,
+      );
+    });
+  });
+}
+
+void _ignore(String? _) {}
+
+void _ignoreSet(Set<String> _) {}
+
+String _label(Set<String> chosen) => 'Pick';


### PR DESCRIPTION
Closes #145

Release **4.2.1**, documentation only. The whole `lib/` diff is six removed
one-line comments across three files — verified mechanically, not asserted:
every `-` line in `lib/` is a `///`, and every `+` line is one too.

Released for the reason `CHANGELOG.md` already records for 3.0.2: pub.dev
renders the dartdoc of the version it was published from, so a reader of 4.2.0's
API page is told the opposite of what the code does.

## What the comments claimed

| Field | Said | Does |
|---|---|---|
| `expand` | "fills its parent's **cross-axis** space" | is an `Expanded` — fills the **main** axis. In a `Column` that is vertical: **402px** for a control that is otherwise 50 |
| `width` | "a **fixed** button width" | `Container(width:)`, a request. A tight parent overrules it — `width: 260` in a `ListView` measured **1392** |

Both were found by #143, where an example recipe was written against the comment
rather than the behaviour and rendered as a grey block through a green build.

`FlutterDropdownButton.expand` was **not** wrong — "fill available flex space" —
but named neither the axis nor the requirement, so it now carries the same text
as its twin, as does the internal `DropdownMenuShell` both were copied from.
(#143's body says the wrong wording had a twin on the single-select; it does
not.)

## The correction found something the reading had not

Writing it turned up the half the old wording had no room for: `expand` also
sets `fillsWidth` (`dropdown_menu_shell.dart:518`), putting the button's content
row in `MainAxisSize.max`, so it takes the offered **cross**-axis width as well.
Inside a `Column` it is a box filling both directions.

That is exactly how #143 described the screen — "far taller **and wider** than
318 asks for" — and that description turns out to have been accurate for the
build it was made against.

**The test caught it, not the reading.** The first draft asserted the button
stayed narrow in a `Column` and went red at 400.

## Guards

`test/button_box_contract_test.dart` — five tests, one per corrected claim,
because a comment with nothing under it drifts back to the field name and a
guess. Discriminating power bought rather than assumed: implementing `expand` as
a cross-axis fill reddens both expand tests; making the widget loosen its own
constraints reddens the width ones.

One assertion had to be **moved before it meant anything**. "A tight parent
overrules it" was first taken on the outer widget, where it cannot fail — a
render box must satisfy a tight incoming constraint, so it was a claim about
Flutter rather than about this package, and the first mutation written against
it stayed green. It is taken on the **painted** box instead, which a widget
loosening its own constraints internally would change. That mutation reddens it.

## Gates

All bare. Root analyze, `flutter test --coverage` **367** (was 362), line
coverage 100% (1220/1220), API coverage 100% (203/203), example analyze, example
test, `publish --dry-run` **0 warnings**.

`dart format .` corpus-wide still exits 1 on `test/search/dropdown_search_controller_test.dart`
— untouched here, identical to `main`, the recorded drift of #120. The scoped
check over this branch's files is clean.

## Publishing

`flutter pub publish` is the maintainer's to run, not the agent's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017St56TpwJzoDiWgDjsdE3m
