### PR TITLE
feat: the search field gains its own look

### DIFF
--- a/example/lib/recipes/search_recipe.dart
+++ b/example/lib/recipes/search_recipe.dart
@@ -54,16 +54,26 @@ class SearchRecipe extends StatefulWidget {
 
 class _SearchRecipeState extends State<SearchRecipe> {
   Airport? _selected;
+  Airport? _themed;
+  Airport? _decorated;
 
   static String _label(Airport a) => '${a.iata} — ${a.city}';
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          FlutterDropdownButton<Airport>.text(
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        _caption(
+          context,
+          'The filter, and the state when it matches none',
+          'Type "korea" or "jp": the label says neither, and searchFilter is '
+              'what finds them anyway. Type "zzz" for the empty state, which '
+              'is handed the query.',
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: FlutterDropdownButton<Airport>.text(
             width: 300,
             height: 260,
             items: _airports,
@@ -100,14 +110,127 @@ class _SearchRecipeState extends State<SearchRecipe> {
             ),
             onChanged: (airport) => setState(() => _selected = airport),
           ),
-          const SizedBox(height: 24),
-          Text(
-            _selected == null
-                ? 'Try "korea", "jp", or "zzz"'
-                : '${_selected!.iata} · ${_selected!.country}',
+        ),
+        const SizedBox(height: 12),
+        Text(
+          _selected == null
+              ? 'Try "korea", "jp", or "zzz"'
+              : '${_selected!.iata} · ${_selected!.country}',
+        ),
+        const SizedBox(height: 32),
+        _caption(
+          context,
+          'The field itself, themed',
+          'Every field SearchFieldTheme declares. The divider is the one worth '
+              'reading about: Flutter\'s Divider is 16 pixels tall, not one, '
+              'and the height reserved for it has to say so.',
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: FlutterDropdownButton<Airport>.text(
+            width: 300,
+            height: 280,
+            items: _airports,
+            value: _themed,
+            label: _label,
+            hint: 'Themed search',
+            searchable: true,
+            onChanged: (airport) => setState(() => _themed = airport),
+            theme: _searchTheme,
           ),
-        ],
-      ),
+        ),
+        const SizedBox(height: 32),
+        _caption(
+          context,
+          'The field, described as an InputDecoration',
+          'decoration takes precedence over the individual properties it '
+              'covers — contentPadding among them — so this one names what it '
+              'wants there and nothing that would be ignored.',
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: FlutterDropdownButton<Airport>.text(
+            width: 300,
+            height: 280,
+            items: _airports,
+            value: _decorated,
+            label: _label,
+            hint: 'Decorated search',
+            searchable: true,
+            onChanged: (airport) => setState(() => _decorated = airport),
+            theme: _decoratedSearchTheme,
+          ),
+        ),
+        const SizedBox(height: 24),
+      ],
     );
   }
+
+  Widget _caption(BuildContext context, String title, String body) => Padding(
+    padding: const EdgeInsets.only(bottom: 12),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 4),
+        Text(body, style: const TextStyle(fontSize: 12, color: Colors.grey)),
+      ],
+    ),
+  );
 }
+
+/// Every field the search field declares, named one at a time.
+final _searchTheme = DropdownStyleTheme(
+  overlay: const DropdownOverlayTheme(backgroundColor: Color(0xFF1B1F27)),
+  search: SearchFieldTheme(
+    backgroundColor: const Color(0xFF141821),
+    textStyle: const TextStyle(fontSize: 14, color: Color(0xFFD7DEEC)),
+    cursorColor: const Color(0xFF6E8BFF),
+    cursorWidth: 2,
+    cursorHeight: 16,
+    cursorRadius: const Radius.circular(1),
+    height: 40,
+    margin: const EdgeInsets.fromLTRB(8, 8, 8, 4),
+    padding: const EdgeInsets.symmetric(horizontal: 4),
+    contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    borderRadius: BorderRadius.circular(8),
+    border: Border.all(color: const Color(0xFF39404E)),
+    focusedBorder: Border.all(color: const Color(0xFF6E8BFF), width: 1.5),
+    // The pair. Flutter's `Divider` is **16** logical pixels tall by default,
+    // not one — the overlay reserves `dividerHeight` and constrains the widget
+    // to it, so a reservation of 1.0 under a real `Divider` used to overflow
+    // the item list by fifteen pixels. Name both, or neither.
+    divider: const Divider(height: 16, thickness: 1, color: Color(0xFF2C323D)),
+    dividerHeight: 16,
+    // The default is true, which is right for a menu opened to be typed into.
+    // Turn it off when the menu is opened to be read.
+    autofocus: false,
+    keyboardType: TextInputType.text,
+    textInputAction: TextInputAction.search,
+    textAlign: TextAlign.start,
+  ),
+);
+
+/// The same field, handed an [InputDecoration] instead.
+final _decoratedSearchTheme = DropdownStyleTheme(
+  overlay: const DropdownOverlayTheme(backgroundColor: Color(0xFF1B1F27)),
+  search: SearchFieldTheme(
+    backgroundColor: const Color(0xFF141821),
+    textStyle: const TextStyle(fontSize: 14, color: Color(0xFFD7DEEC)),
+    height: 44,
+    borderRadius: BorderRadius.circular(10),
+    // `contentPadding` is deliberately absent: this takes precedence over it,
+    // so naming it here would be a value nothing reads.
+    decoration: const InputDecoration(
+      border: InputBorder.none,
+      isDense: true,
+      contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      prefixIcon: Icon(Icons.travel_explore, size: 18),
+      hintText: 'City, code or country',
+      hintStyle: TextStyle(fontSize: 13, color: Color(0xFF7A8296)),
+    ),
+    divider: const Divider(height: 16, thickness: 1, color: Color(0xFF2C323D)),
+    dividerHeight: 16,
+    autofocus: false,
+  ),
+);


### PR DESCRIPTION
Slice 3 of #147, and the last of the theming.

| | no-playground coverage |
|---|---|
| after slice 2 | 70.0% (142/203) |
| **after this** | **80.3% (163/203)** |

**+21** — `SearchFieldTheme` 20/20 and the last `DropdownStyleTheme` slot.

**All nine theme classes are now complete without the page.** The 40 that remain
are widget constructor arguments — geometry and states — which is slice 4. The
live gate stays at 203/203.

## Extended, not added

This grows `search_recipe.dart` instead of adding a menu entry, which is what
#147 recorded: the search field is one surface, and splitting its behaviour from
its appearance would make a reader look in two places for one widget.

Three sections now — the filter and its empty state (unchanged), the field named
field by field, and the field handed an `InputDecoration`.

## The part worth reading

`divider` and `dividerHeight` are a pair. Flutter's `Divider` is **16** logical
pixels tall by default, not one, and the overlay reserves `dividerHeight` and
constrains the widget to it — so a reservation of `1.0` under a real `Divider`
used to overflow the item list by fifteen pixels. The recipe names both, and
says why.

`autofocus: false` is set against a default of `true`, with the distinction
written down: true is right for a menu opened to be **typed into**, false for
one opened to be **read**.

The decorated version deliberately omits `contentPadding` —
`SearchFieldTheme.decoration` takes precedence over it, so naming it there would
be a value nothing reads. Same shape as a `trackColor` with no
`trackVisibility`.

## Verified on the running app

Against a checked bundle timestamp: the bordered field, its search icon, the
divider below it, a list that does **not** overflow, and no cursor — which is
`autofocus: false` arriving.

## Gates

All bare. Root analyze, root test, example test (16), API coverage 100%
(203/203), scoped format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017St56TpwJzoDiWgDjsdE3m
